### PR TITLE
feat(launch): pass REVDIFF_CONFIG to overlay and add configurable popup size

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -32,6 +32,15 @@ Then uncomment and edit the values you want to change.
 | `--config` | `REVDIFF_CONFIG` | Path to config file | `~/.config/revdiff/config` |
 | `--dump-config` | | Print default config to stdout and exit | |
 
+## Popup Size (Claude Code plugin)
+
+When launched via the Claude Code plugin skill, revdiff opens in a terminal overlay. The popup size is configurable via env vars:
+
+| Env var | Description | Default |
+|---------|-------------|---------|
+| `REVDIFF_POPUP_WIDTH` | Tmux popup width (e.g., `100%`, `80%`) | `90%` |
+| `REVDIFF_POPUP_HEIGHT` | Tmux popup height / wezterm split percent | `90%` |
+
 ## Color Customization
 
 All color options accept hex values (`#rrggbb`) and have corresponding `REVDIFF_COLOR_*` env vars.

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -39,7 +39,7 @@ for arg in "$@"; do
 done
 OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 
-# overlay size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars
+# popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux and wezterm)
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 
@@ -77,7 +77,9 @@ if [ -n "${WEZTERM_PANE:-}" ] && command -v wezterm >/dev/null 2>&1; then
     SENTINEL=$(mktemp /tmp/revdiff-done-XXXXXX)
     rm -f "$SENTINEL"
 
-    wezterm cli split-pane --bottom --percent 90 \
+    WEZTERM_PCT="${REVDIFF_POPUP_HEIGHT:-90%}"
+    WEZTERM_PCT="${WEZTERM_PCT%%%}"
+    wezterm cli split-pane --bottom --percent "$WEZTERM_PCT" \
         --pane-id "$WEZTERM_PANE" --cwd "$CWD" -- sh -c "$REVDIFF_CMD; touch '$SENTINEL'" >/dev/null 2>&1
 
     while [ ! -f "$SENTINEL" ]; do


### PR DESCRIPTION
## Summary
- Pass `REVDIFF_CONFIG` env var as `--config` flag to revdiff inside tmux popups. The `sh -c` invocation doesn't inherit fish universal variables, so the config path was lost in overlay shells.
- Add `REVDIFF_POPUP_WIDTH` and `REVDIFF_POPUP_HEIGHT` env vars to override the default 90% tmux popup dimensions.