### PR TITLE
fix(ui): preserve syntax highlight foreground on wrapped lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,11 @@ git diff → diff.parseUnifiedDiff() → []DiffLine
     blameAuthorLen capped at 8; blameGutterWidth() = W+5; Blamer interface (optional, nil when git unavailable)
   when wrap mode is on (`w` toggle, orthogonal to above):
     wrapContent() splits long lines via ansi.Wrap,
-    continuation lines get `↪` gutter marker, cursorViewportY() sums wrapped line counts
+    continuation lines get `↪` gutter marker, cursorViewportY() sums wrapped line counts.
+    ansi.Wrap does not preserve SGR state across inserted newlines, so reemitANSIState()
+    re-prepends active fg color, bold, and italic at the start of each continuation line.
+    State tracking via scanANSIState()/parseSGR()/applySGR(); handles chroma's fg (24-bit/basic),
+    bold (1/22), italic (3/23), fg reset (39), and full reset (0/bare)
   when search is active (`/` to search, `n`/`N` to navigate, `esc` to clear):
     buildSearchMatchSet() converts match indices to O(1) map per render,
     highlightSearchMatches() inserts ANSI bg-only sequence around matched substrings

--- a/app/ui/diffview.go
+++ b/app/ui/diffview.go
@@ -274,12 +274,115 @@ func (m Model) wrappedLineCount(idx int) int {
 
 // wrapContent wraps text content at the given width using word boundaries.
 // returns a slice of visual lines (at least one). handles ANSI escape sequences.
+// re-emits active SGR state (foreground, bold, italic) at the start of each continuation line
+// because ansi.Wrap does not preserve ANSI state across inserted newlines.
 func (m Model) wrapContent(content string, width int) []string {
 	if width <= 0 {
 		return []string{content}
 	}
 	wrapped := ansi.Wrap(content, width, "")
-	return strings.Split(wrapped, "\n")
+	lines := strings.Split(wrapped, "\n")
+	if len(lines) <= 1 {
+		return lines
+	}
+	return m.reemitANSIState(lines)
+}
+
+// reemitANSIState scans each line for active SGR attributes (foreground color, bold, italic)
+// and prepends the accumulated state to the next line. this fixes the issue where ansi.Wrap
+// splits a line mid-token, causing continuation lines to lose their foreground color.
+func (m Model) reemitANSIState(lines []string) []string {
+	var activeFg string // e.g. "\033[38;2;100;200;50m" or "\033[32m"
+	var bold, italic bool
+
+	for i, line := range lines {
+		if i > 0 {
+			// prepend accumulated state from previous lines
+			var prefix strings.Builder
+			if activeFg != "" {
+				prefix.WriteString(activeFg)
+			}
+			if bold {
+				prefix.WriteString("\033[1m")
+			}
+			if italic {
+				prefix.WriteString("\033[3m")
+			}
+			if prefix.Len() > 0 {
+				lines[i] = prefix.String() + line
+			}
+		}
+
+		// scan this line to update active state
+		activeFg, bold, italic = m.scanANSIState(lines[i], activeFg, bold, italic)
+	}
+	return lines
+}
+
+// scanANSIState scans a string for SGR sequences and returns the updated state.
+// tracks foreground color (38;2;r;g;b or 3x), bold (1), italic (3) and their resets.
+func (m Model) scanANSIState(s, fg string, bold, italic bool) (string, bool, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\033' || i+1 >= len(s) || s[i+1] != '[' {
+			continue
+		}
+		seq, params, end := m.parseSGR(s, i)
+		if end < 0 {
+			break
+		}
+		i = end
+		if seq == "" { // not an SGR sequence
+			continue
+		}
+		fg, bold, italic = m.applySGR(params, seq, fg, bold, italic)
+	}
+	return fg, bold, italic
+}
+
+// parseSGR extracts an SGR sequence starting at position i in s.
+// returns the full sequence, the parameter string, and the end index.
+// returns end=-1 if the sequence is unterminated.
+// returns seq="" if the CSI sequence is not SGR (not terminated by 'm').
+func (m Model) parseSGR(s string, i int) (seq, params string, end int) {
+	j := i + 2
+	for j < len(s) && s[j] >= 0x20 && s[j] <= 0x3F {
+		j++
+	}
+	if j >= len(s) {
+		return "", "", -1
+	}
+	if s[j] != 'm' {
+		return "", "", j
+	}
+	return s[i : j+1], s[i+2 : j], j
+}
+
+// applySGR updates the active SGR state based on a parameter string.
+func (m Model) applySGR(params, seq, fg string, bold, italic bool) (string, bool, bool) {
+	switch params {
+	case "", "0": // full reset (\033[m and \033[0m)
+		return "", false, false
+	case "1": // bold on
+		return fg, true, italic
+	case "3": // italic on
+		return fg, bold, true
+	case "22": // bold off
+		return fg, false, italic
+	case "23": // italic off
+		return fg, bold, false
+	case "39": // fg reset
+		return "", bold, italic
+	}
+	if m.isFgColor(params) {
+		return seq, bold, italic
+	}
+	return fg, bold, italic
+}
+
+// isFgColor returns true if the SGR params represent a foreground color (24-bit or basic).
+func (m Model) isFgColor(params string) bool {
+	return strings.HasPrefix(params, "38;2;") ||
+		(len(params) == 2 && params[0] == '3' && params[1] >= '0' && params[1] <= '7')
 }
 
 // prepareLineContent returns the display-ready content for a diff line with tabs replaced.

