### PR TITLE
fix: resolve git repo root so revdiff works from subdirectories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,4 @@ git diff → diff.ParseUnifiedDiff() → []DiffLine
 - Highlighted lines are pre-computed once per file load, stored parallel to `diffLines`
 - `DiffLine.Content` has no `+`/`-` prefix - prefix is re-added at render time
 - Tab replacement happens at render time in `renderDiffLine`, not in diff parsing
+- `run()` resolves git repo root via `git rev-parse --show-toplevel` so revdiff works from any subdirectory

--- a/cmd/revdiff/main.go
+++ b/cmd/revdiff/main.go
@@ -228,6 +228,10 @@ func gitTopLevel() (string, error) {
 	cmd := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("git rev-parse --show-toplevel: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
 		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil

--- a/cmd/revdiff/main_test.go
+++ b/cmd/revdiff/main_test.go
@@ -232,3 +232,19 @@ func TestDefaultConfigPath(t *testing.T) {
 	assert.Contains(t, path, "revdiff")
 	assert.Contains(t, path, "config")
 }
+
+func TestGitTopLevel(t *testing.T) {
+	t.Run("inside repo", func(t *testing.T) {
+		root, err := gitTopLevel()
+		require.NoError(t, err)
+		assert.DirExists(t, root)
+		assert.NotEmpty(t, root)
+	})
+
+	t.Run("outside repo", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		_, err := gitTopLevel()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "git rev-parse --show-toplevel")
+	})
+}


### PR DESCRIPTION
Fixes #1

Use `git rev-parse --show-toplevel` to find the repository root instead of hardcoding `.` as the working directory. Previously, running `revdiff HEAD~1` from a subdirectory would fail because git diff paths are repo-relative but the working directory was the subdirectory.