### PR TITLE
chore: remove redundant tools from allowed-tools

### DIFF
--- a/.claude-plugin/skills/revdiff/SKILL.md
+++ b/.claude-plugin/skills/revdiff/SKILL.md
@@ -2,7 +2,7 @@
 name: revdiff
 description: Review git diffs with inline annotations in a TUI overlay, or answer questions about revdiff usage, configuration, themes, and keybindings. Opens revdiff in tmux/kitty/wezterm, captures annotations, and addresses them. Activates on "revdiff", "review diff", "annotate diff", "git review with revdiff", "interactive diff review", "revdiff config", "revdiff themes", "revdiff keybindings", "how to configure revdiff", "what themes does revdiff have".
 argument-hint: 'optional git ref (e.g., HEAD~1, main)'
-allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, EnterPlanMode, AskUserQuestion]
+allowed-tools: [Bash, Read, Edit, Write, Grep, Glob]
 ---
 
 # revdiff - TUI Diff Review


### PR DESCRIPTION
AskUserQuestion and EnterPlanMode do not require user permission. therefore, there is no reason to add them to allowed-tools

Docs: https://code.claude.com/docs/en/tools-reference