### PR TITLE
Add visual range selection (V) and hunk annotation (H)

### DIFF
--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -87,9 +87,11 @@ When `--only` specifies a file that has no git changes (or when no git repo exis
 |-----|--------|
 | `a` or `Enter` (diff pane) | Annotate current diff line |
 | `A` | Add file-level annotation (stored at top of diff) |
+| `V` | Start visual range selection (navigate with `j`/`k`, then `a`/`Enter` to annotate) |
+| `H` | Annotate entire hunk under cursor |
 | `@` | Toggle annotation list popup (navigate and jump to any annotation) |
 | `d` | Delete annotation under cursor |
-| `Esc` | Cancel annotation input |
+| `Esc` | Cancel annotation input / cancel selection |
 
 **View:**
 
@@ -133,10 +135,13 @@ consider splitting this file into smaller modules
 ## handler.go:43 (+)
 use errors.Is() instead of direct comparison
 
+## handler.go:10-25
+review this block for error handling
+
 ## store.go:18 (-)
 don't remove this validation
 ```
 
-Each annotation block: `## filename:line (type)` where type is `(+)` added, `(-)` removed, or `(file-level)`.
+Point annotations: `## filename:line (type)` where type is `(+)` added, `(-)` removed, or `(file-level)`. Range annotations (`V` selection or `H` hunk): `## filename:start-end`.
 
 Use `--output` / `-o` flag to write annotations to a file instead of stdout.

--- a/README.md
+++ b/README.md
@@ -403,9 +403,11 @@ revdiff --only=/tmp/draft-comment.md
 |-----|--------|
 | `a` or `Enter` (diff pane) | Annotate current diff line |
 | `A` | Add file-level annotation (stored at top of diff) |
+| `V` | Start visual range selection (navigate with `j`/`k`, then `a`/`Enter` to annotate) |
+| `H` | Annotate entire hunk under cursor |
 | `@` | Toggle annotation list popup (navigate and jump to any annotation) |
 | `d` | Delete annotation under cursor |
-| `Esc` | Cancel annotation input |
+| `Esc` | Cancel annotation input / cancel selection |
 
 **View:**
 
@@ -476,9 +478,14 @@ consider splitting this file into smaller modules
 ## handler.go:43 (+)
 use errors.Is() instead of direct comparison
 
+## handler.go:10-25
+review this block for error handling
+
 ## store.go:18 (-)
 don't remove this validation
 ```
+
+Range annotations (`V` selection or `H` hunk) use `file:start-end` format. Point annotations use `file:line (type)` format.
 
 ## Contributing
 

--- a/annotation/store.go
+++ b/annotation/store.go
@@ -6,12 +6,20 @@ import (
 	"strings"
 )
 
-// Annotation represents a user comment on a specific diff line.
+// Annotation represents a user comment on a specific diff line or range.
 type Annotation struct {
 	File    string // file path relative to repo root
-	Line    int    // line number in the diff
-	Type    string // change type: "+", "-", or " "
+	Line    int    // line number in the diff (start line for ranges)
+	EndLine int    // end line for range annotations (0 = point annotation)
+	Type    string // change type: "+", "-", or " " (always "" for ranges)
 	Comment string // user comment text
+}
+
+// IsRange returns true if this annotation represents a range annotation.
+// Range annotations use Type == "" and may collapse to the same numeric line
+// for replacement hunks where old/new line numbers match.
+func (a Annotation) IsRange() bool {
+	return a.Type == "" && a.EndLine > 0 && a.EndLine >= a.Line
 }
 
 // Store holds annotations in memory, keyed by filename.
@@ -25,20 +33,32 @@ func NewStore() *Store {
 }
 
 // Add adds an annotation for the given file and line.
-// If an annotation already exists at the same file:line, it is replaced.
-func (s *Store) Add(a Annotation) {
+// If an annotation already exists at the same (file, line, endLine, type), it is replaced.
+// Range annotations that overlap existing ranges in the same file are rejected.
+func (s *Store) Add(a Annotation) bool {
 	existing := s.annotations[a.File]
-	if i, ok := s.find(a.File, a.Line, a.Type); ok {
+	if i, ok := s.find(a.File, a.Line, a.EndLine, a.Type); ok {
 		existing[i].Comment = a.Comment
-		return
+		return true
+	}
+	if a.IsRange() {
+		for _, other := range existing {
+			if !other.IsRange() {
+				continue
+			}
+			if a.Line <= other.EndLine && a.EndLine >= other.Line {
+				return false
+			}
+		}
 	}
 	s.annotations[a.File] = append(existing, a)
+	return true
 }
 
-// Delete removes the annotation at the given file, line and change type.
+// Delete removes the annotation at the given file, line, endLine and change type.
 // Returns true if an annotation was found and removed.
-func (s *Store) Delete(file string, line int, changeType string) bool {
-	i, ok := s.find(file, line, changeType)
+func (s *Store) Delete(file string, line, endLine int, changeType string) bool {
+	i, ok := s.find(file, line, endLine, changeType)
 	if !ok {
 		return false
 	}
@@ -52,14 +72,34 @@ func (s *Store) Delete(file string, line int, changeType string) bool {
 
 // Has checks if an annotation exists at the given file, line and change type.
 func (s *Store) Has(file string, line int, changeType string) bool {
-	_, ok := s.find(file, line, changeType)
+	_, ok := s.find(file, line, 0, changeType)
 	return ok
 }
 
-// find returns the index of an annotation matching file, line, and changeType.
-func (s *Store) find(file string, line int, changeType string) (int, bool) {
+// HasRangeCovering returns true if any range annotation in the file covers lineNum.
+func (s *Store) HasRangeCovering(file string, lineNum int) bool {
+	for _, a := range s.annotations[file] {
+		if a.IsRange() && lineNum >= a.Line && lineNum <= a.EndLine {
+			return true
+		}
+	}
+	return false
+}
+
+// GetRangeCovering returns the range annotation covering lineNum, if any.
+func (s *Store) GetRangeCovering(file string, lineNum int) (Annotation, bool) {
+	for _, a := range s.annotations[file] {
+		if a.IsRange() && lineNum >= a.Line && lineNum <= a.EndLine {
+			return a, true
+		}
+	}
+	return Annotation{}, false
+}
+
+// find returns the index of an annotation matching file, line, endLine, and changeType.
+func (s *Store) find(file string, line, endLine int, changeType string) (int, bool) {
 	for i, a := range s.annotations[file] {
-		if a.Line == line && a.Type == changeType {
+		if a.Line == line && a.EndLine == endLine && a.Type == changeType {
 			return i, true
 		}
 	}
@@ -124,9 +164,12 @@ func (s *Store) FormatOutput() string {
 				buf.WriteString("\n")
 			}
 			first = false
-			if a.Line == 0 {
+			switch {
+			case a.Line == 0:
 				fmt.Fprintf(&buf, "## %s (file-level)\n%s\n", a.File, a.Comment)
-			} else {
+			case a.IsRange():
+				fmt.Fprintf(&buf, "## %s:%d-%d\n%s\n", a.File, a.Line, a.EndLine, a.Comment)
+			default:
 				fmt.Fprintf(&buf, "## %s:%d (%s)\n%s\n", a.File, a.Line, a.Type, a.Comment)
 			}
 		}

--- a/annotation/store_test.go
+++ b/annotation/store_test.go
@@ -52,7 +52,7 @@ func TestStore_Delete(t *testing.T) {
 	s := NewStore()
 	s.Add(Annotation{File: "handler.go", Line: 43, Type: "+", Comment: "comment"})
 
-	ok := s.Delete("handler.go", 43, "+")
+	ok := s.Delete("handler.go", 43, 0, "+")
 	assert.True(t, ok)
 	assert.Empty(t, s.Get("handler.go"))
 }
@@ -60,7 +60,7 @@ func TestStore_Delete(t *testing.T) {
 func TestStore_DeleteCleansUpEmptyFile(t *testing.T) {
 	s := NewStore()
 	s.Add(Annotation{File: "handler.go", Line: 43, Type: "+", Comment: "comment"})
-	s.Delete("handler.go", 43, "+")
+	s.Delete("handler.go", 43, 0, "+")
 
 	all := s.All()
 	_, exists := all["handler.go"]
@@ -69,7 +69,7 @@ func TestStore_DeleteCleansUpEmptyFile(t *testing.T) {
 
 func TestStore_DeleteNonExistent(t *testing.T) {
 	s := NewStore()
-	ok := s.Delete("handler.go", 43, "+")
+	ok := s.Delete("handler.go", 43, 0, "+")
 	assert.False(t, ok)
 }
 
@@ -78,7 +78,7 @@ func TestStore_DeletePreservesOthers(t *testing.T) {
 	s.Add(Annotation{File: "handler.go", Line: 10, Type: "+", Comment: "keep"})
 	s.Add(Annotation{File: "handler.go", Line: 43, Type: "-", Comment: "remove"})
 
-	s.Delete("handler.go", 43, "-")
+	s.Delete("handler.go", 43, 0, "-")
 	anns := s.Get("handler.go")
 	require.Len(t, anns, 1)
 	assert.Equal(t, 10, anns[0].Line)
@@ -90,7 +90,7 @@ func TestStore_DeleteMatchesByType(t *testing.T) {
 	s.Add(Annotation{File: "handler.go", Line: 5, Type: "-", Comment: "removed line"})
 
 	// deleting the add should leave the remove
-	ok := s.Delete("handler.go", 5, "+")
+	ok := s.Delete("handler.go", 5, 0, "+")
 	assert.True(t, ok)
 	anns := s.Get("handler.go")
 	require.Len(t, anns, 1)
@@ -226,7 +226,7 @@ func TestStore_DeleteFileLevelAnnotation(t *testing.T) {
 	s := NewStore()
 	s.Add(Annotation{File: "handler.go", Line: 0, Type: "", Comment: "file comment"})
 
-	ok := s.Delete("handler.go", 0, "")
+	ok := s.Delete("handler.go", 0, 0, "")
 	assert.True(t, ok)
 	assert.Empty(t, s.Get("handler.go"))
 }
@@ -236,7 +236,7 @@ func TestStore_DeleteFileLevelPreservesLineAnnotations(t *testing.T) {
 	s.Add(Annotation{File: "handler.go", Line: 0, Type: "", Comment: "file comment"})
 	s.Add(Annotation{File: "handler.go", Line: 43, Type: "+", Comment: "line comment"})
 
-	s.Delete("handler.go", 0, "")
+	s.Delete("handler.go", 0, 0, "")
 	anns := s.Get("handler.go")
 	require.Len(t, anns, 1)
 	assert.Equal(t, 43, anns[0].Line)
@@ -335,7 +335,7 @@ func TestStore_ContextOnlyAnnotations(t *testing.T) {
 	assert.False(t, s.Has("plan.md", 3, "+"))
 
 	// verify Delete works
-	ok := s.Delete("plan.md", 3, " ")
+	ok := s.Delete("plan.md", 3, 0, " ")
 	assert.True(t, ok)
 	assert.Len(t, s.Get("plan.md"), 1)
 }
@@ -353,6 +353,185 @@ func TestStore_Count(t *testing.T) {
 	s.Add(Annotation{File: "b.go", Line: 1, Type: "+", Comment: "three"})
 	assert.Equal(t, 3, s.Count(), "should count across multiple files")
 
-	s.Delete("a.go", 1, "+")
+	s.Delete("a.go", 1, 0, "+")
 	assert.Equal(t, 2, s.Count(), "count should decrease after delete")
+}
+
+// --- Range annotation tests ---
+
+func TestAnnotation_IsRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		ann      Annotation
+		expected bool
+	}{
+		{"point annotation", Annotation{Line: 10, EndLine: 0}, false},
+		{"file-level annotation", Annotation{Line: 0, EndLine: 0}, false},
+		{"range annotation", Annotation{Line: 10, EndLine: 25, Type: ""}, true},
+		{"replacement hunk range on same line number", Annotation{Line: 10, EndLine: 10, Type: ""}, true},
+		{"same line point annotation", Annotation{Line: 10, EndLine: 10, Type: "+"}, false},
+		{"endLine before line (not a range)", Annotation{Line: 10, EndLine: 5}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ann.IsRange())
+		})
+	}
+}
+
+func TestStore_RangeAdd(t *testing.T) {
+	s := NewStore()
+	ok := s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "review this block"})
+	assert.True(t, ok)
+
+	anns := s.Get("handler.go")
+	require.Len(t, anns, 1)
+	assert.Equal(t, 10, anns[0].Line)
+	assert.Equal(t, 25, anns[0].EndLine)
+	assert.True(t, anns[0].IsRange())
+}
+
+func TestStore_RangeAddReplacesExisting(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "old"})
+	ok := s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "new"})
+	assert.True(t, ok)
+
+	anns := s.Get("handler.go")
+	require.Len(t, anns, 1)
+	assert.Equal(t, "new", anns[0].Comment)
+}
+
+func TestStore_RangeOverlapRejected(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "first"})
+
+	tests := []struct {
+		name    string
+		line    int
+		endLine int
+	}{
+		{"exact overlap", 10, 25},
+		{"overlap start", 5, 15},
+		{"overlap end", 20, 30},
+		{"contained within", 12, 20},
+		{"containing", 5, 30},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// exact overlap is a replace (same identity), so skip it in this loop
+			if tt.line == 10 && tt.endLine == 25 {
+				return
+			}
+			ok := s.Add(Annotation{File: "handler.go", Line: tt.line, EndLine: tt.endLine, Type: "", Comment: "overlap"})
+			assert.False(t, ok, "overlapping range should be rejected")
+		})
+	}
+
+	// non-overlapping range should succeed
+	ok := s.Add(Annotation{File: "handler.go", Line: 26, EndLine: 30, Type: "", Comment: "adjacent"})
+	assert.True(t, ok)
+	assert.Equal(t, 2, s.Count())
+}
+
+func TestStore_RangeAndPointCoexist(t *testing.T) {
+	s := NewStore()
+	// point annotation on line 10 with type "+"
+	s.Add(Annotation{File: "handler.go", Line: 10, Type: "+", Comment: "point"})
+	// range annotation starting at line 10 with type ""
+	ok := s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "range"})
+	assert.True(t, ok, "range and point on same start line should coexist (different Type)")
+
+	anns := s.Get("handler.go")
+	require.Len(t, anns, 2)
+}
+
+func TestStore_RangeDelete(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "range"})
+
+	ok := s.Delete("handler.go", 10, 25, "")
+	assert.True(t, ok)
+	assert.Empty(t, s.Get("handler.go"))
+}
+
+func TestStore_RangeDeleteDoesNotMatchPoint(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, Type: "+", Comment: "point"})
+
+	// trying to delete as range should fail
+	ok := s.Delete("handler.go", 10, 25, "+")
+	assert.False(t, ok)
+	assert.Len(t, s.Get("handler.go"), 1)
+}
+
+func TestStore_HasRangeCovering(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "range"})
+
+	tests := []struct {
+		line     int
+		expected bool
+	}{
+		{9, false},  // before range
+		{10, true},  // start boundary
+		{15, true},  // middle
+		{25, true},  // end boundary
+		{26, false}, // after range
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, s.HasRangeCovering("handler.go", tt.line), "line %d", tt.line)
+	}
+
+	// point annotations should not match
+	s.Add(Annotation{File: "other.go", Line: 5, Type: "+", Comment: "point"})
+	assert.False(t, s.HasRangeCovering("other.go", 5))
+}
+
+func TestStore_GetRangeCovering(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "range"})
+
+	a, ok := s.GetRangeCovering("handler.go", 15)
+	assert.True(t, ok)
+	assert.Equal(t, 10, a.Line)
+	assert.Equal(t, 25, a.EndLine)
+	assert.Equal(t, "range", a.Comment)
+
+	_, ok = s.GetRangeCovering("handler.go", 9)
+	assert.False(t, ok)
+}
+
+func TestStore_FormatOutputRange(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "review this block"})
+
+	expected := "## handler.go:10-25\nreview this block\n"
+	assert.Equal(t, expected, s.FormatOutput())
+}
+
+func TestStore_FormatOutputReplacementRange(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 10, Type: "", Comment: "review replacement"})
+
+	expected := "## handler.go:10-10\nreview replacement\n"
+	assert.Equal(t, expected, s.FormatOutput())
+}
+
+func TestStore_FormatOutputMixedPointRangeFileLevel(t *testing.T) {
+	s := NewStore()
+	s.Add(Annotation{File: "handler.go", Line: 0, Type: "", Comment: "file note"})
+	s.Add(Annotation{File: "handler.go", Line: 5, Type: "+", Comment: "point"})
+	s.Add(Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "range"})
+
+	out := s.FormatOutput()
+	assert.Contains(t, out, "## handler.go (file-level)\nfile note\n")
+	assert.Contains(t, out, "## handler.go:5 (+)\npoint\n")
+	assert.Contains(t, out, "## handler.go:10-25\nrange\n")
+}
+
+func TestStore_SingleLineSelectionCollapsesToPoint(t *testing.T) {
+	// single-line selections remain point annotations because they keep a change type
+	a := Annotation{File: "handler.go", Line: 10, EndLine: 10, Type: "+", Comment: "single line"}
+	assert.False(t, a.IsRange(), "single-line selection should not be a range")
 }

--- a/cmd/revdiff/main.go
+++ b/cmd/revdiff/main.go
@@ -73,7 +73,7 @@ type options struct {
 		StatusFg   string `long:"color-status-fg"   ini-name:"color-status-fg"   env:"REVDIFF_COLOR_STATUS_FG"   default:"#202020" description:"status bar foreground"`
 		StatusBg   string `long:"color-status-bg"   ini-name:"color-status-bg"   env:"REVDIFF_COLOR_STATUS_BG"   default:"#C5794F" description:"status bar background"`
 		SearchFg   string `long:"color-search-fg"   ini-name:"color-search-fg"   env:"REVDIFF_COLOR_SEARCH_FG"   default:"#1a1a1a" description:"search match foreground"`
-		SearchBg   string `long:"color-search-bg"   ini-name:"color-search-bg"   env:"REVDIFF_COLOR_SEARCH_BG"   default:"#4a4a00" description:"search match background"`
+		SearchBg string `long:"color-search-bg" ini-name:"color-search-bg" env:"REVDIFF_COLOR_SEARCH_BG" default:"#4a4a00" description:"search match background"`
 	} `group:"color options"`
 }
 
@@ -506,8 +506,8 @@ func colorFieldPtrs(opts *options) map[string]*string {
 		"color-diff-bg":     &opts.Colors.DiffBg,
 		"color-status-fg":   &opts.Colors.StatusFg,
 		"color-status-bg":   &opts.Colors.StatusBg,
-		"color-search-fg":   &opts.Colors.SearchFg,
-		"color-search-bg":   &opts.Colors.SearchBg,
+		"color-search-fg": &opts.Colors.SearchFg,
+		"color-search-bg": &opts.Colors.SearchBg,
 	}
 }
 

--- a/docs/plans/2026-04-06-range-hunk-annotations.md
+++ b/docs/plans/2026-04-06-range-hunk-annotations.md
@@ -32,11 +32,9 @@ Add `ActionSelectRange` (`V`) and `ActionAnnotateHunk` (`H`) to the keymap syste
 - [x] Handle `ActionSelectRange` in `handleKey()` — set `selecting=true`, `selectAnchor=diffCursor`; guard against overlays, annotation input, search, dividers, `diffCursor==-1`
 - [x] Handle `esc` during selection — clear `selecting` and `selectAnchor`
 - [x] Disable `cursorOnAnnotation` stops in `moveDiffCursorDown/Up` when `m.selecting`
-- [x] Add `SelectionBg` color key to `theme.go` colorKeys, options struct, `colorFieldPtrs()`, and all 5 bundled theme files
-- [x] Add `SelectionHighlight` style in `newStyles()` built from `SelectionBg`
-- [x] Render selection highlight in `renderDiffLine()` — when `m.selecting && selStart <= idx <= selEnd`, override line background with `SelectionBg`
-- [x] Apply selection highlight in `renderCollapsedDiff()` for collapsed mode
-- [x] Add tests: selection mode entry/exit, selection bounds calculation, selection highlight in render output
+- [x] Add `SelectedBg` color key to `theme.go` colorKeys, options struct, `colorFieldPtrs()` (wired as `color-selected-bg`; not yet added to bundled theme files)
+- [x] Selection range indicated by `┌│└` gutter (reuses range gutter via `appendSelectionRange`) — `SelectionHighlight` background style dropped in favor of always-visible gutter indicator
+- [x] Add tests: selection mode entry/exit, selection bounds calculation
 
 ### Task 3: Range Annotation Creation
 
@@ -70,8 +68,9 @@ Render saved range annotations in the diff view. Build `rangeRenderInfo` (start/
 
 Wire `ActionAnnotateHunk` (`H` key) to auto-select the current hunk and open annotation input. Uses existing `findHunks()` and `hunkStartFor()` to determine hunk boundaries, scans forward to find hunk end, then calls `startRangeAnnotation()`. No-op when cursor is on a context line (not in a hunk).
 
-- [x] Add `annotateHunk() tea.Cmd` in `ui/annotate.go` — find hunk start via `hunkStartFor()`, scan forward for hunk end, compute line numbers, call `startRangeAnnotation()`
+- [x] Add `annotateHunk() tea.Cmd` in `ui/annotate.go` — find hunk start via `hunkStartFor()`, scan forward for hunk end, compute line numbers, call `startRangeAnnotation()`. In collapsed mode, anchors to visible placeholder when hunk end is hidden
 - [x] Add `hunkEndFor(startIdx int) int` helper — returns last diffLines index of the hunk containing `startIdx`
+- [x] Single-line detection uses `hunkStart == hunkEnd` (diff index equality, not line number) to correctly handle replacement hunks where old/new line numbers match
 - [x] Handle `ActionAnnotateHunk` in `handleKey()` — guard same as `ActionSelectRange` (diff pane, no overlays), call `annotateHunk()`
 - [x] Add tests: hunk boundary detection, hunk annotation creates correct range, no-op on context line
 
@@ -86,7 +85,6 @@ Wire range annotations through all remaining UI surfaces. Annotation list (`@`) 
 - [x] Add `▋` selection mode icon in `statusModeIcons()` when `m.selecting`
 - [x] Show `SEL: N lines` in status bar left side during selection (count visible lines in selection range)
 - [x] Add `V select range` and `H annotate hunk` to help overlay annotations section via `HelpSections()`
-- [x] Update all 5 bundled theme TOML files with `SelectionBg` value (if not done in Task 2)
 - [x] Add tests: annotation list format for ranges, delete range annotation, status bar selection indicator
 
 ### Task 7: Documentation
@@ -96,4 +94,13 @@ Update all documentation surfaces to reflect range and hunk annotations: keybind
 - [x] Update README.md — add range/hunk annotation docs to keybindings table, output format section, and usage examples
 - [x] Update `site/docs.html` — mirror README changes
 - [x] Update plugin reference docs in `.claude-plugin/skills/revdiff/references/usage.md` — add `V`/`H` keybindings and range output format
-- [x] Update `.claude-plugin/skills/revdiff/references/config.md` — add `SelectionBg` color key
+- [x] Update `.claude-plugin/skills/revdiff/references/config.md` — add `SelectedBg` color key
+
+### Task 8: Bug Fixes (post-review)
+
+Fixes found during code review after initial implementation.
+
+- [x] `visibleRangeIndices` breaks at `ChangeDivider` once a range has started — prevents range mapping from leaking into adjacent hunks when line numbers alias across hunk boundaries
+- [x] Add `cursorOnRangeAnnotation` field to `Model` — enables independent cursor stops for point and range-end annotations on the same diff line. Cursor movement, Enter dispatch, delete, rendering cursor indicators, and `cursorViewportY` all respect the two sub-rows
+- [x] `saveRangeAnnotation` checks `store.Add()` return value — shows status flash `"overlaps existing range"` instead of silently dropping the annotation
+- [x] Add tests: divider boundary in `visibleRangeIndices`, dual sub-row cursor navigation, Enter/delete dispatch per sub-row

--- a/docs/plans/2026-04-06-range-hunk-annotations.md
+++ b/docs/plans/2026-04-06-range-hunk-annotations.md
@@ -1,0 +1,99 @@
+# Plan: Range & Hunk Annotations
+
+Add visual-mode range selection (`V`) and hunk annotation shortcut (`H`) to revdiff. Currently annotations are point-based (one comment per line). This feature lets users select a line range vim-style or target an entire hunk, then attach a single annotation to the whole region. Range annotations use an `EndLine` field on the existing `Annotation` struct, render with `┌│└` gutter indicators, and output as `file:10-25` in structured format.
+
+## Validation Commands
+
+- `make test`
+- `make lint`
+- `make build`
+
+### Task 1: Data Model — Extend Annotation Store for Ranges
+
+Add `EndLine int` field to `Annotation` struct and update all store operations to handle range identity `(Line, EndLine, Type)`. Range annotations use `Type == ""` to avoid key collisions with point annotations on the same start line. `Delete()` gains an `endLine` parameter. New methods `HasRangeCovering()` and `GetRangeCovering()` enable interval lookups. `FormatOutput()` renders ranges as `## file:10-25`. Overlap prevention in `Add()` rejects ranges that intersect existing ranges in the same file.
+
+- [x] Add `EndLine int` field to `Annotation` struct in `annotation/store.go`
+- [x] Add `IsRange() bool` method on `Annotation`
+- [x] Update `find()` to match on `(Line, EndLine, Type)` instead of `(Line, Type)`
+- [x] Update `Delete()` signature to `Delete(file, line, endLine, changeType)` and fix all call sites in `ui/annotate.go`
+- [x] Add `HasRangeCovering(file, lineNum) bool` — true if any range annotation covers the line
+- [x] Add `GetRangeCovering(file, lineNum) (Annotation, bool)` — returns covering range annotation
+- [x] Add overlap rejection in `Add()` for range annotations
+- [x] Update `FormatOutput()` to render range annotations as `## file:10-25`
+- [x] Add tests: range `Add`/`Delete`/`find`, `IsRange()`, `HasRangeCovering` boundaries, overlap rejection, `FormatOutput` with mixed point+range+file-level, single-line selection collapses to point
+
+### Task 2: Keymap & Visual Selection Mode
+
+Add `ActionSelectRange` (`V`) and `ActionAnnotateHunk` (`H`) to the keymap system. Add `selecting bool` and `selectAnchor int` fields to `Model`. Add `SelectionBg` color key to the theme system with values for all 5 bundled themes. Implement selection entry (`V` in diff pane), exit (`esc`), and highlight rendering — during selection, lines between anchor and cursor get `SelectionBg` background. `cursorOnAnnotation` stops are disabled while selecting.
+
+- [x] Add `ActionSelectRange Action = "select_range"` and `ActionAnnotateHunk Action = "annotate_hunk"` to `keymap/keymap.go`
+- [x] Add default bindings `V → select_range`, `H → annotate_hunk` in keymap defaults
+- [x] Add `selecting bool` and `selectAnchor int` fields to `Model` in `ui/model.go`
+- [x] Handle `ActionSelectRange` in `handleKey()` — set `selecting=true`, `selectAnchor=diffCursor`; guard against overlays, annotation input, search, dividers, `diffCursor==-1`
+- [x] Handle `esc` during selection — clear `selecting` and `selectAnchor`
+- [x] Disable `cursorOnAnnotation` stops in `moveDiffCursorDown/Up` when `m.selecting`
+- [x] Add `SelectionBg` color key to `theme.go` colorKeys, options struct, `colorFieldPtrs()`, and all 5 bundled theme files
+- [x] Add `SelectionHighlight` style in `newStyles()` built from `SelectionBg`
+- [x] Render selection highlight in `renderDiffLine()` — when `m.selecting && selStart <= idx <= selEnd`, override line background with `SelectionBg`
+- [x] Apply selection highlight in `renderCollapsedDiff()` for collapsed mode
+- [x] Add tests: selection mode entry/exit, selection bounds calculation, selection highlight in render output
+
+### Task 3: Range Annotation Creation
+
+Wire `a`/`enter` during visual selection to create range annotations. Add `startRangeAnnotation(startLine, endLine, startIdx, endIdx)` which computes line numbers from the selection bounds, creates a text input (reusing `newAnnotationInput`), and pre-fills if an existing range annotation matches. `saveRangeAnnotation()` stores the annotation and clears selection state. Single-line selections (anchor == cursor) collapse to a regular point annotation via the existing `startAnnotation()` path.
+
+- [x] Add temporary fields `rangeStartLine int`, `rangeEndLine int` to `Model` for in-progress range annotation input
+- [x] Add `startRangeAnnotation(startLine, endLine, startIdx, endIdx) tea.Cmd` in `ui/annotate.go`
+- [x] Add `saveRangeAnnotation()` in `ui/annotate.go` — stores `Annotation{File, Line, EndLine, Type:"", Comment}`, clears selection + annotating state, refreshes tree filter
+- [x] Wire `ActionConfirm` / `a` during `m.selecting` to: collapse single-line to `startAnnotation()`, else call `startRangeAnnotation()`
+- [x] Update `cancelAnnotation()` to also clear `selecting`/`selectAnchor`/`rangeStartLine`/`rangeEndLine`
+- [x] Pre-fill text input when editing existing range annotation (match on `Line, EndLine`)
+- [x] Add tests: `startRangeAnnotation` → `saveRangeAnnotation` lifecycle, single-line collapse to point, pre-fill existing range
+
+### Task 4: Range Annotation Rendering
+
+Render saved range annotations in the diff view. Build `rangeRenderInfo` (start/end diffLines indices + comment) before the render loop. Show `┌│└` gutter indicators on lines within a range using `AnnotationLine` style. Render the annotation comment after the last line of the range with `💬 [lines N-M]` prefix. Update `cursorViewportY()` to account for range annotation rows at range ends. Update `moveDiffCursorDown/Up` to stop on range annotation sub-rows at the last line of a range.
+
+- [x] Add `rangeRenderInfo` struct with `startIdx`, `endIdx`, `comment` fields
+- [x] Add `buildRangeAnnotations() []rangeRenderInfo` — scan store + diffLines to map range annotations to diffLines indices
+- [x] Add `rangeGutterFor(idx, ranges) string` — returns `┌`, `│`, `└`, or `""` for the given diffLines index
+- [x] Integrate gutter indicator into `renderDiffLine()` — prepend range gutter before line number gutter
+- [x] Integrate gutter indicator into `renderWrappedDiffLine()` for wrap mode
+- [x] Render range annotation comment after last line in `renderAnnotationOrInput()` — check `rangeEndsAt` set, use `💬 [lines N-M]` prefix
+- [x] Update `cursorViewportY()` — add range annotation rows at range-end indices (parallel to existing point annotation accounting)
+- [x] Update `moveDiffCursorDown()` — stop on range annotation sub-row at range-end line
+- [x] Update `moveDiffCursorUp()` — land on range annotation sub-row when moving up past range-end line
+- [x] Apply range gutter in `renderCollapsedDiff()` for collapsed mode
+- [x] Add tests: `buildRangeAnnotations` mapping, gutter indicator assignment (first/middle/last), `cursorViewportY` with ranges, cursor movement through range sub-rows
+
+### Task 5: Hunk Annotation Shortcut
+
+Wire `ActionAnnotateHunk` (`H` key) to auto-select the current hunk and open annotation input. Uses existing `findHunks()` and `hunkStartFor()` to determine hunk boundaries, scans forward to find hunk end, then calls `startRangeAnnotation()`. No-op when cursor is on a context line (not in a hunk).
+
+- [x] Add `annotateHunk() tea.Cmd` in `ui/annotate.go` — find hunk start via `hunkStartFor()`, scan forward for hunk end, compute line numbers, call `startRangeAnnotation()`
+- [x] Add `hunkEndFor(startIdx int) int` helper — returns last diffLines index of the hunk containing `startIdx`
+- [x] Handle `ActionAnnotateHunk` in `handleKey()` — guard same as `ActionSelectRange` (diff pane, no overlays), call `annotateHunk()`
+- [x] Add tests: hunk boundary detection, hunk annotation creates correct range, no-op on context line
+
+### Task 6: Integration — Annotation List, Delete, Status Bar, Help
+
+Wire range annotations through all remaining UI surfaces. Annotation list (`@`) displays ranges as `file:10-25` and jumps to range start. `deleteAnnotation()` handles range annotations when `cursorOnAnnotation` at range end. Status bar shows `▋` icon during selection and `SEL: N lines` count. Help overlay includes `V` and `H` bindings in the Annotations section.
+
+- [x] Update `formatAnnotListItem()` in `ui/annotlist.go` — check `IsRange()`, format as `basename:N-M  comment`
+- [x] Update `jumpToAnnotation()` — for ranges, position cursor at start line of range via `findDiffLineIndex(a.Line, ...)`
+- [x] Update `deleteAnnotation()` — detect range annotation at cursor (via `GetRangeCovering`), call `Delete(file, line, endLine, type)`
+- [x] Update `positionOnAnnotation()` to handle range annotations (find range-end line for `cursorOnAnnotation`)
+- [x] Add `▋` selection mode icon in `statusModeIcons()` when `m.selecting`
+- [x] Show `SEL: N lines` in status bar left side during selection (count visible lines in selection range)
+- [x] Add `V select range` and `H annotate hunk` to help overlay annotations section via `HelpSections()`
+- [x] Update all 5 bundled theme TOML files with `SelectionBg` value (if not done in Task 2)
+- [x] Add tests: annotation list format for ranges, delete range annotation, status bar selection indicator
+
+### Task 7: Documentation
+
+Update all documentation surfaces to reflect range and hunk annotations: keybindings, output format, usage examples.
+
+- [x] Update README.md — add range/hunk annotation docs to keybindings table, output format section, and usage examples
+- [x] Update `site/docs.html` — mirror README changes
+- [x] Update plugin reference docs in `.claude-plugin/skills/revdiff/references/usage.md` — add `V`/`H` keybindings and range output format
+- [x] Update `.claude-plugin/skills/revdiff/references/config.md` — add `SelectionBg` color key

--- a/keymap/keymap.go
+++ b/keymap/keymap.go
@@ -50,6 +50,8 @@ const (
 	ActionDiscardQuit      Action = "discard_quit"
 	ActionHelp             Action = "help"
 	ActionDismiss          Action = "dismiss"
+	ActionSelectRange      Action = "select_range"
+	ActionAnnotateHunk     Action = "annotate_hunk"
 )
 
 // validActions contains all known action names for validation.
@@ -64,6 +66,7 @@ var validActions = map[Action]bool{
 	ActionToggleCollapsed: true, ActionToggleWrap: true, ActionToggleTree: true,
 	ActionToggleLineNums: true, ActionToggleBlame: true, ActionToggleHunk: true, ActionFilter: true,
 	ActionQuit: true, ActionDiscardQuit: true, ActionHelp: true, ActionDismiss: true,
+	ActionSelectRange: true, ActionAnnotateHunk: true,
 }
 
 // IsValidAction returns true if the action name is recognized.
@@ -132,6 +135,8 @@ func defaultDescriptions() []HelpEntry {
 		{ActionAnnotateFile, "annotate file", "Annotations"},
 		{ActionDeleteAnnotation, "delete annotation", "Annotations"},
 		{ActionAnnotList, "annotation list", "Annotations"},
+		{ActionSelectRange, "select range", "Annotations"},
+		{ActionAnnotateHunk, "annotate hunk", "Annotations"},
 
 		// view toggles
 		{ActionToggleCollapsed, "toggle collapsed view", "View"},
@@ -190,6 +195,8 @@ func defaultBindings() map[string]Action {
 		"Q":      ActionDiscardQuit,
 		"?":      ActionHelp,
 		"esc":    ActionDismiss,
+		"V":      ActionSelectRange,
+		"H":      ActionAnnotateHunk,
 	}
 }
 

--- a/keymap/keymap_test.go
+++ b/keymap/keymap_test.go
@@ -35,6 +35,7 @@ func TestDefault_allExpectedBindings(t *testing.T) {
 		{"/", ActionSearch},
 		{"a", ActionConfirm}, {"enter", ActionConfirm},
 		{"A", ActionAnnotateFile}, {"d", ActionDeleteAnnotation}, {"@", ActionAnnotList},
+		{"V", ActionSelectRange}, {"H", ActionAnnotateHunk},
 		{"v", ActionToggleCollapsed}, {"w", ActionToggleWrap}, {"t", ActionToggleTree},
 		{"L", ActionToggleLineNums}, {"B", ActionToggleBlame}, {".", ActionToggleHunk}, {"f", ActionFilter},
 		{"q", ActionQuit}, {"Q", ActionDiscardQuit}, {"?", ActionHelp}, {"esc", ActionDismiss},

--- a/site/docs.html
+++ b/site/docs.html
@@ -306,9 +306,11 @@ color-border = #6272a4
             <tbody>
                 <tr><td><code>a</code> or <code>Enter</code></td><td>Annotate current line</td></tr>
                 <tr><td><code>A</code></td><td>Add file-level annotation</td></tr>
+                <tr><td><code>V</code></td><td>Start visual range selection</td></tr>
+                <tr><td><code>H</code></td><td>Annotate entire hunk under cursor</td></tr>
                 <tr><td><code>@</code></td><td>Toggle annotation list popup</td></tr>
                 <tr><td><code>d</code></td><td>Delete annotation under cursor</td></tr>
-                <tr><td><code>Esc</code></td><td>Cancel annotation input</td></tr>
+                <tr><td><code>Esc</code></td><td>Cancel annotation input / cancel selection</td></tr>
             </tbody>
         </table>
 
@@ -414,9 +416,12 @@ consider splitting this file into smaller modules
 <span class="code-comment">## handler.go:43 (+)</span>
 use errors.Is() instead of direct comparison
 
+<span class="code-comment">## handler.go:10-25</span>
+review this block for error handling
+
 <span class="code-comment">## store.go:18 (-)</span>
 don't remove this validation</code></div>
-        <p>Each annotation block: <code>## filename:line (type)</code> where type is <code>(+)</code> added, <code>(-)</code> removed, or <code>(file-level)</code>.</p>
+        <p>Point annotations: <code>## filename:line (type)</code> where type is <code>(+)</code> added, <code>(-)</code> removed, or <code>(file-level)</code>. Range annotations (<code>V</code> selection or <code>H</code> hunk): <code>## filename:start-end</code>.</p>
 
         <h2 id="integration">Integration with other tools</h2>
         <p>The structured stdout output works with any tool that can read text:</p>

--- a/theme/bundled.go
+++ b/theme/bundled.go
@@ -28,6 +28,7 @@ color-status-fg = #282a36
 color-status-bg = #bd93f9
 color-search-fg = #282a36
 color-search-bg = #f1fa8c
+#44475a
 `
 
 const bundledNord = `# name: nord
@@ -55,6 +56,7 @@ color-status-fg = #2e3440
 color-status-bg = #88c0d0
 color-search-fg = #2e3440
 color-search-bg = #ebcb8b
+#3b4252
 `
 
 const bundledSolarizedDark = `# name: solarized-dark
@@ -82,6 +84,7 @@ color-status-fg = #002b36
 color-status-bg = #b58900
 color-search-fg = #002b36
 color-search-bg = #cb4b16
+#073642
 `
 
 const bundledCatppuccinMocha = `# name: catppuccin-mocha
@@ -109,6 +112,7 @@ color-status-fg = #1e1e2e
 color-status-bg = #89b4fa
 color-search-fg = #1e1e2e
 color-search-bg = #f9e2af
+#313244
 `
 
 const bundledGruvbox = `# name: gruvbox
@@ -136,6 +140,7 @@ color-status-fg = #282828
 color-status-bg = #fabd2f
 color-search-fg = #282828
 color-search-bg = #fe8019
+#3c3836
 `
 
 // bundledThemes maps theme name to its file content.

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -41,9 +41,9 @@ var colorKeys = []string{
 // optionalColorKeys lists color keys that may be omitted from theme files.
 // these correspond to CLI flags with no default value (terminal background is used instead).
 var optionalColorKeys = map[string]bool{
-	"color-cursor-bg": true,
-	"color-tree-bg":   true,
-	"color-diff-bg":   true,
+	"color-cursor-bg":   true,
+	"color-tree-bg": true,
+	"color-diff-bg": true,
 }
 
 // ColorKeys returns the ordered list of recognized color key names.

--- a/ui/annotate.go
+++ b/ui/annotate.go
@@ -35,6 +35,7 @@ func (m *Model) startSelection() {
 	m.selecting = true
 	m.selectAnchor = m.diffCursor
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	m.viewport.SetContent(m.renderDiff())
 }
 
@@ -68,15 +69,23 @@ func (m *Model) annotateHunk() tea.Cmd {
 	startLine := m.diffLineNum(m.diffLines[hunkStart])
 	endLine := m.diffLineNum(m.diffLines[hunkEnd])
 
-	if startLine == endLine {
-		// single-line hunk: use point annotation
+	if hunkStart == hunkEnd {
+		// single diff line in hunk: use point annotation.
+		// check diff index count, not line numbers — replacement hunks may have
+		// startLine == endLine (same old/new number) but span multiple diff lines.
 		m.diffCursor = hunkStart
 		return m.startAnnotation()
 	}
 
-	// position cursor at hunk end where annotation input renders
-	m.diffCursor = hunkEnd
-	return m.startRangeAnnotation(startLine, endLine, hunkStart, hunkEnd)
+	// position cursor at hunk end where annotation input renders.
+	// in collapsed mode, if hunk end is hidden (e.g., delete-only hunk),
+	// anchor to the visible placeholder at hunkStart instead.
+	visibleEnd := hunkEnd
+	if m.collapsed.enabled && m.isCollapsedHidden(hunkEnd, hunks) {
+		visibleEnd = hunkStart
+	}
+	m.diffCursor = visibleEnd
+	return m.startRangeAnnotation(startLine, endLine, hunkStart, visibleEnd)
 }
 
 // hunkEndFor returns the last diffLines index of the hunk starting at startIdx.
@@ -249,13 +258,16 @@ func (m *Model) saveRangeAnnotation() {
 		return
 	}
 
-	m.store.Add(annotation.Annotation{
+	if !m.store.Add(annotation.Annotation{
 		File:    m.currFile,
 		Line:    m.rangeStartLine,
 		EndLine: m.rangeEndLine,
 		Type:    "",
 		Comment: text,
-	})
+	}) {
+		m.statusFlash = "overlaps existing range — adjust or [esc] cancel"
+		return
+	}
 	m.annotating = false
 	m.selecting = false
 	m.selectAnchor = 0
@@ -277,6 +289,7 @@ func (m *Model) cancelAnnotation() {
 	m.rangeEndLine = 0
 	m.rangeStartIdx = 0
 	m.rangeEndIdx = 0
+	m.statusFlash = ""
 	m.viewport.SetContent(m.renderDiff())
 }
 
@@ -320,11 +333,21 @@ func (m *Model) deleteAnnotation() tea.Cmd {
 
 	lineNum := m.diffLineNum(dl)
 
+	// when on range sub-row, delete the covering range directly
+	if m.cursorOnRangeAnnotation {
+		if rangeAnn, ok := m.store.GetRangeCovering(m.currFile, lineNum); ok {
+			m.store.Delete(m.currFile, rangeAnn.Line, rangeAnn.EndLine, rangeAnn.Type)
+			return m.afterAnnotationDelete()
+		}
+		return nil
+	}
+
+	// on point sub-row, delete the point annotation
 	if m.store.Delete(m.currFile, lineNum, 0, string(dl.ChangeType)) {
 		return m.afterAnnotationDelete()
 	}
 
-	// fall back to a covering range only after the focused point annotation is handled
+	// fall back to a covering range when no point annotation exists
 	if rangeAnn, ok := m.store.GetRangeCovering(m.currFile, lineNum); ok {
 		m.store.Delete(m.currFile, rangeAnn.Line, rangeAnn.EndLine, rangeAnn.Type)
 		return m.afterAnnotationDelete()
@@ -336,6 +359,7 @@ func (m *Model) deleteAnnotation() tea.Cmd {
 func (m *Model) afterAnnotationDelete() tea.Cmd {
 	m.pendingAnnotJump = nil
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	m.tree.refreshFilter(m.annotatedFiles())
 
 	if newFile := m.tree.selectedFile(); newFile != "" && newFile != m.currFile {
@@ -361,6 +385,7 @@ func (m Model) handleAnnotateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.cancelAnnotation()
 		return m, nil
 	default:
+		m.statusFlash = ""
 		var cmd tea.Cmd
 		m.annotateInput, cmd = m.annotateInput.Update(msg)
 		m.viewport.SetContent(m.renderDiff()) // re-render so typed characters are visible immediately
@@ -495,13 +520,19 @@ func (m Model) cursorViewportY() int {
 			y += m.wrappedRangeAnnotationLineCount(r)
 		}
 	}
-	// if cursor is on the point annotation sub-line below, offset by wrapped line count
-	// (annotation renders after all continuation lines of the diff line)
+	// if cursor is on an annotation sub-line, offset by wrapped line count of the diff line
+	// (annotations render after all continuation lines of the diff line)
 	if m.cursorOnAnnotation {
 		y += m.wrappedLineCount(m.diffCursor)
+		// on range sub-row: also add point annotation height between diff line and range annotation
+		if m.cursorOnRangeAnnotation && m.diffCursor >= 0 && m.diffCursor < len(m.diffLines) {
+			dl := m.diffLines[m.diffCursor]
+			key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
+			if annotationSet[key] {
+				y += m.wrappedAnnotationLineCount(key)
+			}
+		}
 	}
-	// cursor on range annotation above doesn't add the diff line itself —
-	// the range annotation row at this index hasn't been counted yet (loop stops before diffCursor)
 	return y
 }
 

--- a/ui/annotate.go
+++ b/ui/annotate.go
@@ -22,6 +22,91 @@ func (m *Model) newAnnotationInput(placeholder string, prefixWidth int) (textinp
 	return ti, cmd
 }
 
+// startSelection enters visual range selection mode with the current cursor as anchor.
+func (m *Model) startSelection() {
+	if m.focus != paneDiff || m.annotating || m.showHelp || m.showAnnotList ||
+		m.searching || m.diffCursor < 0 || m.diffCursor >= len(m.diffLines) {
+		return
+	}
+	dl := m.diffLines[m.diffCursor]
+	if dl.ChangeType == diff.ChangeDivider {
+		return
+	}
+	m.selecting = true
+	m.selectAnchor = m.diffCursor
+	m.cursorOnAnnotation = false
+	m.viewport.SetContent(m.renderDiff())
+}
+
+// selectionBounds returns the ordered (start, end) diffLines indices of the current selection.
+func (m *Model) selectionBounds() (int, int) {
+	start, end := m.selectAnchor, m.diffCursor
+	if start > end {
+		start, end = end, start
+	}
+	return start, end
+}
+
+// annotateHunk auto-selects the current hunk and opens range annotation input.
+// uses hunk boundary detection to determine the range, then calls startRangeAnnotation.
+// no-op when cursor is on a context/divider line (not inside a hunk).
+func (m *Model) annotateHunk() tea.Cmd {
+	if m.annotating || m.showHelp || m.showAnnotList || m.searching {
+		return nil
+	}
+	if m.diffCursor < 0 || m.diffCursor >= len(m.diffLines) {
+		return nil
+	}
+
+	hunks := m.findHunks()
+	hunkStart := m.hunkStartFor(m.diffCursor, hunks)
+	if hunkStart < 0 {
+		return nil // cursor not on a changed line
+	}
+
+	hunkEnd := m.hunkEndFor(hunkStart)
+	startLine := m.diffLineNum(m.diffLines[hunkStart])
+	endLine := m.diffLineNum(m.diffLines[hunkEnd])
+
+	if startLine == endLine {
+		// single-line hunk: use point annotation
+		m.diffCursor = hunkStart
+		return m.startAnnotation()
+	}
+
+	// position cursor at hunk end where annotation input renders
+	m.diffCursor = hunkEnd
+	return m.startRangeAnnotation(startLine, endLine, hunkStart, hunkEnd)
+}
+
+// hunkEndFor returns the last diffLines index of the hunk starting at startIdx.
+func (m *Model) hunkEndFor(startIdx int) int {
+	end := startIdx
+	for i := startIdx; i < len(m.diffLines); i++ {
+		dl := m.diffLines[i]
+		if dl.ChangeType != diff.ChangeAdd && dl.ChangeType != diff.ChangeRemove {
+			break
+		}
+		end = i
+	}
+	return end
+}
+
+// editRangeAnnotation opens annotation input for the range annotation at the current cursor.
+func (m *Model) editRangeAnnotation() tea.Cmd {
+	dl, ok := m.cursorDiffLine()
+	if !ok {
+		return nil
+	}
+	lineNum := m.diffLineNum(dl)
+	rangeAnn, ok := m.store.GetRangeCovering(m.currFile, lineNum)
+	if !ok {
+		return nil
+	}
+	startIdx, endIdx := m.visibleRangeIndices(rangeAnn.Line, rangeAnn.EndLine)
+	return m.startRangeAnnotation(rangeAnn.Line, rangeAnn.EndLine, startIdx, endIdx)
+}
+
 // startAnnotation enters annotation input mode for the current cursor line.
 func (m *Model) startAnnotation() tea.Cmd {
 	dl, ok := m.cursorDiffLine()
@@ -110,16 +195,94 @@ func (m *Model) saveAnnotation() {
 	m.viewport.SetContent(m.renderDiff())
 }
 
+// confirmSelection finalizes the visual selection and opens range annotation input.
+// single-line selections (anchor == cursor) collapse to a regular point annotation.
+func (m *Model) confirmSelection() tea.Cmd {
+	startIdx, endIdx := m.selectionBounds()
+
+	// single-line selection: collapse to point annotation
+	if startIdx == endIdx {
+		m.selecting = false
+		m.selectAnchor = 0
+		m.diffCursor = startIdx
+		return m.startAnnotation()
+	}
+
+	startDL := m.diffLines[startIdx]
+	endDL := m.diffLines[endIdx]
+	startLine := m.diffLineNum(startDL)
+	endLine := m.diffLineNum(endDL)
+
+	// keep cursor at end of selection where the annotation input renders
+	m.diffCursor = endIdx
+	return m.startRangeAnnotation(startLine, endLine, startIdx, endIdx)
+}
+
+// startRangeAnnotation enters annotation input mode for a range of lines.
+func (m *Model) startRangeAnnotation(startLine, endLine, startIdx, endIdx int) tea.Cmd {
+	prefix := rangeAnnotationPrefix(startLine, endLine)
+	ti, cmd := m.newAnnotationInput("range annotation...", len(prefix)+2)
+
+	// pre-fill with existing range annotation if one matches
+	for _, a := range m.store.Get(m.currFile) {
+		if a.Line == startLine && a.EndLine == endLine {
+			ti.SetValue(a.Comment)
+			break
+		}
+	}
+
+	m.annotateInput = ti
+	m.annotating = true
+	m.fileAnnotating = false
+	m.rangeStartLine = startLine
+	m.rangeEndLine = endLine
+	m.rangeStartIdx = startIdx
+	m.rangeEndIdx = endIdx
+	return cmd
+}
+
+// saveRangeAnnotation saves the current text input as a range annotation.
+func (m *Model) saveRangeAnnotation() {
+	text := m.annotateInput.Value()
+	if text == "" {
+		m.cancelAnnotation()
+		return
+	}
+
+	m.store.Add(annotation.Annotation{
+		File:    m.currFile,
+		Line:    m.rangeStartLine,
+		EndLine: m.rangeEndLine,
+		Type:    "",
+		Comment: text,
+	})
+	m.annotating = false
+	m.selecting = false
+	m.selectAnchor = 0
+	m.rangeStartLine = 0
+	m.rangeEndLine = 0
+	m.rangeStartIdx = 0
+	m.rangeEndIdx = 0
+	m.tree.refreshFilter(m.annotatedFiles())
+	m.viewport.SetContent(m.renderDiff())
+}
+
 // cancelAnnotation exits annotation input mode without saving.
 func (m *Model) cancelAnnotation() {
 	m.annotating = false
 	m.fileAnnotating = false
+	m.selecting = false
+	m.selectAnchor = 0
+	m.rangeStartLine = 0
+	m.rangeEndLine = 0
+	m.rangeStartIdx = 0
+	m.rangeEndIdx = 0
 	m.viewport.SetContent(m.renderDiff())
 }
 
 // deleteFileAnnotation removes the file-level annotation and adjusts cursor position.
 func (m *Model) deleteFileAnnotation() tea.Cmd {
-	if !m.store.Delete(m.currFile, 0, "") {
+	if !m.store.Delete(m.currFile, 0, 0, "") {
 		return nil
 	}
 	m.pendingAnnotJump = nil // clear before refreshFilter which may trigger file load
@@ -156,19 +319,31 @@ func (m *Model) deleteAnnotation() tea.Cmd {
 	}
 
 	lineNum := m.diffLineNum(dl)
-	if m.store.Delete(m.currFile, lineNum, string(dl.ChangeType)) {
-		m.pendingAnnotJump = nil // clear before refreshFilter which may trigger file load
-		m.cursorOnAnnotation = false
-		m.tree.refreshFilter(m.annotatedFiles())
 
-		// if filter moved cursor to a different file, load the new selection
-		if newFile := m.tree.selectedFile(); newFile != "" && newFile != m.currFile {
-			m.loadSeq++
-			return m.loadFileDiff(newFile)
-		}
-
-		m.syncViewportToCursor()
+	if m.store.Delete(m.currFile, lineNum, 0, string(dl.ChangeType)) {
+		return m.afterAnnotationDelete()
 	}
+
+	// fall back to a covering range only after the focused point annotation is handled
+	if rangeAnn, ok := m.store.GetRangeCovering(m.currFile, lineNum); ok {
+		m.store.Delete(m.currFile, rangeAnn.Line, rangeAnn.EndLine, rangeAnn.Type)
+		return m.afterAnnotationDelete()
+	}
+	return nil
+}
+
+// afterAnnotationDelete handles shared cleanup after removing any annotation.
+func (m *Model) afterAnnotationDelete() tea.Cmd {
+	m.pendingAnnotJump = nil
+	m.cursorOnAnnotation = false
+	m.tree.refreshFilter(m.annotatedFiles())
+
+	if newFile := m.tree.selectedFile(); newFile != "" && newFile != m.currFile {
+		m.loadSeq++
+		return m.loadFileDiff(newFile)
+	}
+
+	m.syncViewportToCursor()
 	return nil
 }
 
@@ -176,7 +351,11 @@ func (m *Model) deleteAnnotation() tea.Cmd {
 func (m Model) handleAnnotateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyEnter:
-		m.saveAnnotation()
+		if m.rangeStartLine > 0 {
+			m.saveRangeAnnotation()
+		} else {
+			m.saveAnnotation()
+		}
 		return m, nil
 	case tea.KeyEsc:
 		m.cancelAnnotation()
@@ -196,6 +375,16 @@ func (m Model) cursorLineHasAnnotation() bool {
 		return true
 	}
 	return m.cursorOnAnnotation
+}
+
+// isRangeAnnotationEnd returns true if the given diffLines index is the end of a saved range annotation.
+func (m Model) isRangeAnnotationEnd(idx int) bool {
+	for _, r := range m.buildRangeAnnotations() {
+		if r.endIdx == idx {
+			return true
+		}
+	}
+	return false
 }
 
 // hasFileAnnotation checks if the current file has a file-level annotation (Line=0).
@@ -271,6 +460,11 @@ func (m Model) cursorViewportY() int {
 	}
 
 	annotationSet := m.buildAnnotationSet()
+	ranges := m.buildRangeAnnotations()
+	rangeEndSet := make(map[int]rangeRenderInfo, len(ranges))
+	for _, r := range ranges {
+		rangeEndSet[r.endIdx] = r
+	}
 	var hunks []int
 	if m.collapsed.enabled {
 		hunks = m.findHunks()
@@ -296,13 +490,29 @@ func (m Model) cursorViewportY() int {
 				y += m.wrappedAnnotationLineCount(key)
 			}
 		}
+		// range annotation row below range end
+		if r, ok := rangeEndSet[i]; ok {
+			y += m.wrappedRangeAnnotationLineCount(r)
+		}
 	}
-	// if cursor is on the annotation sub-line, offset by wrapped line count
+	// if cursor is on the point annotation sub-line below, offset by wrapped line count
 	// (annotation renders after all continuation lines of the diff line)
 	if m.cursorOnAnnotation {
 		y += m.wrappedLineCount(m.diffCursor)
 	}
+	// cursor on range annotation above doesn't add the diff line itself —
+	// the range annotation row at this index hasn't been counted yet (loop stops before diffCursor)
 	return y
+}
+
+// wrappedRangeAnnotationLineCount returns the visual row count for a range annotation comment.
+func (m Model) wrappedRangeAnnotationLineCount(r rangeRenderInfo) int {
+	comment := rangeAnnotationPrefix(r.startLine, r.endLine) + r.comment
+	wrapWidth := m.diffContentWidth() - 1
+	if wrapWidth > 10 && lipgloss.Width(comment) > wrapWidth {
+		return len(m.wrapContent(comment, wrapWidth))
+	}
+	return 1
 }
 
 // buildAnnotationSet returns a set of annotation keys for the current file.

--- a/ui/annotlist.go
+++ b/ui/annotlist.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/umputun/revdiff/annotation"
+	"github.com/umputun/revdiff/diff"
 	"github.com/umputun/revdiff/keymap"
 )
 
@@ -86,11 +87,14 @@ func (m Model) annotListEmptyOverlay(popupWidth int) string {
 
 // formatAnnotListItem formats a single annotation list item for display.
 func (m Model) formatAnnotListItem(a annotation.Annotation, width int, selected bool) string {
-	// build prefix: "filename:line (type)" or "filename (file-level)"
+	// build prefix: "filename:line (type)", "filename:N-M", or "filename (file-level)"
 	var prefix string
-	if a.Line == 0 {
+	switch {
+	case a.Line == 0:
 		prefix = filepath.Base(a.File) + " (file-level)"
-	} else {
+	case a.IsRange():
+		prefix = fmt.Sprintf("%s:%d-%d", filepath.Base(a.File), a.Line, a.EndLine)
+	default:
 		prefix = fmt.Sprintf("%s:%d (%s)", filepath.Base(a.File), a.Line, a.Type)
 	}
 
@@ -127,10 +131,12 @@ func (m Model) formatAnnotListItem(a annotation.Annotation, width int, selected 
 
 	// style the prefix with change type color
 	var styledPrefix string
-	switch a.Type {
-	case "+":
+	switch {
+	case a.IsRange():
+		styledPrefix = m.ansiFg(m.styles.colors.Annotation) + prefix + "\033[39m"
+	case a.Type == "+":
 		styledPrefix = m.ansiFg(m.styles.colors.AddFg) + prefix + "\033[39m"
-	case "-":
+	case a.Type == "-":
 		styledPrefix = m.ansiFg(m.styles.colors.RemoveFg) + prefix + "\033[39m"
 	default:
 		styledPrefix = m.ansiFg(m.styles.colors.Muted) + prefix + "\033[39m"
@@ -260,11 +266,17 @@ func (m Model) jumpToAnnotation() (tea.Model, tea.Cmd) {
 // positionOnAnnotation moves the cursor to the given annotation's line, re-renders, and centers the viewport.
 // in collapsed mode, expands the hunk containing the target line so removed lines are visible.
 func (m *Model) positionOnAnnotation(a annotation.Annotation) {
-	if a.Line == 0 {
+	switch {
+	case a.Line == 0:
 		m.diffCursor = -1
-	} else {
-		idx := m.findDiffLineIndex(a.Line, a.Type)
-		if idx >= 0 {
+	case a.IsRange():
+		// range annotations: find by line number only (Type="" doesn't match any diff line type)
+		if idx := m.findDiffLineByNum(a.Line); idx >= 0 {
+			m.diffCursor = idx
+			m.ensureHunkExpanded(idx)
+		}
+	default:
+		if idx := m.findDiffLineIndex(a.Line, a.Type); idx >= 0 {
 			m.diffCursor = idx
 			m.ensureHunkExpanded(idx)
 		}
@@ -273,6 +285,19 @@ func (m *Model) positionOnAnnotation(a annotation.Annotation) {
 	m.syncTOCActiveSection()
 	m.viewport.SetContent(m.renderDiff())
 	m.centerViewportOnCursor()
+}
+
+// findDiffLineByNum finds the first diffLines index matching the given line number.
+func (m Model) findDiffLineByNum(lineNum int) int {
+	for i, dl := range m.diffLines {
+		if dl.ChangeType == diff.ChangeDivider {
+			continue
+		}
+		if m.diffLineNum(dl) == lineNum {
+			return i
+		}
+	}
+	return -1
 }
 
 // ensureHunkExpanded expands the hunk containing diffLines[idx] when collapsed mode is active.

--- a/ui/annotlist_test.go
+++ b/ui/annotlist_test.go
@@ -701,3 +701,21 @@ func TestModel_JumpToAnnotation_EmptyList(t *testing.T) {
 	model := result.(Model)
 	assert.False(t, model.showAnnotList)
 }
+
+func TestAnnotList_RangeFormat(t *testing.T) {
+	m := testModel(nil, nil)
+	m.width = 80
+
+	t.Run("range annotation in list", func(t *testing.T) {
+		a := annotation.Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "review block"}
+		formatted := m.formatAnnotListItem(a, 60, false)
+		assert.Contains(t, formatted, "handler.go:10-25")
+		assert.Contains(t, formatted, "review block")
+	})
+
+	t.Run("range annotation in list selected", func(t *testing.T) {
+		a := annotation.Annotation{File: "handler.go", Line: 10, EndLine: 25, Type: "", Comment: "review block"}
+		formatted := m.formatAnnotListItem(a, 60, true)
+		assert.Contains(t, formatted, "handler.go:10-25")
+	})
+}

--- a/ui/collapsed.go
+++ b/ui/collapsed.go
@@ -339,7 +339,8 @@ func (m *Model) toggleCollapsedMode() {
 	}
 	m.collapsed.enabled = !m.collapsed.enabled
 	m.collapsed.expandedHunks = make(map[int]bool)
-	m.cursorOnAnnotation = false // visible lines change, reset annotation cursor state
+	m.cursorOnAnnotation = false      // visible lines change, reset annotation cursor state
+	m.cursorOnRangeAnnotation = false
 	m.adjustCursorIfHidden()
 	m.realignSearchCursor()
 	m.viewport.SetContent(m.renderDiff())
@@ -357,7 +358,8 @@ func (m *Model) toggleHunkExpansion() {
 	}
 	if m.collapsed.expandedHunks[hunkStart] {
 		delete(m.collapsed.expandedHunks, hunkStart)
-		m.cursorOnAnnotation = false // annotations on removed lines become invisible
+		m.cursorOnAnnotation = false      // annotations on removed lines become invisible
+		m.cursorOnRangeAnnotation = false
 		m.adjustCursorIfHidden()
 		m.realignSearchCursor()
 	} else {

--- a/ui/collapsed.go
+++ b/ui/collapsed.go
@@ -24,6 +24,8 @@ func (m Model) renderCollapsedDiff() string {
 	m.buildSearchMatchSet()
 
 	annotationMap, fileComment := m.buildAnnotationMap()
+	ranges := m.buildRangeAnnotations()
+	ranges = m.appendSelectionRange(ranges)
 	hunks := m.findHunks()
 	modifiedSet := m.buildModifiedSet(hunks)
 
@@ -48,28 +50,30 @@ func (m Model) renderCollapsedDiff() string {
 		case diff.ChangeRemove:
 			switch {
 			case expanded:
-				m.renderDiffLine(&b, i, dl)
+				m.renderDiffLine(&b, i, dl, ranges)
 			case i == hunkStart && hunkStart >= 0 && m.isDeleteOnlyHunk(hunkStart):
-				m.renderDeletePlaceholder(&b, i, hunkStart)
+				m.renderDeletePlaceholder(&b, i, hunkStart, ranges)
 				hasVisibleContent = true
-				continue // placeholder is synthetic, skip annotation rendering
+				m.renderRangeAnnotation(&b, i, ranges)
+				continue // placeholder is synthetic, skip point annotation rendering
 			default:
 				continue // hide removed lines in collapsed mode
 			}
 
 		case diff.ChangeAdd:
 			if expanded {
-				m.renderDiffLine(&b, i, dl) // use standard add styling when hunk is expanded
+				m.renderDiffLine(&b, i, dl, ranges) // use standard add styling when hunk is expanded
 			} else {
-				m.renderCollapsedAddLine(&b, i, dl, modifiedSet[i])
+				m.renderCollapsedAddLine(&b, i, dl, modifiedSet[i], ranges)
 			}
 
 		default: // context and divider lines render normally
-			m.renderDiffLine(&b, i, dl)
+			m.renderDiffLine(&b, i, dl, ranges)
 		}
 		hasVisibleContent = true
 
 		m.renderAnnotationOrInput(&b, i, annotationMap)
+		m.renderRangeAnnotation(&b, i, ranges)
 	}
 
 	if !hasVisibleContent {
@@ -80,7 +84,7 @@ func (m Model) renderCollapsedDiff() string {
 
 // renderCollapsedAddLine renders an add line in collapsed mode with modify or add styling.
 // when search is active, matching lines use search highlight instead of add/modify styling.
-func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffLine, modified bool) {
+func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffLine, modified bool, ranges []rangeRenderInfo) {
 	lineContent, textContent, hasHighlight := m.prepareLineContent(idx, dl)
 	isSearchMatch := m.searchMatchSet[idx]
 
@@ -94,8 +98,8 @@ func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffL
 	}
 
 	isCursor := idx == m.diffCursor && m.focus == paneDiff && !m.cursorOnAnnotation
-
 	numGutter, blGutter := m.lineGutters(dl)
+	rg := m.styledRangeGutter(idx, ranges)
 
 	bgColor := m.styles.colors.AddBg
 	if modified {
@@ -104,7 +108,7 @@ func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffL
 
 	// wrap mode: break long lines at word boundaries with continuation markers
 	if m.wrapMode {
-		m.renderWrappedCollapsedLine(b, textContent, gutter, numGutter, blGutter, isCursor, hasHighlight, style, hlStyle, bgColor)
+		m.renderWrappedCollapsedLine(b, textContent, gutter, numGutter, blGutter, isCursor, hasHighlight, style, hlStyle, bgColor, ranges, idx)
 		return
 	}
 
@@ -119,23 +123,31 @@ func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffL
 	if isCursor {
 		cursor = m.styles.DiffCursorLine.Render("▶")
 	}
-	b.WriteString(cursor + numGutter + blGutter + content + "\n")
+	b.WriteString(cursor + rg + numGutter + blGutter + content + "\n")
 }
 
 // renderWrappedCollapsedLine renders a collapsed add line with word wrapping, producing continuation lines with ↪ markers.
 func (m Model) renderWrappedCollapsedLine(b *strings.Builder, textContent, gutter, numGutter, blGutter string,
-	isCursor, hasHighlight bool, style, hlStyle lipgloss.Style, bgColor string) {
+	isCursor, hasHighlight bool, style, hlStyle lipgloss.Style, bgColor string, ranges []rangeRenderInfo, idx int) {
 	numBlank, blBlank := m.gutterBlanks()
+	rg := m.styledRangeGutter(idx, ranges)
+	rgBlank := ""
 	wrapWidth := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+	if len(ranges) > 0 {
+		rgBlank = strings.Repeat(" ", rangeGutterWidth)
+		wrapWidth -= rangeGutterWidth
+	}
 	visualLines := m.wrapContent(textContent, wrapWidth)
 	for i, vl := range visualLines {
 		prefix := " ↪ "
 		ng := numBlank
 		bg := blBlank
+		rug := rgBlank
 		if i == 0 {
 			prefix = gutter
 			ng = numGutter
 			bg = blGutter
+			rug = rg
 		}
 
 		var styled string
@@ -150,7 +162,7 @@ func (m Model) renderWrappedCollapsedLine(b *strings.Builder, textContent, gutte
 		if i == 0 && isCursor {
 			cursor = m.styles.DiffCursorLine.Render("▶")
 		}
-		b.WriteString(cursor + ng + bg + styled + "\n")
+		b.WriteString(cursor + rug + ng + bg + styled + "\n")
 	}
 }
 
@@ -181,13 +193,16 @@ func (m Model) deletePlaceholderVisualHeight(hunkStart int) int {
 	}
 	text := m.deletePlaceholderText(hunkStart)
 	wrapWidth := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+	if m.hasRangeGutter() {
+		wrapWidth -= rangeGutterWidth
+	}
 	return len(m.wrapContent(text, wrapWidth))
 }
 
 // renderDeletePlaceholder renders a placeholder line for a delete-only hunk in collapsed mode.
 // shows "⋯ N lines deleted" with remove styling so users know deletions exist and can expand with '.'.
 // when search is active, matching placeholders use search highlight instead of remove styling.
-func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int) {
+func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int, ranges []rangeRenderInfo) {
 	text := m.deletePlaceholderText(hunkStart)
 
 	style := m.styles.LineRemove
@@ -196,23 +211,30 @@ func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int) {
 	}
 
 	isCursor := idx == m.diffCursor && m.focus == paneDiff && !m.cursorOnAnnotation
-
 	divider := diff.DiffLine{ChangeType: diff.ChangeDivider}
 	numGutter, blGutter := m.lineGutters(divider)
+	rg := m.styledRangeGutter(idx, ranges)
 
 	// wrap mode: break long placeholder at word boundaries
 	if m.wrapMode {
 		numBlank, blBlank := m.gutterBlanks()
+		rgBlank := ""
 		wrapWidth := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+		if len(ranges) > 0 {
+			rgBlank = strings.Repeat(" ", rangeGutterWidth)
+			wrapWidth -= rangeGutterWidth
+		}
 		visualLines := m.wrapContent(text, wrapWidth)
 		for i, vl := range visualLines {
 			prefix := " ↪ "
 			ng := numBlank
 			bg := blBlank
+			rug := rgBlank
 			if i == 0 {
 				prefix = " - "
 				ng = numGutter
 				bg = blGutter
+				rug = rg
 			}
 			styled := style.Render(prefix + vl)
 			styled = m.extendLineBg(styled, m.styles.colors.RemoveBg)
@@ -221,7 +243,7 @@ func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int) {
 			if i == 0 && isCursor {
 				cursor = m.styles.DiffCursorLine.Render("▶")
 			}
-			b.WriteString(cursor + ng + bg + styled + "\n")
+			b.WriteString(cursor + rug + ng + bg + styled + "\n")
 		}
 		return
 	}
@@ -234,7 +256,7 @@ func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int) {
 	if isCursor {
 		cursor = m.styles.DiffCursorLine.Render("▶")
 	}
-	b.WriteString(cursor + numGutter + blGutter + content + "\n")
+	b.WriteString(cursor + rg + numGutter + blGutter + content + "\n")
 }
 
 // hunkStartFor returns the findHunks() start index for the hunk containing diffLines[idx].

--- a/ui/collapsed_test.go
+++ b/ui/collapsed_test.go
@@ -1551,6 +1551,61 @@ func TestModel_CollapsedWrapPureAddLine(t *testing.T) {
 	assert.Contains(t, rendered, " ↪ ", "wrapped continuation should have ↪ marker")
 }
 
+func TestModel_CollapsedRangeAnnotationsRender(t *testing.T) {
+	m := testModel(nil, nil)
+	m.styles = plainStyles()
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.collapsed.enabled = true
+	m.collapsed.expandedHunks = make(map[int]bool)
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "ctx1", ChangeType: diff.ChangeContext},
+		{OldNum: 2, Content: "old1", ChangeType: diff.ChangeRemove},
+		{NewNum: 2, Content: "new1", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "new2", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "ctx2", ChangeType: diff.ChangeContext},
+	}
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 3, Type: "", Comment: "range note"})
+
+	rendered := ansi.Strip(m.renderDiff())
+	assert.Contains(t, rendered, "range note")
+	assert.Contains(t, rendered, "┌ ")
+	assert.Contains(t, rendered, "└ ")
+}
+
+func TestModel_CollapsedWrapCursorViewportYWithRangeGutter(t *testing.T) {
+	m := testModel(nil, nil)
+	m.styles = plainStyles()
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.collapsed.enabled = true
+	m.collapsed.expandedHunks = make(map[int]bool)
+	m.wrapMode = true
+	m.width = 44
+	m.treeWidth = 0
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "ctx1", ChangeType: diff.ChangeContext},
+		{OldNum: 2, Content: "old1", ChangeType: diff.ChangeRemove},
+		{NewNum: 2, Content: "this is a very long modified line that should wrap when the range gutter is visible", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "ctx2", ChangeType: diff.ChangeContext},
+	}
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 2, Type: "", Comment: "replacement"})
+
+	rendered := strings.Split(strings.TrimSuffix(ansi.Strip(m.renderDiff()), "\n"), "\n")
+	ctx2Row := -1
+	for i, line := range rendered {
+		if strings.Contains(line, "ctx2") {
+			ctx2Row = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, ctx2Row, 0, "ctx2 should be rendered")
+
+	m.diffCursor = 3
+	m.cursorOnAnnotation = false
+	assert.Equal(t, ctx2Row, m.cursorViewportY())
+}
+
 func TestModel_CollapsedWrapDeletePlaceholder(t *testing.T) {
 	t.Run("wrapping", func(t *testing.T) {
 		m := testModel(nil, nil)

--- a/ui/collapsed_test.go
+++ b/ui/collapsed_test.go
@@ -1769,3 +1769,71 @@ func TestModel_CollapsedRenderWithLineNumbers(t *testing.T) {
 	assert.Contains(t, stripped, " 1  1")
 	assert.Contains(t, stripped, "    2")
 }
+
+func TestModel_CollapsedRangeDoesNotSpillIntoContext(t *testing.T) {
+	// P2: a range annotation on hidden removed lines should not spill into
+	// following context lines that happen to share the same display line numbers
+	// (OldNum of removes vs NewNum of context after the gap).
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.collapsed.enabled = true
+	m.diffLines = []diff.DiffLine{
+		{OldNum: 17, NewNum: 17, Content: "ctx before", ChangeType: diff.ChangeContext},
+		{OldNum: 18, Content: "removed18", ChangeType: diff.ChangeRemove},
+		{OldNum: 19, Content: "removed19", ChangeType: diff.ChangeRemove},
+		{OldNum: 20, Content: "removed20", ChangeType: diff.ChangeRemove},
+		{OldNum: 21, NewNum: 18, Content: "ctx after1", ChangeType: diff.ChangeContext},
+		{OldNum: 22, NewNum: 19, Content: "ctx after2", ChangeType: diff.ChangeContext},
+	}
+
+	// range covers the removed lines 18-20
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 18, EndLine: 20, Comment: "range on removes"})
+
+	// visibleRangeIndices should only include the visible placeholder (hunkStart)
+	// and must NOT extend into context lines at NewNum=18, 19
+	startIdx, endIdx := m.visibleRangeIndices(18, 20)
+
+	// in collapsed mode, the delete-only hunk placeholder is idx 1 (first remove line);
+	// endIdx should not be 4 or 5 (the context lines)
+	assert.Equal(t, 1, startIdx, "should start at the visible placeholder")
+	assert.Equal(t, 1, endIdx, "should stop at the placeholder, not spill into context")
+
+	// render should not show range gutter on context lines
+	rendered := m.renderDiff()
+	for line := range strings.SplitSeq(rendered, "\n") {
+		stripped := ansi.Strip(line)
+		if strings.Contains(stripped, "ctx after") {
+			assert.NotContains(t, stripped, "│", "range gutter should not appear on context lines after hidden hunk")
+			assert.NotContains(t, stripped, "┌", "range start gutter should not appear on context lines")
+			assert.NotContains(t, stripped, "└", "range end gutter should not appear on context lines")
+		}
+	}
+}
+
+func TestModel_CollapsedAnnotateHunkOnDeleteOnly(t *testing.T) {
+	// P2: pressing H on a collapsed delete-only placeholder should anchor the
+	// annotation input to the visible placeholder, not to a hidden row.
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.collapsed.enabled = true
+	m.diffLines = []diff.DiffLine{
+		{OldNum: 9, NewNum: 9, Content: "ctx", ChangeType: diff.ChangeContext},
+		{OldNum: 10, Content: "del1", ChangeType: diff.ChangeRemove},
+		{OldNum: 11, Content: "del2", ChangeType: diff.ChangeRemove},
+		{OldNum: 12, Content: "del3", ChangeType: diff.ChangeRemove},
+		{OldNum: 13, NewNum: 10, Content: "ctx", ChangeType: diff.ChangeContext},
+	}
+
+	m.diffCursor = 1 // on the visible placeholder for the delete-only hunk
+	cmd := m.annotateHunk()
+
+	assert.NotNil(t, cmd)
+	assert.True(t, m.annotating)
+	assert.Equal(t, 10, m.rangeStartLine)
+	assert.Equal(t, 12, m.rangeEndLine)
+	// cursor should be on the visible placeholder (hunkStart=1), not hunkEnd=3 (hidden)
+	assert.Equal(t, 1, m.diffCursor, "cursor should stay on visible placeholder")
+	assert.Equal(t, 1, m.rangeEndIdx, "endIdx should be the visible placeholder")
+}

--- a/ui/diffview.go
+++ b/ui/diffview.go
@@ -15,6 +15,23 @@ import (
 // matchRange represents a range of visible character positions for search match highlighting.
 type matchRange struct{ start, end int }
 
+// rangeRenderInfo maps a range annotation to its diffLines indices for rendering.
+type rangeRenderInfo struct {
+	startIdx  int    // first visible diffLines index in the range
+	endIdx    int    // last visible diffLines index in the range
+	startLine int    // annotation start line number
+	endLine   int    // annotation end line number
+	comment   string // annotation comment
+}
+
+// rangeGutterWidth is the character width of the range annotation gutter indicator.
+const rangeGutterWidth = 2
+
+// rangeAnnotationPrefix returns the formatted prefix for range annotation display.
+func rangeAnnotationPrefix(startLine, endLine int) string {
+	return fmt.Sprintf("\U0001f4ac [lines %d-%d] ", startLine, endLine)
+}
+
 // lineNumGutterWidth returns the total character width of the line number gutter.
 // layout: " " + oldNum(W) + " " + newNum(W) = 2*W + 2
 func (m Model) lineNumGutterWidth() int {
@@ -153,12 +170,15 @@ func (m Model) renderDiff() string {
 	m.buildSearchMatchSet()
 
 	annotationMap, fileComment := m.buildAnnotationMap()
+	ranges := m.buildRangeAnnotations()
+	ranges = m.appendSelectionRange(ranges)
 	var b strings.Builder
 	m.renderFileAnnotationHeader(&b, fileComment)
 
 	for i, dl := range m.diffLines {
-		m.renderDiffLine(&b, i, dl)
+		m.renderDiffLine(&b, i, dl, ranges)
 		m.renderAnnotationOrInput(&b, i, annotationMap)
+		m.renderRangeAnnotation(&b, i, ranges)
 	}
 	return b.String()
 }
@@ -198,19 +218,19 @@ func (m Model) renderFileAnnotationHeader(b *strings.Builder, fileComment string
 
 // renderDiffLine writes a single styled diff line (with cursor highlight) to the builder.
 // when wrap mode is active, long lines are broken at word boundaries with ↪ continuation markers.
-func (m Model) renderDiffLine(b *strings.Builder, idx int, dl diff.DiffLine) {
+func (m Model) renderDiffLine(b *strings.Builder, idx int, dl diff.DiffLine, ranges []rangeRenderInfo) {
 	lineContent, textContent, hasHighlight := m.prepareLineContent(idx, dl)
 	isSearchMatch := m.searchMatchSet[idx]
 
 	isCursor := idx == m.diffCursor && m.focus == paneDiff && !m.cursorOnAnnotation
-
 	// wrap mode: break long lines at word boundaries (dividers are short, skip them)
 	if m.wrapMode && dl.ChangeType != diff.ChangeDivider {
-		m.renderWrappedDiffLine(b, dl, textContent, hasHighlight, isCursor, isSearchMatch)
+		m.renderWrappedDiffLine(b, dl, textContent, hasHighlight, isCursor, isSearchMatch, ranges, idx)
 		return
 	}
 
 	numGutter, blGutter := m.lineGutters(dl)
+	rg := m.styledRangeGutter(idx, ranges)
 
 	var content string
 	if dl.ChangeType == diff.ChangeDivider {
@@ -225,24 +245,111 @@ func (m Model) renderDiffLine(b *strings.Builder, idx int, dl diff.DiffLine) {
 	if isCursor {
 		cursor = m.styles.DiffCursorLine.Render("▶")
 	}
-	b.WriteString(cursor + numGutter + blGutter + content + "\n")
+	b.WriteString(cursor + rg + numGutter + blGutter + content + "\n")
+}
+
+// styledRangeGutter returns the styled range gutter indicator for a diffLines index.
+func (m Model) styledRangeGutter(idx int, ranges []rangeRenderInfo) string {
+	gutter := rangeGutterFor(idx, ranges)
+	if gutter == "" {
+		if len(ranges) > 0 {
+			return strings.Repeat(" ", rangeGutterWidth)
+		}
+		return ""
+	}
+	return m.styles.AnnotationLine.Render(gutter)
+}
+
+// renderRangeAnnotation writes the range annotation comment or input below the last line of a range.
+func (m Model) renderRangeAnnotation(b *strings.Builder, idx int, ranges []rangeRenderInfo) {
+	// render range annotation input below the end line
+	if m.annotating && m.rangeStartLine > 0 && idx == m.diffCursor {
+		prefix := rangeAnnotationPrefix(m.rangeStartLine, m.rangeEndLine)
+		b.WriteString(" " + m.styles.AnnotationLine.Render(prefix) + m.annotateInput.View() + "\n")
+		return
+	}
+
+	for _, r := range ranges {
+		if r.endIdx != idx || r.comment == "" {
+			continue
+		}
+		prefix := rangeAnnotationPrefix(r.startLine, r.endLine)
+		cursor := " "
+		if idx == m.diffCursor && m.cursorOnAnnotation && m.focus == paneDiff {
+			cursor = m.styles.DiffCursorLine.Render("▶")
+		}
+		m.renderWrappedAnnotation(b, cursor, prefix+r.comment)
+		return
+	}
+}
+
+// hasRangeGutter returns true if range gutter indicators are currently shown.
+func (m Model) hasRangeGutter() bool {
+	if m.selecting || (m.annotating && m.rangeStartLine > 0) {
+		return true
+	}
+	for _, a := range m.store.Get(m.currFile) {
+		if a.IsRange() {
+			return true
+		}
+	}
+	return false
+}
+
+// appendSelectionRange adds a live selection indicator to the ranges slice.
+// shown during active selection and while typing a range annotation input.
+func (m Model) appendSelectionRange(ranges []rangeRenderInfo) []rangeRenderInfo {
+	if m.selecting {
+		start, end := m.selectionBounds()
+		if start != end {
+			return append(ranges, rangeRenderInfo{
+				startIdx:  start,
+				endIdx:    end,
+				startLine: m.diffLineNum(m.diffLines[start]),
+				endLine:   m.diffLineNum(m.diffLines[end]),
+			})
+		}
+		return ranges
+	}
+	// keep gutter visible while editing range annotation (diffCursor is at range end)
+	if m.annotating && m.rangeStartLine > 0 {
+		if m.rangeStartIdx >= 0 && m.rangeEndIdx >= m.rangeStartIdx {
+			return append(ranges, rangeRenderInfo{
+				startIdx:  m.rangeStartIdx,
+				endIdx:    m.rangeEndIdx,
+				startLine: m.rangeStartLine,
+				endLine:   m.rangeEndLine,
+			})
+		}
+	}
+	return ranges
 }
 
 // renderWrappedDiffLine renders a diff line with word wrapping, producing continuation lines with ↪ markers.
-func (m Model) renderWrappedDiffLine(b *strings.Builder, dl diff.DiffLine, textContent string, hasHighlight, isCursor, isSearchMatch bool) {
+func (m Model) renderWrappedDiffLine(b *strings.Builder, dl diff.DiffLine, textContent string, hasHighlight, isCursor, isSearchMatch bool, ranges []rangeRenderInfo, idx int) {
 	numGutter, blGutter := m.lineGutters(dl)
 	numBlank, blBlank := m.gutterBlanks()
+	rg := m.styledRangeGutter(idx, ranges)
+	rgBlank := ""
+	if len(ranges) > 0 {
+		rgBlank = strings.Repeat(" ", rangeGutterWidth)
+	}
 	wrapWidth := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+	if len(ranges) > 0 {
+		wrapWidth -= rangeGutterWidth
+	}
 
 	visualLines := m.wrapContent(textContent, wrapWidth)
 	for i, vl := range visualLines {
 		prefix := " ↪ "
 		ng := numBlank
 		bg := blBlank
+		rug := rgBlank
 		if i == 0 {
 			prefix = m.linePrefix(dl.ChangeType)
 			ng = numGutter
 			bg = blGutter
+			rug = rg
 		}
 
 		styled := m.styleDiffContent(dl.ChangeType, prefix, vl, hasHighlight, isSearchMatch)
@@ -251,7 +358,7 @@ func (m Model) renderWrappedDiffLine(b *strings.Builder, dl diff.DiffLine, textC
 		if i == 0 && isCursor {
 			cursor = m.styles.DiffCursorLine.Render("▶")
 		}
-		b.WriteString(cursor + ng + bg + styled + "\n")
+		b.WriteString(cursor + rug + ng + bg + styled + "\n")
 	}
 }
 
@@ -269,7 +376,42 @@ func (m Model) wrappedLineCount(idx int) int {
 
 	_, textContent, _ := m.prepareLineContent(idx, dl)
 	wrapWidth := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+	if m.hasRangeGutter() {
+		wrapWidth -= rangeGutterWidth
+	}
 	return len(m.wrapContent(textContent, wrapWidth))
+}
+
+// visibleRangeIndices maps an annotation line range to visible diff line indices.
+func (m Model) visibleRangeIndices(startLine, endLine int) (int, int) {
+	startIdx := -1
+	endIdx := -1
+	hunks := m.findHunks()
+	for i, dl := range m.diffLines {
+		if dl.ChangeType == diff.ChangeDivider {
+			continue
+		}
+		if m.collapsed.enabled && m.isCollapsedHidden(i, hunks) {
+			continue
+		}
+
+		lineNum := m.diffLineNum(dl)
+		inRange := lineNum >= startLine && lineNum <= endLine
+		if startIdx == -1 {
+			if !inRange {
+				continue
+			}
+			startIdx = i
+			endIdx = i
+			continue
+		}
+
+		if !inRange {
+			break
+		}
+		endIdx = i
+	}
+	return startIdx, endIdx
 }
 
 // wrapContent wraps text content at the given width using word boundaries.
@@ -425,6 +567,47 @@ func (m Model) styleDiffContent(changeType diff.ChangeType, prefix, content stri
 	}
 }
 
+// buildRangeAnnotations maps range annotations to their diffLines indices.
+func (m Model) buildRangeAnnotations() []rangeRenderInfo {
+	var ranges []rangeRenderInfo
+	for _, a := range m.store.Get(m.currFile) {
+		if !a.IsRange() {
+			continue
+		}
+		startIdx, endIdx := m.visibleRangeIndices(a.Line, a.EndLine)
+		if startIdx >= 0 && endIdx >= 0 {
+			ranges = append(ranges, rangeRenderInfo{
+				startIdx:  startIdx,
+				endIdx:    endIdx,
+				startLine: a.Line,
+				endLine:   a.EndLine,
+				comment:   a.Comment,
+			})
+		}
+	}
+	return ranges
+}
+
+// rangeGutterFor returns the gutter indicator for a diffLines index within range annotations.
+// returns "┌ ", "│ ", "└ ", or "" depending on position within the range.
+func rangeGutterFor(idx int, ranges []rangeRenderInfo) string {
+	for _, r := range ranges {
+		if r.startIdx == r.endIdx && idx == r.startIdx {
+			return "│ "
+		}
+		if idx == r.startIdx {
+			return "┌ "
+		}
+		if idx == r.endIdx {
+			return "└ "
+		}
+		if idx > r.startIdx && idx < r.endIdx {
+			return "│ "
+		}
+	}
+	return ""
+}
+
 // extendLineBg extends a styled line's background to the full diff content width
 // using raw ANSI sequences. this ensures add/remove/modify backgrounds fill the entire line.
 // subtracts line number gutter width when line numbers are enabled.
@@ -446,7 +629,7 @@ func (m Model) extendLineBg(styled, bgColor string) string {
 
 // renderAnnotationOrInput writes the annotation input or existing annotation below a diff line.
 func (m Model) renderAnnotationOrInput(b *strings.Builder, idx int, annotationMap map[string]string) {
-	if m.annotating && !m.fileAnnotating && idx == m.diffCursor {
+	if m.annotating && !m.fileAnnotating && m.rangeStartLine == 0 && idx == m.diffCursor {
 		b.WriteString(" " + m.styles.AnnotationLine.Render("\U0001f4ac ") + m.annotateInput.View() + "\n")
 		return
 	}
@@ -509,13 +692,13 @@ func (m *Model) moveDiffCursorDown() {
 		return
 	}
 
-	// if current line has an annotation, stop on it first.
+	// if current line has a point or range-end annotation, stop on it first (disabled during selection).
 	// skip for delete-only placeholders — their annotations are only visible when expanded.
-	if m.diffCursor >= 0 && m.diffCursor < len(m.diffLines) {
+	if !m.selecting && m.diffCursor >= 0 && m.diffCursor < len(m.diffLines) {
 		dl := m.diffLines[m.diffCursor]
 		if dl.ChangeType != diff.ChangeDivider && !m.isDeleteOnlyPlaceholder(m.diffCursor, hunks) {
 			lineNum := m.diffLineNum(dl)
-			if m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) {
+			if m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) || m.isRangeAnnotationEnd(m.diffCursor) {
 				m.cursorOnAnnotation = true
 				return
 			}
@@ -551,16 +734,19 @@ func (m *Model) moveDiffCursorUp() {
 			continue
 		}
 		m.diffCursor = i
-		// if this line has an annotation, land on it (skip for delete-only placeholders)
-		dl := m.diffLines[i]
-		lineNum := m.diffLineNum(dl)
-		if m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) && !m.isDeleteOnlyPlaceholder(i, hunks) {
-			m.cursorOnAnnotation = true
+		// if this line has a point or range-end annotation, land on it (skip for delete-only placeholders; disabled during selection)
+		if !m.selecting {
+			dl := m.diffLines[i]
+			lineNum := m.diffLineNum(dl)
+			hasAnnot := m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) || m.isRangeAnnotationEnd(i)
+			if hasAnnot && !m.isDeleteOnlyPlaceholder(i, hunks) {
+				m.cursorOnAnnotation = true
+			}
 		}
 		return
 	}
-	// if we're at the first line and there's a file-level annotation, go to it
-	if m.diffCursor >= 0 && m.hasFileAnnotation() {
+	// if we're at the first line and there's a file-level annotation, go to it (disabled during selection)
+	if !m.selecting && m.diffCursor >= 0 && m.hasFileAnnotation() {
 		m.diffCursor = -1
 	}
 }

--- a/ui/diffview.go
+++ b/ui/diffview.go
@@ -275,7 +275,7 @@ func (m Model) renderRangeAnnotation(b *strings.Builder, idx int, ranges []range
 		}
 		prefix := rangeAnnotationPrefix(r.startLine, r.endLine)
 		cursor := " "
-		if idx == m.diffCursor && m.cursorOnAnnotation && m.focus == paneDiff {
+		if idx == m.diffCursor && m.cursorOnAnnotation && m.cursorOnRangeAnnotation && m.focus == paneDiff {
 			cursor = m.styles.DiffCursorLine.Render("▶")
 		}
 		m.renderWrappedAnnotation(b, cursor, prefix+r.comment)
@@ -389,6 +389,9 @@ func (m Model) visibleRangeIndices(startLine, endLine int) (int, int) {
 	hunks := m.findHunks()
 	for i, dl := range m.diffLines {
 		if dl.ChangeType == diff.ChangeDivider {
+			if startIdx != -1 {
+				break // stop at hunk boundary once range has started
+			}
 			continue
 		}
 		if m.collapsed.enabled && m.isCollapsedHidden(i, hunks) {
@@ -409,6 +412,18 @@ func (m Model) visibleRangeIndices(startLine, endLine int) (int, int) {
 		if !inRange {
 			break
 		}
+
+		// in collapsed mode, stop if hidden lines exist between last match and current line.
+		// this prevents a range on hidden removed lines from spilling into context lines
+		// that happen to share the same display line numbers (OldNum vs NewNum aliasing).
+		if m.collapsed.enabled {
+			for j := endIdx + 1; j < i; j++ {
+				if m.isCollapsedHidden(j, hunks) {
+					return startIdx, endIdx
+				}
+			}
+		}
+
 		endIdx = i
 	}
 	return startIdx, endIdx
@@ -638,7 +653,7 @@ func (m Model) renderAnnotationOrInput(b *strings.Builder, idx int, annotationMa
 		key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
 		if comment, ok := annotationMap[key]; ok {
 			cursor := " "
-			if idx == m.diffCursor && m.cursorOnAnnotation && m.focus == paneDiff {
+			if idx == m.diffCursor && m.cursorOnAnnotation && !m.cursorOnRangeAnnotation && m.focus == paneDiff {
 				cursor = m.styles.DiffCursorLine.Render("▶")
 			}
 			m.renderWrappedAnnotation(b, cursor, "\U0001f4ac "+comment)
@@ -680,9 +695,20 @@ func (m Model) cursorDiffLine() (diff.DiffLine, bool) {
 func (m *Model) moveDiffCursorDown() {
 	hunks := m.findHunks()
 
-	// if currently on annotation sub-line, move to the next diff line
+	// if currently on annotation sub-line, advance to the next sub-row or diff line
 	if m.cursorOnAnnotation {
+		// on point sub-row: if a range-end also exists here, advance to range sub-row
+		if !m.cursorOnRangeAnnotation && m.isRangeAnnotationEnd(m.diffCursor) {
+			dl := m.diffLines[m.diffCursor]
+			lineNum := m.diffLineNum(dl)
+			if m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) {
+				m.cursorOnRangeAnnotation = true
+				return
+			}
+		}
+		// otherwise move to the next diff line
 		m.cursorOnAnnotation = false
+		m.cursorOnRangeAnnotation = false
 		for i := m.diffCursor + 1; i < len(m.diffLines); i++ {
 			if m.diffLines[i].ChangeType != diff.ChangeDivider && !m.isCollapsedHidden(i, hunks) {
 				m.diffCursor = i
@@ -698,8 +724,11 @@ func (m *Model) moveDiffCursorDown() {
 		dl := m.diffLines[m.diffCursor]
 		if dl.ChangeType != diff.ChangeDivider && !m.isDeleteOnlyPlaceholder(m.diffCursor, hunks) {
 			lineNum := m.diffLineNum(dl)
-			if m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) || m.isRangeAnnotationEnd(m.diffCursor) {
+			hasPoint := m.store.Has(m.currFile, lineNum, string(dl.ChangeType))
+			hasRangeEnd := m.isRangeAnnotationEnd(m.diffCursor)
+			if hasPoint || hasRangeEnd {
 				m.cursorOnAnnotation = true
+				m.cursorOnRangeAnnotation = !hasPoint && hasRangeEnd
 				return
 			}
 		}
@@ -722,9 +751,19 @@ func (m *Model) moveDiffCursorDown() {
 // when moving up from a diff line, if the previous line has an annotation, lands on the annotation first.
 // in collapsed mode, also skips removed lines unless their hunk is expanded.
 func (m *Model) moveDiffCursorUp() {
-	// if currently on annotation sub-line, move up to the diff line itself
+	// if currently on annotation sub-line, move up to previous sub-row or diff line
 	if m.cursorOnAnnotation {
+		// on range sub-row: if a point annotation also exists, move up to point sub-row
+		if m.cursorOnRangeAnnotation {
+			dl := m.diffLines[m.diffCursor]
+			lineNum := m.diffLineNum(dl)
+			if m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) {
+				m.cursorOnRangeAnnotation = false
+				return
+			}
+		}
 		m.cursorOnAnnotation = false
+		m.cursorOnRangeAnnotation = false
 		return
 	}
 
@@ -734,13 +773,15 @@ func (m *Model) moveDiffCursorUp() {
 			continue
 		}
 		m.diffCursor = i
-		// if this line has a point or range-end annotation, land on it (skip for delete-only placeholders; disabled during selection)
-		if !m.selecting {
+		// if this line has annotations, land on the last sub-row (skip for delete-only placeholders; disabled during selection)
+		if !m.selecting && !m.isDeleteOnlyPlaceholder(i, hunks) {
 			dl := m.diffLines[i]
 			lineNum := m.diffLineNum(dl)
-			hasAnnot := m.store.Has(m.currFile, lineNum, string(dl.ChangeType)) || m.isRangeAnnotationEnd(i)
-			if hasAnnot && !m.isDeleteOnlyPlaceholder(i, hunks) {
+			hasRangeEnd := m.isRangeAnnotationEnd(i)
+			hasPoint := m.store.Has(m.currFile, lineNum, string(dl.ChangeType))
+			if hasPoint || hasRangeEnd {
 				m.cursorOnAnnotation = true
+				m.cursorOnRangeAnnotation = hasRangeEnd
 			}
 		}
 		return
@@ -834,6 +875,7 @@ func (m *Model) moveDiffCursorHalfPageUp() {
 // if a file-level annotation exists, the cursor goes to -1 (file annotation line).
 func (m *Model) moveDiffCursorToStart() {
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	if m.hasFileAnnotation() {
 		m.diffCursor = -1
 		m.syncViewportToCursor()
@@ -848,6 +890,7 @@ func (m *Model) moveDiffCursorToStart() {
 // in collapsed mode, skips hidden removed lines.
 func (m *Model) moveDiffCursorToEnd() {
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	hunks := m.findHunks()
 	for i := len(m.diffLines) - 1; i >= 0; i-- {
 		if m.diffLines[i].ChangeType != diff.ChangeDivider && !m.isCollapsedHidden(i, hunks) {
@@ -917,6 +960,7 @@ func (m Model) currentHunk() (int, int) {
 // in collapsed mode, advances past hidden removed lines to the first visible line in the hunk.
 func (m *Model) moveToNextHunk() {
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	hunks := m.findHunks()
 	for _, start := range hunks {
 		if start <= m.diffCursor {
@@ -936,6 +980,7 @@ func (m *Model) moveToNextHunk() {
 // in collapsed mode, advances past hidden removed lines to the first visible line in the hunk.
 func (m *Model) moveToPrevHunk() {
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	hunks := m.findHunks()
 	for i := len(hunks) - 1; i >= 0; i-- {
 		target := m.firstVisibleInHunk(hunks[i], hunks)

--- a/ui/model.go
+++ b/ui/model.go
@@ -81,7 +81,7 @@ type Model struct {
 	ready              bool              // true after first WindowSizeMsg
 	annotating         bool              // true when annotation text input is active
 	fileAnnotating     bool              // true when annotating at file level (Line=0)
-	cursorOnAnnotation bool              // true when cursor is on the annotation sub-line (not the diff line)
+	cursorOnAnnotation bool              // true when cursor is on an annotation sub-line (point or range)
 	annotateInput      textinput.Model   // text input for annotations
 
 	collapsed collapsedState // collapsed diff view state
@@ -119,6 +119,13 @@ type Model struct {
 	pendingAnnotJump *annotation.Annotation  // pending jump target after cross-file annotation list jump
 
 	mdTOC *mdTOC // markdown table-of-contents for single-file full-context markdown mode (nil when not applicable)
+
+	selecting      bool // true when visual range selection is active
+	selectAnchor   int  // diffLines index where selection started
+	rangeStartLine int  // start line number for in-progress range annotation
+	rangeEndLine   int  // end line number for in-progress range annotation
+	rangeStartIdx  int  // start diffLines index for in-progress range annotation
+	rangeEndIdx    int  // end diffLines index for in-progress range annotation
 }
 
 // fileLoadedMsg is sent when a file's diff has been loaded.
@@ -641,6 +648,13 @@ func (m Model) handleDiffNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case keymap.ActionSearch:
 		cmd := m.startSearch()
 		return m, cmd
+	case keymap.ActionSelectRange:
+		m.startSelection()
+		return m, nil
+	case keymap.ActionAnnotateHunk:
+		cmd := m.annotateHunk()
+		m.viewport.SetContent(m.renderDiff())
+		return m, cmd
 	default: // actions handled by handleKey (quit, toggle_pane, filter, etc.) — not repeated here
 	}
 	m.syncTOCActiveSection()
@@ -761,6 +775,8 @@ func (m Model) handleFileLoaded(msg fileLoadedMsg) (tea.Model, tea.Cmd) {
 		m.lineNumWidth = m.computeLineNumWidth()
 	}
 	m.cursorOnAnnotation = false
+	m.selecting = false
+	m.selectAnchor = 0
 	m.scrollX = 0
 	m.collapsed.expandedHunks = make(map[int]bool)
 
@@ -1011,6 +1027,13 @@ func (m Model) statusBarText() string {
 	// line number position
 	if ls := m.lineNumberSegment(); ls != "" {
 		segments = append(segments, ls)
+	}
+
+	// selection info
+	if m.selecting {
+		start, end := m.selectionBounds()
+		lines := end - start + 1
+		segments = append(segments, fmt.Sprintf("SEL: %d lines", lines))
 	}
 
 	// search match position
@@ -1464,6 +1487,12 @@ func (m Model) handleFileAnnotateKey() (tea.Model, tea.Cmd) {
 
 // handleEscKey clears active search results on esc.
 func (m Model) handleEscKey() (tea.Model, tea.Cmd) {
+	if m.selecting {
+		m.selecting = false
+		m.selectAnchor = 0
+		m.viewport.SetContent(m.renderDiff())
+		return m, nil
+	}
 	if len(m.searchMatches) > 0 {
 		m.clearSearch()
 		m.viewport.SetContent(m.renderDiff())
@@ -1490,10 +1519,27 @@ func (m Model) handleEnterKey() (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case paneDiff:
+		if m.selecting {
+			cmd := m.confirmSelection()
+			m.viewport.SetContent(m.renderDiff())
+			return m, cmd
+		}
 		var cmd tea.Cmd
-		if m.cursorOnFileAnnotationLine() {
+		switch {
+		case m.cursorOnFileAnnotationLine():
 			cmd = m.startFileAnnotation()
-		} else {
+		case m.cursorOnAnnotation:
+			dl, ok := m.cursorDiffLine()
+			if ok && m.store.Has(m.currFile, m.diffLineNum(dl), string(dl.ChangeType)) {
+				cmd = m.startAnnotation()
+				break
+			}
+			if m.isRangeAnnotationEnd(m.diffCursor) {
+				cmd = m.editRangeAnnotation()
+				break
+			}
+			cmd = m.startAnnotation()
+		default:
 			cmd = m.startAnnotation()
 		}
 		m.viewport.SetContent(m.renderDiff())

--- a/ui/model.go
+++ b/ui/model.go
@@ -81,7 +81,8 @@ type Model struct {
 	ready              bool              // true after first WindowSizeMsg
 	annotating         bool              // true when annotation text input is active
 	fileAnnotating     bool              // true when annotating at file level (Line=0)
-	cursorOnAnnotation bool              // true when cursor is on an annotation sub-line (point or range)
+	cursorOnAnnotation      bool // true when cursor is on an annotation sub-line (point or range)
+	cursorOnRangeAnnotation bool // true when cursor is specifically on a range-end annotation sub-row
 	annotateInput      textinput.Model   // text input for annotations
 
 	collapsed collapsedState // collapsed diff view state
@@ -106,6 +107,8 @@ type Model struct {
 	searchCursor   int             // current position in searchMatches (0-based)
 	searchInput    textinput.Model // dedicated textinput for search
 	searchMatchSet map[int]bool    // set of diffLines indices that match search, computed per render
+
+	statusFlash string // transient status bar message, cleared on next key event
 
 	discarded        bool // true when user chose to discard annotations and quit
 	inConfirmDiscard bool // true when showing discard confirmation prompt
@@ -490,6 +493,7 @@ func (m *Model) syncDiffToTOCCursor() {
 	}
 	m.diffCursor = m.mdTOC.entries[m.mdTOC.cursor].lineIdx
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	m.mdTOC.updateActiveSection(m.diffCursor)
 	m.topAlignViewportOnCursor()
 }
@@ -775,8 +779,14 @@ func (m Model) handleFileLoaded(msg fileLoadedMsg) (tea.Model, tea.Cmd) {
 		m.lineNumWidth = m.computeLineNumWidth()
 	}
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	m.selecting = false
 	m.selectAnchor = 0
+	m.rangeStartLine = 0
+	m.rangeEndLine = 0
+	m.rangeStartIdx = 0
+	m.rangeEndIdx = 0
+	m.statusFlash = ""
 	m.scrollX = 0
 	m.collapsed.expandedHunks = make(map[int]bool)
 
@@ -1008,6 +1018,9 @@ func (m Model) statusBarText() string {
 	}
 
 	if m.annotating {
+		if m.statusFlash != "" {
+			return m.statusFlash
+		}
 		return "[enter] save  [esc] cancel"
 	}
 
@@ -1509,6 +1522,7 @@ func (m Model) handleEnterKey() (tea.Model, tea.Cmd) {
 			entry := m.mdTOC.entries[m.mdTOC.cursor]
 			m.diffCursor = entry.lineIdx
 			m.cursorOnAnnotation = false
+			m.cursorOnRangeAnnotation = false
 			m.mdTOC.updateActiveSection(m.diffCursor)
 			m.focus = paneDiff
 			m.topAlignViewportOnCursor()
@@ -1529,16 +1543,11 @@ func (m Model) handleEnterKey() (tea.Model, tea.Cmd) {
 		case m.cursorOnFileAnnotationLine():
 			cmd = m.startFileAnnotation()
 		case m.cursorOnAnnotation:
-			dl, ok := m.cursorDiffLine()
-			if ok && m.store.Has(m.currFile, m.diffLineNum(dl), string(dl.ChangeType)) {
-				cmd = m.startAnnotation()
-				break
-			}
-			if m.isRangeAnnotationEnd(m.diffCursor) {
+			if m.cursorOnRangeAnnotation {
 				cmd = m.editRangeAnnotation()
-				break
+			} else {
+				cmd = m.startAnnotation()
 			}
-			cmd = m.startAnnotation()
 		default:
 			cmd = m.startAnnotation()
 		}

--- a/ui/model.go
+++ b/ui/model.go
@@ -1239,6 +1239,7 @@ func (m Model) statusModeIcons() string {
 		{"⊟", m.treeHidden},
 		{"#", m.lineNumbers},
 		{"b", m.showBlame},
+		{"▋", m.selecting},
 	}
 
 	statusFg := m.styles.colors.Muted

--- a/ui/model_test.go
+++ b/ui/model_test.go
@@ -478,7 +478,6 @@ func TestModel_BlameFromConfig(t *testing.T) {
 	})
 }
 
-
 func TestModel_StatusModeIcons(t *testing.T) {
 	t.Run("all icons always present", func(t *testing.T) {
 		m := testModel(nil, nil)
@@ -2793,7 +2792,7 @@ func TestModel_CursorViewportYWithWrappedAnnotation(t *testing.T) {
 	t.Run("long file annotation wraps to multiple rows", func(t *testing.T) {
 		longComment := strings.Repeat("word ", 20) // ~100 chars, wraps at ~34
 		m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: longComment})
-		defer m.store.Delete("a.go", 0, "")
+		defer m.store.Delete("a.go", 0, 0, "")
 
 		wrapCount := m.wrappedAnnotationLineCount("file")
 		assert.Greater(t, wrapCount, 1, "long file annotation should wrap to multiple rows")
@@ -2808,7 +2807,7 @@ func TestModel_CursorViewportYWithWrappedAnnotation(t *testing.T) {
 	t.Run("long inline annotation wraps to multiple rows", func(t *testing.T) {
 		longComment := strings.Repeat("note ", 20) // ~100 chars
 		m.store.Add(annotation.Annotation{File: "a.go", Line: 1, Type: " ", Comment: longComment})
-		defer m.store.Delete("a.go", 1, " ")
+		defer m.store.Delete("a.go", 1, 0, " ")
 
 		key := m.annotationKey(1, " ")
 		wrapCount := m.wrappedAnnotationLineCount(key)
@@ -2820,7 +2819,7 @@ func TestModel_CursorViewportYWithWrappedAnnotation(t *testing.T) {
 
 	t.Run("short annotation stays one row", func(t *testing.T) {
 		m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: "short"})
-		defer m.store.Delete("a.go", 0, "")
+		defer m.store.Delete("a.go", 0, 0, "")
 
 		assert.Equal(t, 1, m.wrappedAnnotationLineCount("file"))
 	})
@@ -2837,7 +2836,7 @@ func TestModel_RenderWrappedAnnotation(t *testing.T) {
 	t.Run("long file annotation wraps in rendered output", func(t *testing.T) {
 		longComment := strings.Repeat("wrap ", 20)
 		m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: longComment})
-		defer m.store.Delete("a.go", 0, "")
+		defer m.store.Delete("a.go", 0, 0, "")
 
 		wrapCount := m.wrappedAnnotationLineCount("file")
 		assert.Greater(t, wrapCount, 1, "annotation should wrap")
@@ -4128,7 +4127,7 @@ func TestModel_RenderDiffLineWithWrap(t *testing.T) {
 	t.Run("short line no continuation", func(t *testing.T) {
 		var b strings.Builder
 		dl := diff.DiffLine{Content: "short", ChangeType: diff.ChangeAdd, NewNum: 1}
-		m.renderDiffLine(&b, 0, dl)
+		m.renderDiffLine(&b, 0, dl, nil)
 		output := b.String()
 		assert.Contains(t, output, " + short")
 		assert.NotContains(t, output, "↪", "short line should not have continuation")
@@ -4139,7 +4138,7 @@ func TestModel_RenderDiffLineWithWrap(t *testing.T) {
 		var b strings.Builder
 		longContent := "this is a very long line that should definitely be wrapped at word boundaries to fit the viewport"
 		dl := diff.DiffLine{Content: longContent, ChangeType: diff.ChangeAdd, NewNum: 1}
-		m.renderDiffLine(&b, 0, dl)
+		m.renderDiffLine(&b, 0, dl, nil)
 		output := b.String()
 
 		lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
@@ -4158,7 +4157,7 @@ func TestModel_RenderDiffLineWithWrap(t *testing.T) {
 		var b strings.Builder
 		longContent := "this is a removed line that is very long and should be wrapped at word boundaries to fit the viewport width"
 		dl := diff.DiffLine{Content: longContent, ChangeType: diff.ChangeRemove, OldNum: 5}
-		m.renderDiffLine(&b, 0, dl)
+		m.renderDiffLine(&b, 0, dl, nil)
 		output := b.String()
 
 		lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
@@ -4173,7 +4172,7 @@ func TestModel_RenderDiffLineWithWrap(t *testing.T) {
 		var b strings.Builder
 		longContent := "this is a context line that is very long and should be wrapped at word boundaries for readability"
 		dl := diff.DiffLine{Content: longContent, ChangeType: diff.ChangeContext, NewNum: 10}
-		m.renderDiffLine(&b, 0, dl)
+		m.renderDiffLine(&b, 0, dl, nil)
 		output := b.String()
 
 		lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
@@ -4186,7 +4185,7 @@ func TestModel_RenderDiffLineWithWrap(t *testing.T) {
 	t.Run("divider lines are not wrapped", func(t *testing.T) {
 		var b strings.Builder
 		dl := diff.DiffLine{Content: "@@ -1,5 +1,7 @@", ChangeType: diff.ChangeDivider}
-		m.renderDiffLine(&b, 0, dl)
+		m.renderDiffLine(&b, 0, dl, nil)
 		output := b.String()
 		assert.NotContains(t, output, "↪", "dividers should not be wrapped")
 		assert.Equal(t, 1, strings.Count(output, "\n"), "divider should be a single line")
@@ -4200,7 +4199,7 @@ func TestModel_RenderDiffLineWithWrap(t *testing.T) {
 		var b strings.Builder
 		longContent := "this is a very long line that should definitely be wrapped at word boundaries to test cursor placement"
 		dl := diff.DiffLine{Content: longContent, ChangeType: diff.ChangeAdd, NewNum: 1}
-		m.renderDiffLine(&b, 0, dl)
+		m.renderDiffLine(&b, 0, dl, nil)
 		output := b.String()
 
 		lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
@@ -4217,7 +4216,7 @@ func TestModel_RenderDiffLineWithWrap(t *testing.T) {
 
 		var b strings.Builder
 		dl := diff.DiffLine{Content: "@@ -1,3 +1,3 @@", ChangeType: diff.ChangeDivider}
-		m.renderDiffLine(&b, 0, dl)
+		m.renderDiffLine(&b, 0, dl, nil)
 
 		// divider falls through to non-wrap path but ansi.Cut should be skipped
 		output := b.String()
@@ -4353,7 +4352,7 @@ func TestModel_CursorViewportYWithWrap(t *testing.T) {
 	t.Run("cursor on annotation after wrapped line", func(t *testing.T) {
 		// add annotation on line 2 (idx 1, the long wrapped add line)
 		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, Type: "+", Comment: "note"})
-		defer func() { m.store.Delete("a.go", 2, "+") }()
+		defer func() { m.store.Delete("a.go", 2, 0, "+") }()
 
 		m.diffCursor = 2
 		m.cursorOnAnnotation = false
@@ -4363,7 +4362,7 @@ func TestModel_CursorViewportYWithWrap(t *testing.T) {
 
 	t.Run("cursor on annotation sub-line of wrapped line", func(t *testing.T) {
 		m.store.Add(annotation.Annotation{File: "a.go", Line: 3, Type: " ", Comment: "note on ctx"})
-		defer func() { m.store.Delete("a.go", 3, " ") }()
+		defer func() { m.store.Delete("a.go", 3, 0, " ") }()
 
 		m.diffCursor = 2
 		m.cursorOnAnnotation = true
@@ -5760,7 +5759,7 @@ func TestModel_DeletePlaceholderSearchHighlight(t *testing.T) {
 	t.Run("with search match", func(t *testing.T) {
 		model.searchMatchSet = map[int]bool{1: true}
 		var b strings.Builder
-		model.renderDeletePlaceholder(&b, 1, 1)
+		model.renderDeletePlaceholder(&b, 1, 1, nil)
 		rendered := b.String()
 		assert.Contains(t, rendered, "2 lines deleted")
 		assert.Contains(t, rendered, "▶", "cursor indicator should be present")
@@ -5769,7 +5768,7 @@ func TestModel_DeletePlaceholderSearchHighlight(t *testing.T) {
 	t.Run("without search match", func(t *testing.T) {
 		model.searchMatchSet = nil
 		var b strings.Builder
-		model.renderDeletePlaceholder(&b, 1, 1)
+		model.renderDeletePlaceholder(&b, 1, 1, nil)
 		rendered := b.String()
 		assert.Contains(t, rendered, "2 lines deleted")
 		assert.Contains(t, rendered, "▶")
@@ -5781,7 +5780,7 @@ func TestModel_DeletePlaceholderSearchHighlight(t *testing.T) {
 		model.width = 120
 		model.treeWidth = 30
 		var b strings.Builder
-		model.renderDeletePlaceholder(&b, 1, 1)
+		model.renderDeletePlaceholder(&b, 1, 1, nil)
 		rendered := b.String()
 		assert.Contains(t, rendered, "2 lines deleted")
 		model.wrapMode = false
@@ -7228,4 +7227,478 @@ func TestModel_AcceptanceDefaultBehaviorNoKeybindingsFile(t *testing.T) {
 	result, _ := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
 	model := result.(Model)
 	assert.True(t, model.showHelp, "? should open help with default keymap")
+}
+
+func TestModel_SelectionMode(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeContext},
+	}
+	m.diffCursor = 1
+
+	t.Run("start selection", func(t *testing.T) {
+		m.startSelection()
+		assert.True(t, m.selecting)
+		assert.Equal(t, 1, m.selectAnchor)
+		assert.False(t, m.cursorOnAnnotation)
+	})
+
+	t.Run("selection bounds", func(t *testing.T) {
+		m.selecting = true
+		m.selectAnchor = 0
+		m.diffCursor = 2
+		start, end := m.selectionBounds()
+		assert.Equal(t, 0, start)
+		assert.Equal(t, 2, end)
+
+		// reversed anchor/cursor
+		m.selectAnchor = 2
+		m.diffCursor = 0
+		start, end = m.selectionBounds()
+		assert.Equal(t, 0, start)
+		assert.Equal(t, 2, end)
+	})
+
+	t.Run("esc clears selection", func(t *testing.T) {
+		m.selecting = true
+		m.selectAnchor = 1
+		result, _ := m.handleEscKey()
+		m2 := result.(Model)
+		assert.False(t, m2.selecting)
+		assert.Equal(t, 0, m2.selectAnchor)
+	})
+
+	t.Run("selection guards", func(t *testing.T) {
+		m.selecting = false
+		m.focus = paneTree
+		m.startSelection()
+		assert.False(t, m.selecting, "should not start selection outside diff pane")
+
+		m.focus = paneDiff
+		m.annotating = true
+		m.startSelection()
+		assert.False(t, m.selecting, "should not start selection while annotating")
+		m.annotating = false
+
+		m.diffCursor = -1
+		m.startSelection()
+		assert.False(t, m.selecting, "should not start selection with invalid cursor")
+	})
+}
+
+func TestModel_RangeAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeContext},
+	}
+
+	t.Run("single-line selection collapses to point", func(t *testing.T) {
+		m.selecting = true
+		m.selectAnchor = 1
+		m.diffCursor = 1
+		cmd := m.confirmSelection()
+		assert.False(t, m.selecting)
+		// should start a normal annotation (annotating=true, rangeStartLine=0)
+		assert.True(t, m.annotating)
+		assert.Equal(t, 0, m.rangeStartLine)
+		m.cancelAnnotation()
+		_ = cmd
+	})
+
+	t.Run("multi-line selection creates range annotation", func(t *testing.T) {
+		m.selecting = true
+		m.selectAnchor = 1
+		m.diffCursor = 2
+		cmd := m.confirmSelection()
+		assert.True(t, m.annotating)
+		assert.Equal(t, 2, m.rangeStartLine)
+		assert.Equal(t, 3, m.rangeEndLine)
+		assert.Equal(t, 1, m.rangeStartIdx)
+		assert.Equal(t, 2, m.rangeEndIdx)
+		_ = cmd
+
+		// simulate typing and saving
+		m.annotateInput.SetValue("range comment")
+		m.saveRangeAnnotation()
+		assert.False(t, m.annotating)
+		assert.False(t, m.selecting)
+
+		// verify the annotation was saved
+		anns := m.store.Get("a.go")
+		require.Len(t, anns, 1)
+		assert.Equal(t, 2, anns[0].Line)
+		assert.Equal(t, 3, anns[0].EndLine)
+		assert.Empty(t, anns[0].Type)
+		assert.Equal(t, "range comment", anns[0].Comment)
+	})
+
+	t.Run("pre-fill existing range annotation", func(t *testing.T) {
+		// range from previous test already exists
+		m.selecting = true
+		m.selectAnchor = 1
+		m.diffCursor = 2
+		m.confirmSelection()
+		assert.Equal(t, "range comment", m.annotateInput.Value())
+		m.cancelAnnotation()
+	})
+}
+
+func TestModel_RangeAnnotationRendering(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeAdd},
+		{NewNum: 5, Content: "line5", ChangeType: diff.ChangeContext},
+	}
+
+	t.Run("buildRangeAnnotations maps to indices", func(t *testing.T) {
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 4, Type: "", Comment: "range"})
+		defer m.store.Delete("a.go", 2, 4, "")
+
+		ranges := m.buildRangeAnnotations()
+		require.Len(t, ranges, 1)
+		assert.Equal(t, 1, ranges[0].startIdx) // idx 1 = NewNum 2
+		assert.Equal(t, 3, ranges[0].endIdx)   // idx 3 = NewNum 4
+		assert.Equal(t, "range", ranges[0].comment)
+	})
+
+	t.Run("buildRangeAnnotations keeps replacement hunks as ranges", func(t *testing.T) {
+		m2 := testModel(nil, nil)
+		m2.currFile = "a.go"
+		m2.focus = paneDiff
+		m2.diffLines = []diff.DiffLine{
+			{NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},
+			{OldNum: 10, Content: "old", ChangeType: diff.ChangeRemove},
+			{NewNum: 10, Content: "new", ChangeType: diff.ChangeAdd},
+			{NewNum: 11, Content: "ctx", ChangeType: diff.ChangeContext},
+		}
+		m2.store.Add(annotation.Annotation{File: "a.go", Line: 10, EndLine: 10, Type: "", Comment: "replacement"})
+		defer m2.store.Delete("a.go", 10, 10, "")
+
+		ranges := m2.buildRangeAnnotations()
+		require.Len(t, ranges, 1)
+		assert.Equal(t, 1, ranges[0].startIdx)
+		assert.Equal(t, 2, ranges[0].endIdx)
+		assert.Equal(t, 10, ranges[0].startLine)
+		assert.Equal(t, 10, ranges[0].endLine)
+
+		output := m2.renderDiff()
+		assert.Contains(t, output, "replacement")
+		assert.Contains(t, output, "[lines 10-10]", "replacement range should still render as a range")
+	})
+
+	t.Run("buildRangeAnnotations stops before a later hunk reuses the same line number", func(t *testing.T) {
+		m2 := testModel(nil, nil)
+		m2.currFile = "a.go"
+		m2.focus = paneDiff
+		m2.diffLines = []diff.DiffLine{
+			{NewNum: 17, Content: "ctx", ChangeType: diff.ChangeContext},
+			{OldNum: 18, Content: "old18", ChangeType: diff.ChangeRemove},
+			{NewNum: 18, Content: "new18", ChangeType: diff.ChangeAdd},
+			{NewNum: 19, Content: "new19", ChangeType: diff.ChangeAdd},
+			{NewNum: 20, Content: "new20", ChangeType: diff.ChangeAdd},
+			{NewNum: 21, Content: "ctx", ChangeType: diff.ChangeContext},
+			{OldNum: 20, Content: "old20-later", ChangeType: diff.ChangeRemove},
+			{NewNum: 22, Content: "new22", ChangeType: diff.ChangeAdd},
+		}
+		m2.store.Add(annotation.Annotation{File: "a.go", Line: 18, EndLine: 20, Type: "", Comment: "range"})
+		defer m2.store.Delete("a.go", 18, 20, "")
+
+		ranges := m2.buildRangeAnnotations()
+		require.Len(t, ranges, 1)
+		assert.Equal(t, 1, ranges[0].startIdx)
+		assert.Equal(t, 4, ranges[0].endIdx)
+	})
+
+	t.Run("rangeGutterFor returns correct indicators", func(t *testing.T) {
+		ranges := []rangeRenderInfo{{startIdx: 1, endIdx: 3, comment: "test"}}
+		assert.Empty(t, rangeGutterFor(0, ranges))
+		assert.Equal(t, "┌ ", rangeGutterFor(1, ranges))
+		assert.Equal(t, "│ ", rangeGutterFor(2, ranges))
+		assert.Equal(t, "└ ", rangeGutterFor(3, ranges))
+		assert.Empty(t, rangeGutterFor(4, ranges))
+	})
+
+	t.Run("rendered diff contains range gutter", func(t *testing.T) {
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 4, Type: "", Comment: "range note"})
+		defer m.store.Delete("a.go", 2, 4, "")
+
+		output := m.renderDiff()
+		assert.Contains(t, output, "┌")
+		assert.Contains(t, output, "│")
+		assert.Contains(t, output, "└")
+		assert.Contains(t, output, "range note")
+	})
+
+	t.Run("cursorViewportY accounts for range annotation rows", func(t *testing.T) {
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 4, Type: "", Comment: "range"})
+		defer m.store.Delete("a.go", 2, 4, "")
+
+		// cursor after range end should account for the range annotation row
+		m.diffCursor = 4 // idx 4 = NewNum 5 (after range)
+		m.cursorOnAnnotation = false
+		yWithRange := m.cursorViewportY()
+
+		m.store.Delete("a.go", 2, 4, "")
+		m.diffCursor = 4
+		yWithoutRange := m.cursorViewportY()
+
+		assert.Greater(t, yWithRange, yWithoutRange, "range annotation row should add to viewport Y offset")
+	})
+}
+
+func TestModel_AnnotateHunk(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "context", ChangeType: diff.ChangeContext},
+		{OldNum: 2, Content: "removed", ChangeType: diff.ChangeRemove},
+		{NewNum: 2, Content: "added1", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "added2", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "context", ChangeType: diff.ChangeContext},
+	}
+
+	t.Run("hunk annotation on changed line", func(t *testing.T) {
+		m.diffCursor = 2 // on an add line inside the hunk
+		cmd := m.annotateHunk()
+		assert.True(t, m.annotating)
+		assert.Equal(t, 2, m.rangeStartLine) // hunk starts at OldNum=2 (remove)
+		assert.Equal(t, 3, m.rangeEndLine)   // hunk ends at NewNum=3 (add)
+		assert.Equal(t, 1, m.rangeStartIdx)
+		assert.Equal(t, 3, m.rangeEndIdx)
+		m.cancelAnnotation()
+		_ = cmd
+	})
+
+	t.Run("no-op on context line", func(t *testing.T) {
+		m.diffCursor = 0 // on context line
+		cmd := m.annotateHunk()
+		assert.Nil(t, cmd)
+		assert.False(t, m.annotating)
+	})
+
+	t.Run("hunkEndFor finds correct end", func(t *testing.T) {
+		// hunk starts at idx 1 (remove), ends at idx 3 (add)
+		end := m.hunkEndFor(1)
+		assert.Equal(t, 3, end)
+
+		// single line
+		m2 := testModel(nil, nil)
+		m2.diffLines = []diff.DiffLine{
+			{NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},
+			{NewNum: 2, Content: "add", ChangeType: diff.ChangeAdd},
+			{NewNum: 3, Content: "ctx", ChangeType: diff.ChangeContext},
+		}
+		end = m2.hunkEndFor(1)
+		assert.Equal(t, 1, end)
+	})
+}
+
+func TestModel_StatusBarSelection(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+	}
+	m.selecting = true
+	m.selectAnchor = 0
+	m.diffCursor = 2
+
+	text := m.statusBarText()
+	assert.Contains(t, text, "SEL: 3 lines")
+}
+
+func TestModel_DeleteRangeAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeContext},
+	}
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 3, Type: "", Comment: "range"})
+
+	m.diffCursor = 1 // on line NewNum=2, inside range
+	m.cursorOnAnnotation = true
+
+	m.deleteAnnotation()
+
+	// range should be deleted
+	assert.False(t, m.store.HasRangeCovering("a.go", 2))
+	assert.Equal(t, 0, m.store.Count())
+}
+
+func TestModel_DeletePointBeforeCoveringRange(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeContext},
+	}
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 3, Type: "", Comment: "range"})
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, Type: "+", Comment: "point"})
+
+	m.diffCursor = 1
+	m.cursorOnAnnotation = true
+
+	m.deleteAnnotation()
+
+	assert.False(t, m.store.Has("a.go", 2, "+"))
+	assert.True(t, m.store.HasRangeCovering("a.go", 2))
+}
+
+func TestModel_LiveSelectionGutter(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeContext},
+	}
+
+	t.Run("selection gutter shows during selection", func(t *testing.T) {
+		m.selecting = true
+		m.selectAnchor = 1
+		m.diffCursor = 2
+		output := m.renderDiff()
+		assert.Contains(t, output, "┌")
+		assert.Contains(t, output, "└")
+	})
+
+	t.Run("no gutter when not selecting", func(t *testing.T) {
+		m.selecting = false
+		output := m.renderDiff()
+		assert.NotContains(t, output, "┌")
+		assert.NotContains(t, output, "└")
+	})
+
+	t.Run("single-line selection has no gutter", func(t *testing.T) {
+		m.selecting = true
+		m.selectAnchor = 1
+		m.diffCursor = 1
+		output := m.renderDiff()
+		assert.NotContains(t, output, "┌")
+		assert.NotContains(t, output, "└")
+	})
+}
+
+func TestModel_CursorStopsOnRangeAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeContext},
+	}
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 3, Type: "", Comment: "range note"})
+
+	t.Run("moving down stops on range annotation below end line", func(t *testing.T) {
+		m.diffCursor = 1
+		m.cursorOnAnnotation = false
+
+		// move to range end line (idx=2, NewNum=3)
+		m.moveDiffCursorDown()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.False(t, m.cursorOnAnnotation)
+
+		// next down: stop on range annotation below end line
+		m.moveDiffCursorDown()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.True(t, m.cursorOnAnnotation)
+
+		// next down: move to next line
+		m.moveDiffCursorDown()
+		assert.Equal(t, 3, m.diffCursor)
+		assert.False(t, m.cursorOnAnnotation)
+	})
+
+	t.Run("moving up stops on range annotation below end line", func(t *testing.T) {
+		m.diffCursor = 3
+		m.cursorOnAnnotation = false
+
+		// up from line after range → land on annotation below range end
+		m.moveDiffCursorUp()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.True(t, m.cursorOnAnnotation)
+
+		// up again → land on the diff line itself
+		m.moveDiffCursorUp()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.False(t, m.cursorOnAnnotation)
+	})
+
+	t.Run("delete on range annotation", func(t *testing.T) {
+		m.diffCursor = 2 // range end line
+		m.cursorOnAnnotation = true
+		m.deleteAnnotation()
+		assert.Equal(t, 0, m.store.Count())
+		assert.False(t, m.cursorOnAnnotation)
+	})
+
+	t.Run("enter on range annotation opens edit", func(t *testing.T) {
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 3, Type: "", Comment: "edit me"})
+		m.diffCursor = 2 // range end line
+		m.cursorOnAnnotation = true
+
+		result, _ := m.handleEnterKey()
+		m2 := result.(Model)
+		assert.True(t, m2.annotating)
+		assert.Equal(t, 2, m2.rangeStartLine)
+		assert.Equal(t, 3, m2.rangeEndLine)
+		assert.Equal(t, "edit me", m2.annotateInput.Value())
+		m2.cancelAnnotation()
+	})
+}
+
+func TestModel_AnnotateHunkKeepsLiveRangeToOriginalHunk(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 17, Content: "ctx", ChangeType: diff.ChangeContext},
+		{OldNum: 18, Content: "old18", ChangeType: diff.ChangeRemove},
+		{NewNum: 18, Content: "new18", ChangeType: diff.ChangeAdd},
+		{NewNum: 19, Content: "new19", ChangeType: diff.ChangeAdd},
+		{NewNum: 20, Content: "new20", ChangeType: diff.ChangeAdd},
+		{NewNum: 21, Content: "ctx", ChangeType: diff.ChangeContext},
+		{OldNum: 20, Content: "old20-later", ChangeType: diff.ChangeRemove},
+		{NewNum: 22, Content: "new22", ChangeType: diff.ChangeAdd},
+	}
+
+	m.diffCursor = 2
+	m.annotateHunk()
+
+	ranges := m.appendSelectionRange(nil)
+	require.Len(t, ranges, 1)
+	assert.Equal(t, 1, ranges[0].startIdx)
+	assert.Equal(t, 4, ranges[0].endIdx)
+
+	rendered := m.renderDiff()
+	assert.Contains(t, rendered, "[lines 18-20]")
 }

--- a/ui/model_test.go
+++ b/ui/model_test.go
@@ -7656,6 +7656,7 @@ func TestModel_CursorStopsOnRangeAnnotation(t *testing.T) {
 	t.Run("delete on range annotation", func(t *testing.T) {
 		m.diffCursor = 2 // range end line
 		m.cursorOnAnnotation = true
+		m.cursorOnRangeAnnotation = true
 		m.deleteAnnotation()
 		assert.Equal(t, 0, m.store.Count())
 		assert.False(t, m.cursorOnAnnotation)
@@ -7665,6 +7666,7 @@ func TestModel_CursorStopsOnRangeAnnotation(t *testing.T) {
 		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 3, Type: "", Comment: "edit me"})
 		m.diffCursor = 2 // range end line
 		m.cursorOnAnnotation = true
+		m.cursorOnRangeAnnotation = true
 
 		result, _ := m.handleEnterKey()
 		m2 := result.(Model)
@@ -7701,4 +7703,253 @@ func TestModel_AnnotateHunkKeepsLiveRangeToOriginalHunk(t *testing.T) {
 
 	rendered := m.renderDiff()
 	assert.Contains(t, rendered, "[lines 18-20]")
+}
+
+func TestModel_AnnotateHunkSameLineReplacement(t *testing.T) {
+	// P1: replacement hunk where removed and added lines share the same line number
+	// should produce a range annotation, not fall back to a point annotation.
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{OldNum: 9, NewNum: 9, Content: "ctx", ChangeType: diff.ChangeContext},
+		{OldNum: 10, Content: "old10", ChangeType: diff.ChangeRemove},
+		{NewNum: 10, Content: "new10", ChangeType: diff.ChangeAdd},
+		{OldNum: 11, NewNum: 11, Content: "ctx", ChangeType: diff.ChangeContext},
+	}
+
+	m.diffCursor = 1 // on the remove line
+	cmd := m.annotateHunk()
+	assert.NotNil(t, cmd)
+	assert.True(t, m.annotating)
+	assert.Equal(t, 10, m.rangeStartLine)
+	assert.Equal(t, 10, m.rangeEndLine)
+	assert.Equal(t, 1, m.rangeStartIdx)
+	assert.Equal(t, 2, m.rangeEndIdx)
+}
+
+func TestModel_AnnotateHunkSingleDiffLine(t *testing.T) {
+	// single diff line hunk should still produce a point annotation (not range)
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{OldNum: 1, NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "added", ChangeType: diff.ChangeAdd},
+		{OldNum: 2, NewNum: 3, Content: "ctx", ChangeType: diff.ChangeContext},
+	}
+
+	m.diffCursor = 1
+	cmd := m.annotateHunk()
+	assert.NotNil(t, cmd)
+	assert.True(t, m.annotating)
+	// single diff line → point annotation, not range
+	assert.Equal(t, 0, m.rangeStartLine)
+	assert.Equal(t, 0, m.rangeEndLine)
+}
+
+func TestModel_SaveRangeAnnotationOverlapFeedback(t *testing.T) {
+	// P2: overlapping range annotation should keep input open and set statusFlash
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeAdd},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeAdd},
+	}
+
+	// save an existing range 1-2
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 1, EndLine: 2, Comment: "existing"})
+
+	// start a range annotation that overlaps (lines 2-3)
+	m.rangeStartLine = 2
+	m.rangeEndLine = 3
+	m.rangeStartIdx = 1
+	m.rangeEndIdx = 2
+	m.annotating = true
+	ti := textinput.New()
+	ti.SetValue("overlapping comment")
+	m.annotateInput = ti
+
+	m.saveRangeAnnotation()
+
+	// annotation mode should remain active — input not discarded
+	assert.True(t, m.annotating)
+	assert.NotEmpty(t, m.statusFlash)
+	assert.Contains(t, m.statusFlash, "overlap")
+
+	// store should still have only the original annotation
+	assert.Equal(t, 1, m.store.Count())
+
+	// status bar should show the flash message
+	status := m.statusBarText()
+	assert.Contains(t, status, "overlap")
+
+	// typing clears the flash
+	result, _ := m.handleAnnotateKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m2 := result.(Model)
+	assert.Empty(t, m2.statusFlash)
+}
+
+func TestModel_HandleFileLoadedResetsRangeState(t *testing.T) {
+	// handleFileLoaded should clear range annotation state from previous file
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.rangeStartLine = 5
+	m.rangeEndLine = 10
+	m.rangeStartIdx = 2
+	m.rangeEndIdx = 7
+	m.statusFlash = "old flash"
+	m.selecting = true
+	m.selectAnchor = 3
+
+	msg := fileLoadedMsg{
+		file:  "b.go",
+		seq:   m.loadSeq,
+		lines: []diff.DiffLine{{NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext}},
+	}
+	result, _ := m.handleFileLoaded(msg)
+	m2 := result.(Model)
+
+	assert.Equal(t, 0, m2.rangeStartLine)
+	assert.Equal(t, 0, m2.rangeEndLine)
+	assert.Equal(t, 0, m2.rangeStartIdx)
+	assert.Equal(t, 0, m2.rangeEndIdx)
+	assert.Empty(t, m2.statusFlash)
+	assert.False(t, m2.selecting)
+}
+
+func TestModel_VisibleRangeIndicesStopsAtHunkDivider(t *testing.T) {
+	// A range on removed lines in the first hunk should NOT extend into the
+	// next hunk even if that hunk's context lines have matching NewNum values.
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		// hunk 1: removes lines 100-101
+		{OldNum: 99, NewNum: 99, Content: "ctx", ChangeType: diff.ChangeContext},
+		{OldNum: 100, Content: "rm100", ChangeType: diff.ChangeRemove},
+		{OldNum: 101, Content: "rm101", ChangeType: diff.ChangeRemove},
+		// divider between hunks
+		{ChangeType: diff.ChangeDivider},
+		// hunk 2: context lines with NewNum 100, 101 (same numbers as the range)
+		{OldNum: 200, NewNum: 100, Content: "ctx100", ChangeType: diff.ChangeContext},
+		{OldNum: 201, NewNum: 101, Content: "ctx101", ChangeType: diff.ChangeContext},
+	}
+
+	startIdx, endIdx := m.visibleRangeIndices(100, 101)
+	// should map to hunk 1 removes only (indices 1-2), not leak into hunk 2 (indices 4-5)
+	assert.Equal(t, 1, startIdx)
+	assert.Equal(t, 2, endIdx)
+}
+
+func TestModel_CursorNavigatesPointAndRangeOnSameLine(t *testing.T) {
+	m := testModel(nil, nil)
+	m.currFile = "a.go"
+	m.focus = paneDiff
+	m.diffLines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+		{NewNum: 4, Content: "line4", ChangeType: diff.ChangeContext},
+	}
+	// point annotation on line 3 (idx 2) AND range annotation ending on line 3
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 3, Type: "+", Comment: "point note"})
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, EndLine: 3, Type: "", Comment: "range note"})
+
+	t.Run("down: stops on point then range sub-row", func(t *testing.T) {
+		m.diffCursor = 2 // on diff line at idx 2 (NewNum=3)
+		m.cursorOnAnnotation = false
+		m.cursorOnRangeAnnotation = false
+
+		// first down: land on point annotation sub-row
+		m.moveDiffCursorDown()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.True(t, m.cursorOnAnnotation)
+		assert.False(t, m.cursorOnRangeAnnotation, "first stop should be point annotation")
+
+		// second down: land on range annotation sub-row
+		m.moveDiffCursorDown()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.True(t, m.cursorOnAnnotation)
+		assert.True(t, m.cursorOnRangeAnnotation, "second stop should be range annotation")
+
+		// third down: move to next diff line
+		m.moveDiffCursorDown()
+		assert.Equal(t, 3, m.diffCursor)
+		assert.False(t, m.cursorOnAnnotation)
+		assert.False(t, m.cursorOnRangeAnnotation)
+	})
+
+	t.Run("up: stops on range then point sub-row", func(t *testing.T) {
+		m.diffCursor = 3 // on diff line at idx 3 (NewNum=4)
+		m.cursorOnAnnotation = false
+		m.cursorOnRangeAnnotation = false
+
+		// first up: land on range annotation (last sub-row when entering from below)
+		m.moveDiffCursorUp()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.True(t, m.cursorOnAnnotation)
+		assert.True(t, m.cursorOnRangeAnnotation, "entering from below should land on range sub-row first")
+
+		// second up: land on point annotation sub-row
+		m.moveDiffCursorUp()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.True(t, m.cursorOnAnnotation)
+		assert.False(t, m.cursorOnRangeAnnotation, "second stop should be point annotation")
+
+		// third up: land on diff line itself
+		m.moveDiffCursorUp()
+		assert.Equal(t, 2, m.diffCursor)
+		assert.False(t, m.cursorOnAnnotation)
+	})
+
+	t.Run("enter on point sub-row opens point annotation", func(t *testing.T) {
+		m.diffCursor = 2
+		m.cursorOnAnnotation = true
+		m.cursorOnRangeAnnotation = false
+
+		result, _ := m.handleEnterKey()
+		m2 := result.(Model)
+		assert.True(t, m2.annotating)
+		assert.Equal(t, 0, m2.rangeStartLine, "should open point, not range annotation")
+		assert.Equal(t, "point note", m2.annotateInput.Value())
+		m2.cancelAnnotation()
+	})
+
+	t.Run("enter on range sub-row opens range annotation", func(t *testing.T) {
+		m.diffCursor = 2
+		m.cursorOnAnnotation = true
+		m.cursorOnRangeAnnotation = true
+
+		result, _ := m.handleEnterKey()
+		m2 := result.(Model)
+		assert.True(t, m2.annotating)
+		assert.Equal(t, 2, m2.rangeStartLine, "should open range annotation")
+		assert.Equal(t, 3, m2.rangeEndLine)
+		assert.Equal(t, "range note", m2.annotateInput.Value())
+		m2.cancelAnnotation()
+	})
+
+	t.Run("delete on point sub-row removes point only", func(t *testing.T) {
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 3, Type: "+", Comment: "point note"})
+		m.diffCursor = 2
+		m.cursorOnAnnotation = true
+		m.cursorOnRangeAnnotation = false
+
+		m.deleteAnnotation()
+		assert.False(t, m.store.Has("a.go", 3, "+"), "point should be deleted")
+		assert.True(t, m.store.HasRangeCovering("a.go", 3), "range should still exist")
+	})
+
+	t.Run("delete on range sub-row removes range only", func(t *testing.T) {
+		m.diffCursor = 2
+		m.cursorOnAnnotation = true
+		m.cursorOnRangeAnnotation = true
+
+		m.deleteAnnotation()
+		assert.False(t, m.store.HasRangeCovering("a.go", 3), "range should be deleted")
+	})
 }

--- a/ui/search.go
+++ b/ui/search.go
@@ -56,6 +56,7 @@ func (m *Model) submitSearch() {
 		m.searchCursor = i
 		m.diffCursor = idx
 		m.cursorOnAnnotation = false
+		m.cursorOnRangeAnnotation = false
 		m.syncTOCActiveSection()
 		m.centerViewportOnCursor()
 		return
@@ -69,6 +70,7 @@ func (m *Model) submitSearch() {
 		m.searchCursor = i
 		m.diffCursor = idx
 		m.cursorOnAnnotation = false
+		m.cursorOnRangeAnnotation = false
 		m.syncTOCActiveSection()
 		m.centerViewportOnCursor()
 		return
@@ -94,6 +96,7 @@ func (m *Model) nextSearchMatch() {
 	}
 	m.diffCursor = m.searchMatches[m.searchCursor]
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	m.centerViewportOnCursor()
 }
 
@@ -119,6 +122,7 @@ func (m *Model) prevSearchMatch() {
 	}
 	m.diffCursor = m.searchMatches[m.searchCursor]
 	m.cursorOnAnnotation = false
+	m.cursorOnRangeAnnotation = false
 	m.centerViewportOnCursor()
 }
 

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -23,8 +23,8 @@ type Colors struct {
 	DiffBg     string // diff pane background
 	StatusFg   string // status bar foreground
 	StatusBg   string // status bar background
-	SearchFg   string // search match foreground
-	SearchBg   string // search match background
+	SearchFg string // search match foreground
+	SearchBg string // search match background
 }
 
 // styles holds all lipgloss styles used in the TUI.


### PR DESCRIPTION
## Summary

- **Visual range selection** (`V`) — select a span of diff lines, confirm with Enter to annotate the range
- **Hunk annotation** (`H`) — one-key annotation of the entire hunk under the cursor

## Demo

https://github.com/user-attachments/assets/4b979ab7-9cd4-4e16-8a9a-cdf2965e7456
