### PR TITLE
fix(ui): center entire hunk in viewport during hunk navigation

### DIFF
--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -327,54 +327,58 @@ func (m Model) wrappedAnnotationLineCount(key string) int {
 	return 1
 }
 
+// hunkLineHeight returns the visual row count for a single diff line,
+// including collapsed visibility, wrap, and inline annotation.
+func (m Model) hunkLineHeight(idx int, hunks []int, annotationSet map[string]bool) int {
+	if m.isCollapsedHidden(idx, hunks) {
+		return 0
+	}
+	if m.isDeleteOnlyPlaceholder(idx, hunks) {
+		return m.deletePlaceholderVisualHeight(idx)
+	}
+	h := m.wrappedLineCount(idx)
+	dl := m.diffLines[idx]
+	if dl.ChangeType != diff.ChangeDivider {
+		key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
+		if annotationSet[key] {
+			h += m.wrappedAnnotationLineCount(key)
+		}
+	}
+	return h
+}
+
 // cursorViewportY computes the actual viewport Y position of the cursor,
 // accounting for injected annotation lines and the file-level annotation line.
 // in collapsed mode, hidden removed lines (those in non-expanded hunks) are not counted.
 func (m Model) cursorViewportY() int {
+	var hunks []int
+	if m.collapsed.enabled {
+		hunks = m.findHunks()
+	}
+	return m.cursorViewportYUsing(hunks, m.buildAnnotationSet())
+}
+
+// cursorViewportYUsing is the same as cursorViewportY but accepts pre-built
+// hunks and annotationSet to avoid redundant computation when the caller
+// already has them (e.g. centerHunkInViewport).
+func (m Model) cursorViewportYUsing(hunks []int, annotationSet map[string]bool) int {
 	if m.currFile == "" || len(m.diffLines) == 0 {
 		return max(0, m.diffCursor)
 	}
 
-	// file-level annotation line at the top (may wrap to multiple rows)
 	fileAnnotationOffset := 0
 	if m.hasFileAnnotation() {
 		fileAnnotationOffset = m.wrappedAnnotationLineCount(annotKeyFile)
 	}
 
-	// cursor is on the file annotation line
 	if m.diffCursor == -1 {
 		return 0
 	}
 
-	annotationSet := m.buildAnnotationSet()
-	var hunks []int
-	if m.collapsed.enabled {
-		hunks = m.findHunks()
-	}
-
 	y := fileAnnotationOffset
 	for i := 0; i < m.diffCursor && i < len(m.diffLines); i++ {
-		// skip hidden removed lines in collapsed mode
-		if m.isCollapsedHidden(i, hunks) {
-			continue
-		}
-		// delete-only placeholders render synthetic text ("⋯ N lines deleted"), not original content.
-		// use placeholder text for wrapping to stay in sync with renderDeletePlaceholder.
-		if m.isDeleteOnlyPlaceholder(i, hunks) {
-			y += m.deletePlaceholderVisualHeight(i)
-			continue
-		}
-		y += m.wrappedLineCount(i) // the diff line (may occupy multiple visual rows when wrapping)
-		dl := m.diffLines[i]
-		if dl.ChangeType != diff.ChangeDivider {
-			key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
-			if annotationSet[key] {
-				y += m.wrappedAnnotationLineCount(key)
-			}
-		}
+		y += m.hunkLineHeight(i, hunks, annotationSet)
 	}
-	// if cursor is on the annotation sub-line, offset by wrapped line count
-	// (annotation renders after all continuation lines of the diff line)
 	if m.cursorOnAnnotation {
 		y += m.wrappedLineCount(m.diffCursor)
 	}

--- a/app/ui/diffnav.go
+++ b/app/ui/diffnav.go
@@ -249,7 +249,7 @@ func (m *Model) centerHunkInViewport() {
 	if m.collapsed.enabled {
 		hunks = m.findHunks()
 	}
-	annotationSet := m.buildAnnotationSet()
+	annotationSet := m.buildAnnotationSet() // note: also built inside cursorViewportY; acceptable duplication for now
 	hunkVisualHeight := 0
 	for i := m.diffCursor; i <= hunkEnd; i++ {
 		if m.collapsed.enabled && m.isCollapsedHidden(i, hunks) {

--- a/app/ui/diffnav.go
+++ b/app/ui/diffnav.go
@@ -219,6 +219,60 @@ func (m *Model) centerViewportOnCursor() {
 	m.viewport.SetContent(m.renderDiff())
 }
 
+// centerHunkInViewport centers the current hunk in the viewport.
+// For small hunks, the entire hunk is centered. For large hunks that exceed
+// the viewport height, the first line is placed near the top with a small context margin.
+func (m *Model) centerHunkInViewport() {
+	cursorY := m.cursorViewportY()
+
+	// find hunk end: scan forward from cursor while lines are changed
+	hunkEnd := m.diffCursor
+	for i := m.diffCursor + 1; i < len(m.diffLines); i++ {
+		ct := m.diffLines[i].ChangeType
+		if ct != diff.ChangeAdd && ct != diff.ChangeRemove {
+			break
+		}
+		hunkEnd = i
+	}
+
+	// calculate visual height of the hunk from cursor to hunk end
+	var hunks []int
+	if m.collapsed.enabled {
+		hunks = m.findHunks()
+	}
+	annotationSet := m.buildAnnotationSet()
+	hunkVisualHeight := 0
+	for i := m.diffCursor; i <= hunkEnd; i++ {
+		if m.collapsed.enabled && m.isCollapsedHidden(i, hunks) {
+			continue
+		}
+		if m.isDeleteOnlyPlaceholder(i, hunks) {
+			hunkVisualHeight += m.deletePlaceholderVisualHeight(i)
+			continue
+		}
+		hunkVisualHeight += m.wrappedLineCount(i)
+		dl := m.diffLines[i]
+		if dl.ChangeType != diff.ChangeDivider {
+			key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
+			if annotationSet[key] {
+				hunkVisualHeight += m.wrappedAnnotationLineCount(key)
+			}
+		}
+	}
+
+	var offset int
+	if hunkVisualHeight >= m.viewport.Height {
+		// hunk taller than viewport: place first line near top with small context margin
+		offset = max(0, cursorY-2)
+	} else {
+		// center the entire hunk by centering its midpoint
+		hunkMidY := cursorY + hunkVisualHeight/2
+		offset = max(0, hunkMidY-m.viewport.Height/2)
+	}
+	m.viewport.SetYOffset(offset)
+	m.viewport.SetContent(m.renderDiff())
+}
+
 // topAlignViewportOnCursor scrolls the viewport to place the cursor at the top of the page.
 func (m *Model) topAlignViewportOnCursor() {
 	cursorY := m.cursorViewportY()
@@ -284,7 +338,7 @@ func (m *Model) moveToNextHunk() {
 			continue // skip delete-only hunks in collapsed mode
 		}
 		m.diffCursor = target
-		m.centerViewportOnCursor()
+		m.centerHunkInViewport()
 		return
 	}
 }
@@ -301,7 +355,7 @@ func (m *Model) moveToPrevHunk() {
 		}
 		if target < m.diffCursor {
 			m.diffCursor = target
-			m.centerViewportOnCursor()
+			m.centerHunkInViewport()
 			return
 		}
 	}

--- a/app/ui/diffnav.go
+++ b/app/ui/diffnav.go
@@ -222,7 +222,16 @@ func (m *Model) centerViewportOnCursor() {
 // centerHunkInViewport centers the current hunk in the viewport.
 // For small hunks, the entire hunk is centered. For large hunks that exceed
 // the viewport height, the first line is placed near the top with a small context margin.
+// No-op if the cursor is not on a changed line (ChangeAdd/ChangeRemove).
 func (m *Model) centerHunkInViewport() {
+	if m.diffCursor < 0 || m.diffCursor >= len(m.diffLines) {
+		return
+	}
+	ct := m.diffLines[m.diffCursor].ChangeType
+	if ct != diff.ChangeAdd && ct != diff.ChangeRemove {
+		return
+	}
+
 	cursorY := m.cursorViewportY()
 
 	// find hunk end: scan forward from cursor while lines are changed

--- a/app/ui/diffnav.go
+++ b/app/ui/diffnav.go
@@ -232,7 +232,14 @@ func (m *Model) centerHunkInViewport() {
 		return
 	}
 
-	cursorY := m.cursorViewportY()
+	// build shared context once for both cursor Y and hunk height
+	var hunks []int
+	if m.collapsed.enabled {
+		hunks = m.findHunks()
+	}
+	annotationSet := m.buildAnnotationSet()
+
+	cursorY := m.cursorViewportYUsing(hunks, annotationSet)
 
 	// find hunk end: scan forward from cursor while lines are changed
 	hunkEnd := m.diffCursor
@@ -244,29 +251,10 @@ func (m *Model) centerHunkInViewport() {
 		hunkEnd = i
 	}
 
-	// calculate visual height of the hunk from cursor to hunk end
-	var hunks []int
-	if m.collapsed.enabled {
-		hunks = m.findHunks()
-	}
-	annotationSet := m.buildAnnotationSet() // note: also built inside cursorViewportY; acceptable duplication for now
+	// calculate visual height of the hunk
 	hunkVisualHeight := 0
 	for i := m.diffCursor; i <= hunkEnd; i++ {
-		if m.collapsed.enabled && m.isCollapsedHidden(i, hunks) {
-			continue
-		}
-		if m.isDeleteOnlyPlaceholder(i, hunks) {
-			hunkVisualHeight += m.deletePlaceholderVisualHeight(i)
-			continue
-		}
-		hunkVisualHeight += m.wrappedLineCount(i)
-		dl := m.diffLines[i]
-		if dl.ChangeType != diff.ChangeDivider {
-			key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
-			if annotationSet[key] {
-				hunkVisualHeight += m.wrappedAnnotationLineCount(key)
-			}
-		}
+		hunkVisualHeight += m.hunkLineHeight(i, hunks, annotationSet)
 	}
 
 	var offset int

--- a/app/ui/diffnav_test.go
+++ b/app/ui/diffnav_test.go
@@ -1185,6 +1185,48 @@ func TestModel_CenterHunkInViewport_NoOpOnContextLine(t *testing.T) {
 	assert.Equal(t, beforeOffset, m.viewport.YOffset, "should be no-op when cursor is on context line")
 }
 
+func TestModel_CenterHunkInViewport_CollapsedMode(t *testing.T) {
+	// in collapsed mode, removed lines in a mixed add/remove hunk are hidden;
+	// the visual height should only count visible (add) lines
+	var lines []diff.DiffLine
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, diff.DiffLine{OldNum: i, NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	// mixed hunk: 3 removes then 3 adds (indices 20-25)
+	lines = append(lines,
+		diff.DiffLine{OldNum: 21, Content: "old1", ChangeType: diff.ChangeRemove}, // idx 20, hidden in collapsed
+		diff.DiffLine{OldNum: 22, Content: "old2", ChangeType: diff.ChangeRemove}, // idx 21, hidden
+		diff.DiffLine{OldNum: 23, Content: "old3", ChangeType: diff.ChangeRemove}, // idx 22, hidden
+		diff.DiffLine{NewNum: 21, Content: "new1", ChangeType: diff.ChangeAdd},    // idx 23, visible
+		diff.DiffLine{NewNum: 22, Content: "new2", ChangeType: diff.ChangeAdd},    // idx 24, visible
+		diff.DiffLine{NewNum: 23, Content: "new3", ChangeType: diff.ChangeAdd},    // idx 25, visible
+	)
+	for i := 24; i <= 60; i++ {
+		lines = append(lines, diff.DiffLine{OldNum: i, NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+	m.collapsed.enabled = true
+	m.collapsed.expandedHunks = make(map[int]bool)
+	vpHeight := m.viewport.Height
+
+	m.diffCursor = 0
+	m.moveToNextHunk()
+	// in collapsed mode, cursor lands on first visible line (first add, idx 23)
+	assert.Equal(t, 23, m.diffCursor, "cursor should skip hidden removes and land on first add")
+
+	// hunk visual height = 3 visible add lines (removes are hidden)
+	cursorY := m.cursorViewportY()
+	hunkMidY := cursorY + 3/2
+	expectedOffset := max(0, hunkMidY-vpHeight/2)
+	assert.Equal(t, expectedOffset, m.viewport.YOffset, "collapsed mode: offset should only count visible lines")
+}
+
 func TestModel_HunkNavigationViaKeys(t *testing.T) {
 	lines := []diff.DiffLine{
 		{NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},  // 0

--- a/app/ui/diffnav_test.go
+++ b/app/ui/diffnav_test.go
@@ -928,6 +928,145 @@ func TestModel_MoveToPrevHunk(t *testing.T) {
 	m.moveToPrevHunk()
 	assert.Equal(t, 1, m.diffCursor, "should stay at first chunk")
 }
+func TestModel_CenterHunkInViewport_SmallHunk(t *testing.T) {
+	// build a file with context, a small 3-line hunk, and more context
+	// total: 50 lines, hunk at indices 20-22
+	var lines []diff.DiffLine
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	lines = append(lines, diff.DiffLine{NewNum: 21, Content: "add1", ChangeType: diff.ChangeAdd}) // idx 20
+	lines = append(lines, diff.DiffLine{NewNum: 22, Content: "add2", ChangeType: diff.ChangeAdd}) // idx 21
+	lines = append(lines, diff.DiffLine{NewNum: 23, Content: "add3", ChangeType: diff.ChangeAdd}) // idx 22
+	for i := 24; i <= 50; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+	vpHeight := m.viewport.Height
+	require.Positive(t, vpHeight)
+
+	m.diffCursor = 0
+	m.moveToNextHunk()
+	assert.Equal(t, 20, m.diffCursor, "cursor should land on first line of hunk")
+
+	// hunk midpoint: cursorY + hunkHeight/2 = 20 + 1 = 21
+	// offset: midY - vpHeight/2
+	expectedOffset := 21 - vpHeight/2
+	assert.Equal(t, expectedOffset, m.viewport.YOffset, "small hunk should be centered by its midpoint")
+}
+
+func TestModel_CenterHunkInViewport_LargeHunk(t *testing.T) {
+	// hunk larger than viewport
+	var lines []diff.DiffLine
+	for i := 1; i <= 10; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	for i := 11; i <= 110; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "add", ChangeType: diff.ChangeAdd})
+	}
+	lines = append(lines, diff.DiffLine{NewNum: 111, Content: "ctx", ChangeType: diff.ChangeContext})
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+
+	m.diffCursor = 0
+	m.moveToNextHunk()
+	assert.Equal(t, 10, m.diffCursor, "cursor should land on first line of hunk")
+
+	// hunk is 100 lines >> viewport, so offset = cursorY - 2 = 10 - 2 = 8
+	assert.Equal(t, 8, m.viewport.YOffset, "large hunk should place first line near top with context margin")
+}
+
+func TestModel_CenterHunkInViewport_HunkAtStart(t *testing.T) {
+	// hunk starts at line 0 — offset should be clamped to 0
+	var lines []diff.DiffLine
+	lines = append(lines, diff.DiffLine{NewNum: 1, Content: "add1", ChangeType: diff.ChangeAdd})
+	lines = append(lines, diff.DiffLine{NewNum: 2, Content: "add2", ChangeType: diff.ChangeAdd})
+	for i := 3; i <= 50; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+
+	m.diffCursor = 10
+	m.moveToPrevHunk()
+	assert.Equal(t, 0, m.diffCursor, "cursor should land on first line")
+	assert.Equal(t, 0, m.viewport.YOffset, "offset should be clamped to 0 when hunk is near top")
+}
+
+func TestModel_CenterHunkInViewport_PrevHunkCenters(t *testing.T) {
+	// verify moveToPrevHunk also centers the hunk
+	var lines []diff.DiffLine
+	for i := 1; i <= 25; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	lines = append(lines, diff.DiffLine{NewNum: 26, Content: "add1", ChangeType: diff.ChangeAdd}) // idx 25
+	lines = append(lines, diff.DiffLine{NewNum: 27, Content: "add2", ChangeType: diff.ChangeAdd}) // idx 26
+	for i := 28; i <= 60; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+	vpHeight := m.viewport.Height
+
+	m.diffCursor = 40
+	m.syncViewportToCursor()
+	m.moveToPrevHunk()
+	assert.Equal(t, 25, m.diffCursor, "cursor should land on first line of hunk")
+
+	// hunk midpoint: 25 + 2/2 = 26, offset: 26 - vpHeight/2
+	expectedOffset := 26 - vpHeight/2
+	assert.Equal(t, expectedOffset, m.viewport.YOffset, "prevHunk should center the hunk by its midpoint")
+}
+
+func TestModel_CenterHunkInViewport_SingleLineHunk(t *testing.T) {
+	// single-line hunk should still be centered
+	var lines []diff.DiffLine
+	for i := 1; i <= 25; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	lines = append(lines, diff.DiffLine{NewNum: 26, Content: "add", ChangeType: diff.ChangeAdd}) // idx 25
+	for i := 27; i <= 60; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+	vpHeight := m.viewport.Height
+
+	m.diffCursor = 0
+	m.moveToNextHunk()
+	assert.Equal(t, 25, m.diffCursor)
+
+	// single-line hunk: midY = 25 + 0 = 25, offset = 25 - vpHeight/2
+	expectedOffset := 25 - vpHeight/2
+	assert.Equal(t, expectedOffset, m.viewport.YOffset, "single-line hunk midpoint centered in viewport")
+}
+
 func TestModel_HunkNavigationViaKeys(t *testing.T) {
 	lines := []diff.DiffLine{
 		{NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},  // 0

--- a/app/ui/diffnav_test.go
+++ b/app/ui/diffnav_test.go
@@ -935,9 +935,11 @@ func TestModel_CenterHunkInViewport_SmallHunk(t *testing.T) {
 	for i := 1; i <= 20; i++ {
 		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
 	}
-	lines = append(lines, diff.DiffLine{NewNum: 21, Content: "add1", ChangeType: diff.ChangeAdd}) // idx 20
-	lines = append(lines, diff.DiffLine{NewNum: 22, Content: "add2", ChangeType: diff.ChangeAdd}) // idx 21
-	lines = append(lines, diff.DiffLine{NewNum: 23, Content: "add3", ChangeType: diff.ChangeAdd}) // idx 22
+	lines = append(lines,
+		diff.DiffLine{NewNum: 21, Content: "add1", ChangeType: diff.ChangeAdd}, // idx 20
+		diff.DiffLine{NewNum: 22, Content: "add2", ChangeType: diff.ChangeAdd}, // idx 21
+		diff.DiffLine{NewNum: 23, Content: "add3", ChangeType: diff.ChangeAdd}, // idx 22
+	)
 	for i := 24; i <= 50; i++ {
 		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
 	}
@@ -990,8 +992,10 @@ func TestModel_CenterHunkInViewport_LargeHunk(t *testing.T) {
 func TestModel_CenterHunkInViewport_HunkAtStart(t *testing.T) {
 	// hunk starts at line 0 — offset should be clamped to 0
 	var lines []diff.DiffLine
-	lines = append(lines, diff.DiffLine{NewNum: 1, Content: "add1", ChangeType: diff.ChangeAdd})
-	lines = append(lines, diff.DiffLine{NewNum: 2, Content: "add2", ChangeType: diff.ChangeAdd})
+	lines = append(lines,
+		diff.DiffLine{NewNum: 1, Content: "add1", ChangeType: diff.ChangeAdd},
+		diff.DiffLine{NewNum: 2, Content: "add2", ChangeType: diff.ChangeAdd},
+	)
 	for i := 3; i <= 50; i++ {
 		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
 	}
@@ -1015,8 +1019,10 @@ func TestModel_CenterHunkInViewport_PrevHunkCenters(t *testing.T) {
 	for i := 1; i <= 25; i++ {
 		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
 	}
-	lines = append(lines, diff.DiffLine{NewNum: 26, Content: "add1", ChangeType: diff.ChangeAdd}) // idx 25
-	lines = append(lines, diff.DiffLine{NewNum: 27, Content: "add2", ChangeType: diff.ChangeAdd}) // idx 26
+	lines = append(lines,
+		diff.DiffLine{NewNum: 26, Content: "add1", ChangeType: diff.ChangeAdd}, // idx 25
+		diff.DiffLine{NewNum: 27, Content: "add2", ChangeType: diff.ChangeAdd}, // idx 26
+	)
 	for i := 28; i <= 60; i++ {
 		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
 	}
@@ -1065,6 +1071,118 @@ func TestModel_CenterHunkInViewport_SingleLineHunk(t *testing.T) {
 	// single-line hunk: midY = 25 + 0 = 25, offset = 25 - vpHeight/2
 	expectedOffset := 25 - vpHeight/2
 	assert.Equal(t, expectedOffset, m.viewport.YOffset, "single-line hunk midpoint centered in viewport")
+}
+
+func TestModel_CenterHunkInViewport_WrapMode(t *testing.T) {
+	// when wrap mode is on, long changed lines occupy multiple visual rows;
+	// the hunk visual height (and thus the centering offset) must account for them
+	var lines []diff.DiffLine
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	// two changed lines: one short, one long enough to wrap
+	lines = append(lines,
+		diff.DiffLine{NewNum: 21, Content: "short add", ChangeType: diff.ChangeAdd},                      // idx 20
+		diff.DiffLine{NewNum: 22, Content: strings.Repeat("a", 200), ChangeType: diff.ChangeAdd}, // idx 21, wraps
+	)
+	for i := 23; i <= 60; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+	m.wrapMode = true
+	vpHeight := m.viewport.Height
+	require.Positive(t, vpHeight)
+
+	m.diffCursor = 0
+	m.moveToNextHunk()
+	assert.Equal(t, 20, m.diffCursor, "cursor should land on first line of hunk")
+
+	// compute expected offset using the same helpers the production code uses
+	wrapCount0 := m.wrappedLineCount(20)
+	wrapCount1 := m.wrappedLineCount(21)
+	require.Greater(t, wrapCount1, 1, "long line should wrap to multiple rows")
+	hunkVisualHeight := wrapCount0 + wrapCount1
+	cursorY := m.cursorViewportY()
+	hunkMidY := cursorY + hunkVisualHeight/2
+	expectedOffset := max(0, hunkMidY-vpHeight/2)
+	assert.Equal(t, expectedOffset, m.viewport.YOffset, "wrap mode: offset should account for wrapped line height")
+}
+
+func TestModel_CenterHunkInViewport_WithAnnotation(t *testing.T) {
+	// an inline annotation on a hunk line adds visual rows that must be
+	// included when computing the hunk midpoint for centering
+	var lines []diff.DiffLine
+	for i := 1; i <= 25; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	lines = append(lines,
+		diff.DiffLine{NewNum: 26, Content: "add1", ChangeType: diff.ChangeAdd}, // idx 25
+		diff.DiffLine{NewNum: 27, Content: "add2", ChangeType: diff.ChangeAdd}, // idx 26
+	)
+	for i := 28; i <= 60; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+	vpHeight := m.viewport.Height
+
+	// add an annotation on the first changed line
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 26, Type: "+", Comment: "review note"})
+	defer m.store.Delete("a.go", 26, "+")
+
+	m.diffCursor = 0
+	m.moveToNextHunk()
+	assert.Equal(t, 25, m.diffCursor, "cursor should land on first line of hunk")
+
+	// expected: hunk height = 2 changed lines + annotation visual rows
+	annotKey := m.annotationKey(26, "+")
+	annotHeight := m.wrappedAnnotationLineCount(annotKey)
+	require.Positive(t, annotHeight, "annotation should contribute visual rows")
+	hunkVisualHeight := 2 + annotHeight // 2 changed lines + annotation
+	cursorY := m.cursorViewportY()
+	hunkMidY := cursorY + hunkVisualHeight/2
+	expectedOffset := max(0, hunkMidY-vpHeight/2)
+	assert.Equal(t, expectedOffset, m.viewport.YOffset, "annotation: offset should include annotation visual rows")
+}
+
+func TestModel_CenterHunkInViewport_NoOpOnContextLine(t *testing.T) {
+	// calling centerHunkInViewport when the cursor is on a context line
+	// should be a no-op — viewport offset must not change
+	var lines []diff.DiffLine
+	for i := 1; i <= 30; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+	lines = append(lines, diff.DiffLine{NewNum: 31, Content: "add", ChangeType: diff.ChangeAdd})
+	for i := 32; i <= 60; i++ {
+		lines = append(lines, diff.DiffLine{NewNum: i, Content: "ctx", ChangeType: diff.ChangeContext})
+	}
+
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = result.(Model)
+	result, _ = m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	m = result.(Model)
+	m.focus = paneDiff
+
+	// position cursor on a context line and set a known viewport offset
+	m.diffCursor = 10
+	m.viewport.SetYOffset(5)
+	m.viewport.SetContent(m.renderDiff())
+	beforeOffset := m.viewport.YOffset
+
+	m.centerHunkInViewport()
+	assert.Equal(t, beforeOffset, m.viewport.YOffset, "should be no-op when cursor is on context line")
 }
 
 func TestModel_HunkNavigationViaKeys(t *testing.T) {


### PR DESCRIPTION
## Summary
- Hunk navigation (`[`/`]`) now centers the **entire hunk** in the viewport instead of just the first changed line
- Small hunks are centered by their midpoint; large hunks (taller than viewport) are placed near the top with a 2-line context margin
- Accounts for wrap mode, collapsed mode, and inline annotations when calculating hunk visual height

Closes #82

## Test plan
- [ ] Navigate hunks with `]`/`[` — small hunks should appear centered in the viewport
- [ ] Navigate to a large hunk (more lines than viewport height) — first line should appear near the top
- [ ] Test in collapsed mode (`v`) — centering should still work correctly
- [ ] Test in wrap mode (`w`) — wrapped lines should be accounted for
- [ ] Cross-file hunk navigation should center on the target hunk in the new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