--- a/app/ui/diffview_test.go
+++ b/app/ui/diffview_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/umputun/revdiff/app/annotation"
 	"github.com/umputun/revdiff/app/diff"
@@ -306,5 +307,88 @@ func TestModel_StyleDiffContent(t *testing.T) {
 		result := m.styleDiffContent(diff.ChangeAdd, " + ", "\033[32mgreen\033[0m", true, false)
 		assert.Contains(t, result, " + ")
 		assert.Contains(t, result, "\033[32m")
+	})
+}
+
+func TestModel_WrapContent_ANSIStatePreservation(t *testing.T) {
+	m := testModel(nil, nil)
+
+	t.Run("fg color carries across wrap boundary", func(t *testing.T) {
+		// simulate chroma-highlighted long token: fg set, long text, fg reset
+		content := "\033[38;2;100;200;50mthis is a very long green token that must wrap\033[39m"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1, "should wrap into multiple lines")
+		// continuation lines must start with the active fg sequence
+		for i := 1; i < len(lines); i++ {
+			assert.Contains(t, lines[i], "\033[38;2;100;200;50m",
+				"continuation line %d should have fg color re-emitted", i)
+		}
+	})
+
+	t.Run("bold carries across wrap boundary", func(t *testing.T) {
+		content := "\033[1mthis is a bold token that should wrap at boundary\033[22m"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1)
+		for i := 1; i < len(lines); i++ {
+			assert.Contains(t, lines[i], "\033[1m", "continuation line %d should have bold re-emitted", i)
+		}
+	})
+
+	t.Run("italic carries across wrap boundary", func(t *testing.T) {
+		content := "\033[3mthis is italic text that should wrap properly\033[23m"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1)
+		for i := 1; i < len(lines); i++ {
+			assert.Contains(t, lines[i], "\033[3m", "continuation line %d should have italic re-emitted", i)
+		}
+	})
+
+	t.Run("fg reset before wrap means no carry", func(t *testing.T) {
+		// fg is set and reset on the first segment, second segment should have no fg
+		content := "\033[32mshort\033[39m and then some more plain text that wraps here"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1)
+		// first line has the color, continuation should NOT re-emit it (already reset)
+		assert.NotContains(t, lines[len(lines)-1], "\033[32m", "reset fg should not carry")
+	})
+
+	t.Run("multiple fg changes across wrap", func(t *testing.T) {
+		// first token green, then red token that wraps
+		content := "\033[32mhi\033[39m \033[31mthis red token is long enough to wrap over\033[39m"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1)
+		// the last line should carry the red fg, not green
+		assert.Contains(t, lines[len(lines)-1], "\033[31m", "should carry the last active fg color")
+		assert.NotContains(t, lines[len(lines)-1], "\033[32m", "should not carry the first fg color")
+	})
+
+	t.Run("full reset clears all state before wrap", func(t *testing.T) {
+		content := "\033[38;2;100;200;50m\033[1m\033[3mstyled text\033[0m and then plain text long enough to wrap here"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1)
+		// after \033[0m, no state should carry to continuation lines
+		last := lines[len(lines)-1]
+		assert.NotContains(t, last, "\033[38;2;100;200;50m", "fg should not carry after full reset")
+		assert.NotContains(t, last, "\033[1m", "bold should not carry after full reset")
+		assert.NotContains(t, last, "\033[3m", "italic should not carry after full reset")
+	})
+
+	t.Run("bare reset ESC[m clears all state", func(t *testing.T) {
+		content := "\033[38;2;100;200;50m\033[1mstyled text\033[m and then plain wrapping text here"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1)
+		last := lines[len(lines)-1]
+		assert.NotContains(t, last, "\033[38;2;100;200;50m", "fg should not carry after bare reset")
+		assert.NotContains(t, last, "\033[1m", "bold should not carry after bare reset")
+	})
+
+	t.Run("no ANSI content unchanged", func(t *testing.T) {
+		content := "plain text that is long enough to wrap at the boundary"
+		lines := m.wrapContent(content, 20)
+		require.Greater(t, len(lines), 1)
+		// no ANSI codes should appear
+		for _, line := range lines {
+			assert.NotContains(t, line, "\033[", "plain text should have no ANSI injected")
+		}
 	})
 }


### PR DESCRIPTION
Word wrap continuation lines lost their syntax highlight foreground color, showing terminal default instead. The background was correct but text appeared in the wrong color.

**Root cause:** `ansi.Wrap` (charmbracelet/x/ansi) does not preserve SGR state across inserted newlines. After `strings.Split`, continuation lines start without ANSI foreground codes. Combined with `LineAddHighlight` setting only background (chroma owns foreground), continuation lines got terminal default foreground.

**Fix:** `wrapContent()` now tracks active SGR state (fg color, bold, italic) across wrap boundaries via `reemitANSIState()` and re-emits the accumulated state at the start of each continuation line. Handles 24-bit and basic foreground colors, bold/italic, individual resets, and full reset (`\033[0m` and bare `\033[m`).