### PR TITLE
feat(plugin): add Codex CLI plugin for revdiff

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "revdiff",
+  "owner": {
+    "name": "umputun",
+    "email": "umputun@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "revdiff",
+      "source": "./plugins/codex",
+      "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
+      "version": "0.1.0",
+      "author": {
+        "name": "umputun"
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,15 @@ git diff → diff.parseUnifiedDiff() → []DiffLine
   - `config.md` — options, colors, chroma styles
   - `usage.md` — examples, key bindings, output format
 
+## Codex Plugin
+- Plugin lives at `plugins/codex/` with `.codex-plugin/plugin.json` manifest and `skills/`
+- Codex marketplace entry at `.agents/plugins/marketplace.json` (separate from Claude marketplace)
+- Two skills: `revdiff` (diff review) and `revdiff-plan` (plan review via last Codex assistant message)
+- Scripts are copies from `.claude-plugin/skills/revdiff/scripts/`, not symlinks — each has a source comment at top
+- Codex has no hook system — plan review is manual via `/revdiff-plan`
+- **CRITICAL: After any codex plugin file change, ask user if they want to bump the plugin version**
+- When bumping, update version in both `plugins/codex/.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`
+
 ## Pi Plugin
 - Pi package defined in root `package.json`, extensions and skills in `plugins/pi/`
 - **CRITICAL: After any pi plugin file change, ask user if they want to bump the version in `package.json`**

--- a/README.md
+++ b/README.md
@@ -160,6 +160,37 @@ pi install https://github.com/umputun/revdiff
 - Optional post-edit reminders are available via `/revdiff-reminders on` and suggest running `/revdiff` or `/revdiff-rerun` after agent edits
 - In the repo, the pi-specific resources live under `plugins/pi/` to keep harness integrations clearly separated
 
+## Codex Plugin
+
+revdiff ships with a [Codex CLI](https://github.com/openai/codex) plugin for interactive diff review and plan annotation directly from a Codex session. The plugin provides two skills:
+
+- `/revdiff` — same diff review workflow as the Claude Code plugin (detect ref, launch overlay, capture annotations, feedback loop)
+- `/revdiff-plan` — extracts the last Codex assistant message from session rollout files, opens it in revdiff for annotation, and feeds feedback back
+
+The plugin uses the same terminal overlay mechanism (tmux, Zellij, kitty, wezterm, etc.) as the Claude Code plugin.
+
+**Install:**
+
+```bash
+# copy plugin to Codex plugins directory
+cp -r plugins/codex ~/.codex/plugins/revdiff
+
+# or, if working from a cloned repo, Codex discovers the plugin
+# automatically via .agents/plugins/marketplace.json
+```
+
+**Requirements:**
+
+- `revdiff` binary on `PATH`
+- `jq` (required for `/revdiff-plan` session extraction)
+- One of the supported terminal multiplexers for overlay mode
+
+**Notes:**
+
+- Codex has no hook system — plan review requires manually invoking `/revdiff-plan` after Codex generates a plan
+- Scripts are portable copies from the Claude Code plugin, not symlinks
+- Plugin source lives under `plugins/codex/` in the repository
+
 ### Integration with Other Tools
 
 The structured stdout output works with any tool that can read text:

--- a/docs/plans/completed/20260409-codex-plugin.md
+++ b/docs/plans/completed/20260409-codex-plugin.md
@@ -1,0 +1,148 @@
+# Codex CLI Plugin for revdiff
+
+## Overview
+- Create a Codex CLI plugin that provides revdiff integration for diff review and plan annotation
+- Addresses Issue #84 — user request for Codex plugin/skill for easy install
+- Two skills: `revdiff` (diff review) and `revdiff-plan` (manual plan review after Codex generates a plan)
+- Targets Claude-plugin parity (not Pi-extension parity) since Codex's plugin model is skill-based
+
+## Context (from brainstorm + external review)
+- Codex plugin format: `.codex-plugin/plugin.json` manifest + `skills/` directory with `SKILL.md` files
+- Codex marketplace: `.agents/plugins/marketplace.json` (separate from `.claude-plugin/marketplace.json`)
+- Codex has no hook system (no `ExitPlanMode` interception) — plan review is manual via `/revdiff-plan`
+- Existing scripts (`detect-ref.sh`, `launch-revdiff.sh`) are pure shell and portable to Codex
+- Plugin lives at `plugins/codex/` — coexists with `plugins/pi/` and `plugins/revdiff-planning/`
+- SKILL.md format is identical between Claude Code and Codex (YAML frontmatter + markdown body)
+- Codex rollout files at `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` contain assistant messages
+- **Script path resolution**: Codex has no `CODEX_SKILL_DIR` env var (unlike Claude Code's `CLAUDE_SKILL_DIR`).
+  Three documented patterns exist (from Codex system skills):
+  1. `$CODEX_HOME/skills/<name>/scripts/` — for home-installed skills (used by imagegen)
+  2. Repo-relative path with CWD=repo root — for repo-local plugins (used by plugin-creator)
+  3. "Resolve relative to this skill directory" — agent infers path (used by plannotator, least reliable)
+  **Our approach**: SKILL.md instructs the agent to resolve via repo root first, then fall back to `$CODEX_HOME`:
+  `SCRIPT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/codex/skills/revdiff/scripts"` with
+  fallback `SCRIPT_DIR="${CODEX_HOME:-$HOME/.codex}/plugins/revdiff/skills/revdiff/scripts"`.
+  This covers both repo-local usage and external plugin installation.
+- **Codex rollout JSONL format**: each line is a JSON object. Assistant messages have
+  `type: "response_item"`, `payload.type: "message"`, `payload.role: "assistant"`,
+  `payload.content[].type: "output_text"`, `payload.content[].text: "<message text>"`
+- **Codex tools**: Codex supports `Bash`, `Read`, `Edit`, `Write`, `Grep`, `Glob` (same as Claude Code)
+
+## Development Approach
+- **testing approach**: manual verification after implementation. Test by either:
+  (a) pointing Codex plugin path to our repo directory (if Codex supports custom plugin paths), or
+  (b) copying `plugins/codex/` to `~/.codex/plugins/revdiff/` (or wherever Codex installs plugins) manually.
+  Verify both skills trigger and scripts execute correctly.
+- complete each task fully before moving to the next
+- scripts are **copies** from `.claude-plugin/skills/revdiff/scripts/`, not symlinks
+- add a comment at the top of each copied script noting source file for future sync
+- SKILL.md files are adapted for Codex (no `AskUserQuestion`, no `EnterPlanMode`)
+- no hooks — Codex doesn't support them reliably yet
+
+## Solution Overview
+- Port the Claude Code `revdiff` skill to Codex with minimal adaptations
+- Add a new `revdiff-plan` skill for manual plan review (extracts last Codex assistant message)
+- Package as a Codex plugin with marketplace entry
+- Codex marketplace is separate from Claude marketplace — no cross-listing needed
+
+## Acceptance Criteria
+- Codex CLI can discover the plugin via `.agents/plugins/marketplace.json`
+- `/revdiff` triggers a diff review session in terminal overlay
+- `/revdiff-plan` extracts the last Codex assistant message and opens it in revdiff for annotation
+- annotation feedback loop works (re-launch until user quits without annotations)
+- all scripts are executable and macOS/Linux compatible
+
+## Implementation Steps
+
+### Task 1: Create plugin scaffold and manifest
+
+**Files:**
+- Create: `plugins/codex/.codex-plugin/plugin.json`
+- Create: `.agents/plugins/marketplace.json`
+
+- [x] create `plugins/codex/` directory structure
+- [x] create `plugins/codex/.codex-plugin/plugin.json` with name, version, description, author, repository, license, keywords, skills path
+- [x] create `.agents/plugins/marketplace.json` with Codex marketplace entry
+- [x] verify manifest structure matches Codex plugin-creator spec
+
+### Task 2: Create `revdiff` skill (main diff review)
+
+**Files:**
+- Create: `plugins/codex/skills/revdiff/SKILL.md`
+- Create: `plugins/codex/skills/revdiff/scripts/detect-ref.sh`
+- Create: `plugins/codex/skills/revdiff/scripts/launch-revdiff.sh`
+- Create: `plugins/codex/skills/revdiff/references/config.md`
+- Create: `plugins/codex/skills/revdiff/references/install.md`
+- Create: `plugins/codex/skills/revdiff/references/usage.md`
+
+- [x] copy `detect-ref.sh` from `.claude-plugin/skills/revdiff/scripts/`
+- [x] copy `launch-revdiff.sh` from `.claude-plugin/skills/revdiff/scripts/`
+- [x] copy reference docs from `.claude-plugin/skills/revdiff/references/`
+- [x] create `SKILL.md` adapted for Codex:
+  - [x] replace `${CLAUDE_SKILL_DIR}` with `$(git rev-parse --show-toplevel)/plugins/codex/skills/revdiff`
+  - [x] replace `AskUserQuestion` with "present options as a numbered list and wait for user response"
+  - [x] replace `EnterPlanMode` with "write the plan as a markdown list and ask 'proceed with these changes?'"
+  - [x] set `allowed-tools: [Bash, Read, Edit, Write, Grep, Glob]` (Codex supports all six)
+  - [x] keep workflow steps 0-7 (install check, ref detection, launch, capture, classify, plan, address, loop)
+  - [x] keep timeout handling as-is (Codex has similar bash timeout behavior)
+- [x] verify scripts have execute permissions
+
+### Task 3: Create `revdiff-plan` skill (manual plan review)
+
+**Files:**
+- Create: `plugins/codex/skills/revdiff-plan/SKILL.md`
+- Create: `plugins/codex/skills/revdiff-plan/scripts/extract-last-message.sh`
+
+- [x] create `extract-last-message.sh` script:
+  - [x] check `~/.codex/sessions/` exists, exit with error message if not
+  - [x] find most recent rollout file via `ls -t ~/.codex/sessions/*/*/*/*rollout*.jsonl 2>/dev/null | head -1`
+  - [x] extract last assistant message using jq forward scan + tail:
+    `jq -r 'select(.type=="response_item" and .payload.type=="message" and .payload.role=="assistant") | .payload.content[] | select(.type=="output_text") | .text' "$rollout" | tail -1`
+  - [x] output raw markdown text to stdout
+  - [x] handle edge cases: no rollout files found, empty/no assistant messages, jq not installed (check with `command -v jq`)
+- [x] create `SKILL.md` with:
+  - [x] trigger on "revdiff-plan", "review plan with revdiff", "annotate plan"
+  - [x] workflow: extract last message → write temp file → launch revdiff `--only=` → capture annotations → feed back
+  - [x] annotation loop (re-launch until no annotations)
+  - [x] cleanup temp file on completion
+- [x] verify script has execute permission
+- [x] test extraction against a real Codex rollout file
+
+### Task 4: Create plugin README
+
+**Files:**
+- Create: `plugins/codex/README.md`
+
+- [x] document installation steps (Codex plugin install command)
+- [x] document available skills and usage examples
+- [x] document requirements (revdiff binary, jq for plan review)
+- [x] note differences from Claude Code plugin
+
+### Task 5: Update project documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+
+- [x] add Codex plugin section to CLAUDE.md project structure
+- [x] add Codex plugin mention to README.md installation/integration section
+- [x] verify no stale references
+
+### Task 6: Verify and finalize
+
+- [x] verify plugin directory structure matches Codex conventions
+- [x] verify all scripts are executable (`chmod +x`)
+- [x] verify marketplace.json is valid JSON
+- [x] verify SKILL.md frontmatter is valid YAML
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification:**
+- install plugin in Codex CLI and test `/revdiff` skill triggers
+- test `/revdiff-plan` extraction against active Codex session
+- verify overlay launch in tmux/kitty/wezterm environments
+- test annotation capture and feedback loop
+
+**Issue follow-up:**
+- respond to Issue #84 with installation instructions

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "revdiff",
+  "version": "0.1.0",
+  "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
+  "author": {
+    "name": "umputun",
+    "email": "umputun@gmail.com"
+  },
+  "repository": "https://github.com/umputun/revdiff",
+  "license": "MIT",
+  "keywords": [
+    "code-review",
+    "diff",
+    "annotations",
+    "tui"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -1,0 +1,70 @@
+# Codex CLI integration
+
+This directory contains the **Codex CLI** plugin for revdiff.
+
+## Contents
+
+- `.codex-plugin/plugin.json` — plugin manifest
+- `skills/revdiff/SKILL.md` — diff review skill (same workflow as Claude Code plugin)
+- `skills/revdiff/scripts/` — detect-ref.sh, launch-revdiff.sh
+- `skills/revdiff/references/` — config.md, install.md, usage.md
+- `skills/revdiff-plan/SKILL.md` — plan/response review skill (extracts last Codex assistant message)
+- `skills/revdiff-plan/scripts/` — extract-last-message.sh
+
+## Requirements
+
+- `revdiff` binary — `brew install umputun/apps/revdiff` or download from [releases](https://github.com/umputun/revdiff/releases)
+- `jq` — required by the `revdiff-plan` skill for extracting messages from Codex rollout files
+- A supported terminal: tmux, Zellij, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm
+
+## Install
+
+Copy the plugin directory to your Codex plugins location:
+
+```bash
+cp -r plugins/codex ~/.codex/plugins/revdiff
+```
+
+Or, if working from a cloned repo, Codex discovers the plugin via `.agents/plugins/marketplace.json` at the repo root.
+
+## Skills
+
+### `/revdiff`
+
+Interactive diff review with inline annotations.
+
+```text
+/revdiff              — auto-detect ref (uncommitted, staged, branch vs master, or last commit)
+/revdiff HEAD~3       — review last 3 commits
+/revdiff main feature — two-ref diff
+/revdiff all files    — browse all tracked files
+/revdiff path/to/file — review a single file
+```
+
+Annotations are captured on exit. Codex classifies them as code-change directives or explanation requests, addresses each, and re-launches revdiff for verification.
+
+### `/revdiff-plan`
+
+Review the last Codex assistant message (plan, analysis, or proposal) with annotations.
+
+```text
+/revdiff-plan         — extract last response from Codex rollout files, open in revdiff
+```
+
+The skill reads `~/.codex/sessions/` rollout JSONL files, extracts the most recent assistant message, writes it to a temp file, and opens revdiff with `--only=<tempfile>`. Annotations feed back into a refinement loop.
+
+## Differences from Claude Code plugin
+
+- No hook-based automatic plan review — Codex lacks hook support, so plan review is manual via `/revdiff-plan`
+- Uses Codex rollout files (`~/.codex/sessions/`) instead of Claude session logs for message extraction
+- Script path resolution falls back to `$CODEX_HOME` (or `~/.codex`) instead of `$CLAUDE_SKILL_DIR`
+- `AskUserQuestion` tool replaced with numbered-list prompts (Codex convention)
+- `EnterPlanMode` replaced with inline markdown plan + confirmation prompt
+
+## Notes
+
+This integration is intentionally kept separate from other harnesses:
+
+- Claude Code integration lives in `.claude-plugin/`
+- Pi integration lives in `plugins/pi/`
+- Codex integration lives here in `plugins/codex/`

--- a/plugins/codex/skills/revdiff-plan/SKILL.md
+++ b/plugins/codex/skills/revdiff-plan/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: revdiff-plan
+description: Review the last Codex assistant message (plan, analysis, or proposal) with inline annotations in a TUI overlay. Extracts the most recent response from Codex rollout files and opens it in revdiff for review and annotation. Activates on "revdiff-plan", "review plan with revdiff", "annotate plan", "review last response", "annotate codex output".
+argument-hint: 'none'
+allowed-tools: [Bash, Read, Edit, Write, Grep, Glob]
+---
+
+# revdiff-plan - Review Codex Output
+
+Review the last Codex assistant message with inline annotations using revdiff TUI in a terminal overlay.
+
+## Script Path Resolution
+
+Resolve the script directory using repo root first, then fall back to Codex home:
+
+```bash
+SCRIPT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/codex/skills/revdiff-plan/scripts"
+if [ ! -d "$SCRIPT_DIR" ]; then
+    SCRIPT_DIR="${CODEX_HOME:-$HOME/.codex}/plugins/revdiff/skills/revdiff-plan/scripts"
+fi
+```
+
+Also resolve the launcher script from the revdiff skill:
+
+```bash
+LAUNCHER_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/codex/skills/revdiff/scripts"
+if [ ! -d "$LAUNCHER_DIR" ]; then
+    LAUNCHER_DIR="${CODEX_HOME:-$HOME/.codex}/plugins/revdiff/skills/revdiff/scripts"
+fi
+```
+
+Use `$SCRIPT_DIR` and `$LAUNCHER_DIR` in place of script paths throughout this skill.
+
+## Activation Triggers
+
+- "revdiff-plan", "review plan with revdiff", "annotate plan"
+- "review last response", "annotate codex output"
+
+## How It Works
+
+1. Extract the last Codex assistant message from rollout files
+2. Write it to a temp markdown file
+3. Launch revdiff with `--only=<tempfile>` in a terminal overlay
+4. User reads the plan, adds annotations on specific lines
+5. On quit, annotations are captured from stdout
+6. Codex reads annotations and addresses each one (refine plan, answer questions, fix issues)
+7. Loop: re-launch revdiff to verify changes, user can add more annotations
+8. Done when user quits without annotations; clean up temp file
+
+## Workflow
+
+### Step 0: Verify Installation
+
+```bash
+which revdiff
+```
+
+If not found, guide installation:
+- `brew install umputun/apps/revdiff`
+- Binary releases: https://github.com/umputun/revdiff/releases
+
+Also verify jq is installed (required for rollout extraction):
+```bash
+which jq
+```
+
+If not found: `brew install jq`
+
+### Step 1: Extract Last Assistant Message
+
+Run the extraction script with `--skip-current` to avoid picking up this session's own output:
+
+```bash
+$SCRIPT_DIR/extract-last-message.sh --skip-current
+```
+
+The script:
+- Uses a best-effort heuristic: picks the second most recent rollout JSONL file by modification time from `~/.codex/sessions/`
+- This assumes the newest file belongs to the active session; if concurrent Codex sessions exist, the wrong file may be selected
+- Falls back to the newest file if only one session exists
+- Extracts the last assistant message text using jq
+- Outputs raw markdown to stdout
+- Accepts an explicit rollout file path as an argument to bypass auto-detection when precision matters
+
+If the script fails (no sessions, no messages), inform the user and stop.
+If the user reports that the wrong content was extracted, ask them to provide the rollout file path
+explicitly: `$SCRIPT_DIR/extract-last-message.sh /path/to/rollout.jsonl`
+
+Capture the output and write it to a temp file:
+
+```bash
+TMPBASE="${TMPDIR:-/tmp}"
+PLAN_FILE=$(mktemp "$TMPBASE/revdiff-plan-XXXXXX.md")
+$SCRIPT_DIR/extract-last-message.sh --skip-current > "$PLAN_FILE"
+```
+
+### Step 2: Launch Review
+
+Run the launcher script with `--only=<tempfile>`:
+
+```bash
+$LAUNCHER_DIR/launch-revdiff.sh --only="$PLAN_FILE"
+```
+
+**IMPORTANT -- long-running command**: The launcher blocks until the user finishes reviewing in the TUI overlay. Set the bash timeout parameter to the **maximum your harness allows** (e.g. 1800000 or higher). Do NOT use `run_in_background`.
+
+If the bash tool reports a timeout, use the same fallback as the revdiff skill:
+
+1. Tell the user: "The bash tool timed out, but revdiff may still be open. Let me know when you're done reviewing."
+2. Wait for the user to reply.
+3. Read the most recent output file:
+   ```bash
+   output_file="$(ls -t "${TMPDIR:-/tmp}"/revdiff-output-* 2>/dev/null | head -1)"
+   if [ -n "$output_file" ] && [ -f "$output_file" ]; then
+     cat "$output_file"
+   fi
+   ```
+
+### Step 3: Process Annotations
+
+If the launcher produces output, the user made annotations. The output format is:
+
+```
+## plan-XXXXXX.md:12 ( )
+this section needs more detail about error handling
+
+## plan-XXXXXX.md:25 ( )
+explain why we chose this approach over alternatives
+```
+
+Each annotation block has:
+- `## filename:line (type)` -- which file and line
+- Comment text below -- what the user wants changed or clarified
+
+### Step 3.5: Classify Annotations
+
+Split annotations into two categories:
+
+**Explanation requests** -- annotation text starts with (case-insensitive): `explain`, `remind`, `describe`, `what is`, `what are`, `how does`, `how do`, `clarify`. These are questions the user wants answered, not plan changes.
+
+**Plan-change directives** -- everything else. These are instructions to modify the plan content.
+
+**If explanation requests are found:**
+
+1. Answer each explanation request directly
+2. If there are also plan-change directives, note them as pending
+3. Enter the **explanation loop**:
+
+   a. Write the explanation to a temp markdown file
+   b. Launch revdiff with `--only=<explanation-file>` via the launcher script
+   c. If user quits without annotations -- explanation accepted, proceed to pending directives or Step 5
+   d. If user annotates -- refine explanation, loop back to (b)
+
+**If no explanation requests** -- proceed directly to Step 4.
+
+### Step 4: Address Annotations
+
+For plan-change directives:
+- Update the temp plan file with the requested changes
+- Rewrite `$PLAN_FILE` with the updated content
+
+### Step 5: Loop
+
+After addressing annotations, re-launch revdiff with the updated plan:
+
+```bash
+$LAUNCHER_DIR/launch-revdiff.sh --only="$PLAN_FILE"
+```
+
+The user can:
+- Add more annotations -- go back to Step 3
+- Quit without annotations -- review complete
+
+### Step 6: Done
+
+When the launcher produces no output, the review is complete.
+
+Clean up the temp file:
+
+```bash
+rm -f "$PLAN_FILE"
+```
+
+Inform the user that the plan review is complete. If the plan was modified during the review, present the final version.

--- a/plugins/codex/skills/revdiff-plan/scripts/extract-last-message.sh
+++ b/plugins/codex/skills/revdiff-plan/scripts/extract-last-message.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# extract the last assistant message from a Codex rollout file.
+# source: codex-specific, no Claude Code equivalent.
+#
+# usage: extract-last-message.sh [--skip-current] [rollout-file]
+#   --skip-current  best-effort heuristic: use the second most recent rollout file
+#                   by mtime instead of the newest. assumes the newest file belongs
+#                   to the active session. may select the wrong file if concurrent
+#                   codex sessions exist. use an explicit path argument for precision.
+#   rollout-file    explicit path to a rollout JSONL file (overrides auto-detection)
+# output: raw markdown text of the last assistant response (exits 1 with error to stderr if none found)
+
+set -euo pipefail
+
+# check jq is available
+if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq is required but not installed" >&2
+    echo "install: brew install jq (or see https://jqlang.github.io/jq/download/)" >&2
+    exit 1
+fi
+
+SKIP_CURRENT=false
+if [ "${1:-}" = "--skip-current" ]; then
+    SKIP_CURRENT=true
+    shift
+fi
+
+# explicit file path takes precedence over auto-detection
+if [ -n "${1:-}" ]; then
+    if [ ! -f "$1" ]; then
+        echo "error: rollout file not found: $1" >&2
+        exit 1
+    fi
+    ROLLOUT="$1"
+else
+    SESSIONS_DIR="${HOME}/.codex/sessions"
+    if [ ! -d "$SESSIONS_DIR" ]; then
+        echo "error: codex sessions directory not found: $SESSIONS_DIR" >&2
+        echo "hint: run a codex session first to generate rollout files" >&2
+        exit 1
+    fi
+
+    # find rollout files by modification time.
+    # track both newest and second-newest for --skip-current support.
+    # paths mix flat and hierarchical layouts, so lexicographic sort is unreliable.
+    # use -nt (newer than) comparison to avoid macOS xargs running ls with no args when find is empty.
+    NEWEST=""
+    SECOND=""
+    while IFS= read -r -d '' f; do
+        if [ -z "$NEWEST" ] || [ "$f" -nt "$NEWEST" ]; then
+            SECOND="$NEWEST"
+            NEWEST="$f"
+        elif [ -z "$SECOND" ] || [ "$f" -nt "$SECOND" ]; then
+            SECOND="$f"
+        fi
+    done < <(find "$SESSIONS_DIR" -name '*rollout*.jsonl' -type f -print0 2>/dev/null)
+
+    if [ -z "$NEWEST" ]; then
+        echo "error: no rollout files found in $SESSIONS_DIR" >&2
+        exit 1
+    fi
+
+    # when --skip-current is set and a second file exists, use it to avoid
+    # extracting the active session's own assistant output.
+    if $SKIP_CURRENT && [ -n "$SECOND" ]; then
+        ROLLOUT="$SECOND"
+    else
+        ROLLOUT="$NEWEST"
+    fi
+fi
+
+# extract last assistant message text from the rollout JSONL.
+# each line is a JSON object; assistant messages have:
+#   type: "response_item", payload.type: "message", payload.role: "assistant"
+#   payload.content[].type: "output_text", payload.content[].text: "<message>"
+# slurp all output_text entries and take the last one to preserve multi-line content.
+MSG=$(jq -s -r '
+    [.[]
+     | select(.type == "response_item"
+         and .payload.type == "message"
+         and .payload.role == "assistant")
+     | .payload.content[]
+     | select(.type == "output_text")
+     | .text
+    ] | last // empty
+' "$ROLLOUT" 2>/dev/null)
+
+if [ -z "$MSG" ]; then
+    echo "error: no assistant messages found in $ROLLOUT" >&2
+    exit 1
+fi
+
+printf '%s\n' "$MSG"

--- a/plugins/codex/skills/revdiff/SKILL.md
+++ b/plugins/codex/skills/revdiff/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: revdiff
+description: Review diffs, files, and documents with inline annotations in a TUI overlay, or answer questions about revdiff usage, configuration, themes, and keybindings. Opens revdiff in tmux/zellij/kitty/wezterm/cmux/ghostty/iterm2/emacs-vterm, captures annotations, and addresses them. Activates on "revdiff", "review diff", "annotate diff", "git review with revdiff", "interactive diff review", "revdiff all files", "review all files", "browse all files", "revdiff config", "revdiff themes", "revdiff keybindings", "how to configure revdiff", "what themes does revdiff have".
+argument-hint: 'optional: git ref(s), "all files", or file path'
+allowed-tools: [Bash, Read, Edit, Write, Grep, Glob]
+---
+
+# revdiff - TUI Diff Review
+
+Review git diffs with inline annotations using revdiff TUI in a terminal overlay.
+
+## Script Path Resolution
+
+Resolve the script directory using repo root first, then fall back to Codex home:
+
+```bash
+SCRIPT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/codex/skills/revdiff/scripts"
+if [ ! -d "$SCRIPT_DIR" ]; then
+    SCRIPT_DIR="${CODEX_HOME:-$HOME/.codex}/plugins/revdiff/skills/revdiff/scripts"
+fi
+```
+
+Use `$SCRIPT_DIR` in place of script paths throughout this skill.
+
+## Activation Triggers
+
+- "revdiff", "review diff", "annotate diff"
+- "revdiff HEAD~1", "revdiff main"
+- "revdiff all files", "review all files", "browse all files"
+- "revdiff all files exclude vendor"
+
+## Answering Questions
+
+If the user asks a question about revdiff (configuration, themes, keybindings, installation, usage) rather than requesting a review session, consult the reference files in `references/` and answer directly. Do NOT launch the TUI for informational questions.
+
+- `references/install.md` — installation methods and plugin setup
+- `references/config.md` — config file, options, colors, chroma themes
+- `references/usage.md` — examples, key bindings, output format
+
+## How It Works
+
+1. Launch revdiff in a terminal overlay (tmux popup, Zellij floating pane, kitty overlay, wezterm/Kaku split-pane, cmux split, ghostty split+zoom, iTerm2 split pane, or Emacs vterm frame)
+2. User navigates the diff, adds annotations on specific lines
+3. On quit, annotations are captured from stdout
+4. Codex reads annotations and addresses each one
+5. Loop: re-launch revdiff to verify fixes, user can add more annotations
+6. Done when user quits without annotations
+
+## Workflow
+
+### Step 0: Verify Installation
+
+```bash
+which revdiff
+```
+
+If not found, guide installation:
+- `brew install umputun/apps/revdiff`
+- Binary releases: https://github.com/umputun/revdiff/releases
+
+### Step 1: Determine Review Mode
+
+**All-files mode**: If `$ARGUMENTS` matches "all files", "all-files", or "browse all files" (with optional "exclude <prefix>" parts), use **all-files mode**:
+- Pass `--all-files` to the launcher
+- If user mentions exclude patterns (e.g., "exclude vendor", "exclude vendor and mocks"), pass each as `--exclude=<prefix>`
+- Skip ref detection entirely, go directly to Step 2
+- Example: "all files exclude vendor" → `--all-files --exclude=vendor`
+
+**File review mode**: If `$ARGUMENTS` is a file path (e.g., `docs/plans/feature.md`, `/tmp/notes.txt`):
+- Skip ref detection entirely
+- Go directly to Step 2 with `--only=<filepath>` (no ref argument)
+- Works both inside and outside a git repo — revdiff reads the file from disk as context-only
+
+**Ref mode**: If `$ARGUMENTS` contains explicit ref(s) (e.g., `HEAD~1`, `main`, or `main feature` for two-ref diff), use as-is.
+
+**Auto-detect**: If no ref provided, run the smart detection script:
+
+```bash
+$SCRIPT_DIR/detect-ref.sh
+```
+
+The script outputs structured fields:
+- `branch`, `main_branch`, `is_main`, `has_uncommitted`, `has_staged_only`
+- `suggested_ref` — the ref to pass to revdiff (empty = uncommitted changes)
+- `use_staged` — if `true`, pass `--staged` to the launcher (staged-only changes detected)
+- `needs_ask` — if `true`, ask the user before proceeding
+
+**When `use_staged: true`**, pass `--staged` to the launcher. This means all changes are in the index (staged) with nothing unstaged — without `--staged`, revdiff would show an empty diff.
+
+**When `needs_ask: true`** (on a feature branch with uncommitted changes), present the user with options as a numbered list and wait for their response:
+
+1. **Uncommitted only** — pass no ref (review just working changes)
+2. **Branch vs {main_branch}** — pass main_branch as ref (full branch diff including uncommitted)
+
+**When `needs_ask: false`**, use `suggested_ref` directly:
+- On main + uncommitted → no ref (uncommitted changes)
+- On main + staged only → no ref + `--staged` (staged changes)
+- On main + clean → `HEAD~1` (last commit)
+- On feature branch + clean → main branch name (full branch diff)
+
+### Step 2: Launch Review
+
+Run the launcher script:
+
+```bash
+$SCRIPT_DIR/launch-revdiff.sh [base] [against] [--staged] [--only=file1] [--all-files] [--exclude=prefix]
+```
+
+**IMPORTANT — long-running command**: The launcher blocks until the user finishes reviewing in the TUI overlay, which can exceed the default bash tool timeout. Set the bash timeout parameter to the **maximum your harness allows** (e.g. 1800000 or higher). Do NOT use `run_in_background` for this — background-task handling is unreliable for interactive TUI launchers. If the review outlasts the timeout cap, the fallback in Step 3 handles it.
+
+The script:
+- Detects available terminal (tmux → Zellij → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm)
+- Launches revdiff in an overlay
+- Captures annotation output to a temp file
+- Prints captured annotations to stdout
+
+### Step 3: Process Annotations
+
+**Collecting launcher output**: In the normal case the launcher returns synchronously with annotations on stdout — process them as described below. If the bash tool instead reports a timeout, revdiff is almost certainly still open in the overlay. Do NOT retry the launcher. Use the fallback:
+
+1. Tell the user: "The bash tool timed out, but revdiff may still be open. Let me know when you're done reviewing."
+2. Wait for the user to reply. They cannot respond while the overlay has focus, so their reply confirms revdiff has exited.
+3. Read the most recent output file (the launcher writes to `$TMPDIR` when set, falling back to `/tmp`):
+   ```bash
+   output_file="$(ls -t "${TMPDIR:-/tmp}"/revdiff-output-* 2>/dev/null | head -1)"
+   if [ -n "$output_file" ] && [ -f "$output_file" ]; then
+     cat "$output_file"
+   fi
+   ```
+4. If it has content, process as annotations below. If empty or no file, the user quit without annotating.
+
+This fallback is safe because revdiff writes the output file atomically on exit — there is never a partial read.
+
+If the script produces output, the user made annotations. The output format is:
+
+```
+## file.go:43 (+)
+use errors.Is() instead of direct comparison
+
+## store.go:18 (-)
+don't remove this validation
+```
+
+Each annotation block has:
+- `## filename:line (type)` — which file and line, `(+)` = added, `(-)` = removed, `(file-level)` = file note
+- Comment text below — what the user wants changed
+
+### Step 3.5: Classify Annotations
+
+Split annotations into two categories:
+
+**Explanation requests** — annotation text starts with (case-insensitive): `explain`, `remind`, `describe`, `what is`, `what are`, `how does`, `how do`, `clarify`. These are questions the user wants answered, not code changes.
+
+**Code-change directives** — everything else. These are instructions to modify code.
+
+**If explanation requests are found:**
+
+1. Answer each explanation request — read the referenced code, generate a clear markdown explanation
+2. If there are also code-change directives in the same batch, note them as pending (they carry over to Step 4 after the explanation loop)
+3. Enter the **explanation loop**:
+
+   a. Write the explanation to a temp markdown file (e.g., `/tmp/revdiff-explain-XXXXXX.md`)
+   b. Launch revdiff with `--only=/tmp/revdiff-explain-XXXXXX.md` via the launcher script — this opens the explanation as a scrollable markdown view with TOC sidebar
+   c. **If user quits without annotations** → explanation accepted, clean up temp file, proceed:
+      - If pending code-change directives exist → go to Step 4
+      - Otherwise → go to Step 6 (re-launch revdiff with the original diff ref)
+   d. **If user annotates the explanation** → these are follow-up questions or clarification requests. Read the annotations, refine/extend the explanation markdown, write updated temp file, go back to step (b)
+
+The explanation loop continues until the user quits without annotating. This allows a natural back-and-forth dialogue where the user can ask for more detail or corrections on specific parts of the explanation.
+
+**If no explanation requests** — all annotations are code-change directives, proceed directly to Step 4.
+
+### Step 4: Plan Changes
+
+Write the plan as a markdown list analyzing code-change annotations:
+- List each annotation with file and line reference
+- Describe the planned change for each
+- Ask the user: "Proceed with these changes?"
+
+Wait for user confirmation before modifying code.
+
+### Step 5: Address Annotations
+
+After user approves the plan, fix the actual source code. Each annotation is a directive.
+
+### Step 6: Loop
+
+After fixing (or after "Continue review" from Step 3.5), run the launcher script again with the same ref. The user can:
+- Add more annotations → go back to Step 3
+- Quit without annotations → review complete (no output)
+
+### Step 7: Done
+
+When the script produces no output, the review is complete. Inform the user.
+
+## Example Sessions
+
+```
+User: "revdiff HEAD~1"
+→ launch revdiff in tmux popup with HEAD~1 diff
+→ user annotates: "handler.go:43 - use errors.Is()"
+→ user quits
+→ annotations captured
+→ plan changes: "add errors.Is() check at handler.go:43"
+→ user approves
+→ fix applied
+→ re-launch revdiff HEAD~1
+→ user sees fix, quits without annotations
+→ "review complete"
+```
+
+```
+User: "revdiff HEAD~3"
+→ launch revdiff in tmux popup with HEAD~3 diff
+→ user annotates: "server.go:72 - explain what this mutex protects"
+→ user quits
+→ annotation classified as explanation request (starts with "explain")
+→ Codex reads server.go:72, generates markdown explanation
+→ writes to /tmp/revdiff-explain-XXXXXX.md
+→ launch revdiff --only=/tmp/revdiff-explain-XXXXXX.md (explanation view with TOC)
+→ user reads explanation, annotates: "what about the race condition on line 80?"
+→ Codex refines explanation, rewrites temp file
+→ re-launch revdiff --only=/tmp/revdiff-explain-XXXXXX.md
+→ user reads updated explanation, quits without annotations
+→ explanation accepted, clean up temp file
+→ re-launch revdiff HEAD~3 (back to diff review)
+→ user quits without annotations
+→ "review complete"
+```
+
+```
+User: "revdiff all files exclude vendor"
+→ launch revdiff with --all-files --exclude=vendor
+→ user browses all tracked files, annotates as needed
+→ same annotation loop as above
+```

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -45,9 +45,9 @@ Then uncomment and edit the values you want to change.
 | `--config` | `REVDIFF_CONFIG` | Path to config file | `~/.config/revdiff/config` |
 | `--dump-config` | | Print default config to stdout and exit | |
 
-## Popup Size (Claude Code plugin)
+## Popup Size (plugin overlay)
 
-When launched via the Claude Code plugin skill, revdiff opens in a terminal overlay. The popup size is configurable via env vars:
+When launched via the plugin skill, revdiff opens in a terminal overlay. The popup size is configurable via env vars:
 
 | Env var | Description | Default |
 |---------|-------------|---------|

--- a/plugins/codex/skills/revdiff/references/install.md
+++ b/plugins/codex/skills/revdiff/references/install.md
@@ -1,0 +1,18 @@
+# Installation
+
+**Homebrew (macOS/Linux):**
+```bash
+brew install umputun/apps/revdiff
+```
+
+**Binary releases:** download from [GitHub Releases](https://github.com/umputun/revdiff/releases) (deb, rpm, archives for linux/darwin amd64/arm64).
+
+## Codex Plugin
+
+Install the revdiff Codex plugin from the marketplace or manually copy the `plugins/codex/` directory to your Codex plugins location.
+
+Use: `/revdiff [base] [against]` — opens review session in a terminal overlay (tmux, Zellij, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm).
+
+### Plan Review
+
+Use `/revdiff-plan` to extract the last Codex assistant message and open it in revdiff for annotation review.

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -1,0 +1,171 @@
+# Usage
+
+```
+revdiff [OPTIONS] [base] [against]
+```
+
+## Examples
+
+```bash
+revdiff              # review uncommitted changes
+revdiff main         # review changes against a branch
+revdiff --staged     # review staged changes
+revdiff HEAD~1       # review last commit
+revdiff main feature # diff between two refs
+revdiff main..feature  # same as above, git dot-dot syntax
+revdiff main...feature # changes since feature diverged from main
+revdiff --only=model.go              # review only files matching model.go
+revdiff --only=ui/model.go --only=README.md  # review specific files
+revdiff --all-files                  # browse all git-tracked files in a project
+revdiff --all-files --exclude vendor # browse all files, excluding vendor directory
+revdiff main --exclude vendor        # diff against main, excluding vendor
+revdiff --only=/tmp/plan.md          # review a file outside a git repo (context-only)
+revdiff --only=docs/notes.txt        # review a file with no git changes (context-only)
+printf '# Plan\n\nBody\n' | revdiff --stdin --stdin-name plan.md  # review piped text as markdown
+some-command | revdiff --stdin --output /tmp/annotations.txt      # annotate generated output
+```
+
+## Single-File Mode
+
+When a diff contains exactly one file, revdiff automatically hides the file tree pane and gives full terminal width to the diff view. Pane-switching keys (`Tab`, `h/l`, `n/p`, `f`) become no-ops, except when markdown TOC is active (see below). Search navigation (`n`/`N`) still works normally.
+
+## Markdown TOC Navigation
+
+When reviewing a single markdown file in context-only mode (e.g., `revdiff --only=README.md`), a table-of-contents pane appears on the left listing all markdown headers with indentation by level. Use `Tab` to switch between TOC and diff, `j`/`k` to navigate headers, `n`/`p` to jump to next/prev header from either pane, `Enter` to jump to a header. The TOC highlights the current section as you scroll. Headers inside fenced code blocks are excluded.
+
+## All-Files Mode
+
+Use `--all-files` (`-A`) to browse all git-tracked files, not just diffs. Turns revdiff into a general-purpose code annotation tool. All files shown in context-only mode with full annotation and syntax highlighting support.
+
+- Requires a git repository (uses `git ls-files` for file discovery)
+- Mutually exclusive with refs, `--staged`, and `--only`
+- Combine with `--exclude` (`-X`) to filter out paths by prefix matching
+
+```bash
+revdiff --all-files                          # all tracked files
+revdiff --all-files --exclude vendor         # skip vendor/
+revdiff --all-files --exclude vendor --exclude mocks  # skip both
+revdiff main --exclude vendor                # normal diff, excluding vendor
+```
+
+`--exclude` can be persisted in config file (`exclude = vendor`) or via env var (`REVDIFF_EXCLUDE=vendor,mocks`).
+
+## Context-Only File Review
+
+When `--only` specifies a file that has no git changes (or when no git repo exists), revdiff shows the file in context-only mode: all lines displayed without `+`/`-` markers, with full annotation and syntax highlighting support.
+
+- **Inside a git repo**: `--only` files not in the diff are read from disk alongside changed files
+- **Outside a git repo**: `--only` is required; files are read directly from disk
+
+## Scratch-Buffer Review
+
+Use `--stdin` to review arbitrary piped or redirected text as one synthetic file. All lines are treated as context, so single-file mode, inline annotations, file-level notes, search, wrap, collapsed mode, and structured output all work unchanged.
+
+- `--stdin` is explicit and requires piped or redirected input
+- `--stdin-name` sets the synthetic filename used in annotations and syntax highlighting
+- `--stdin` conflicts with refs, `--staged`, `--only`, `--all-files`, and `--exclude`
+
+## Key Bindings
+
+**Navigation:**
+
+| Key | Action |
+|-----|--------|
+| `j/k` or up/down | Navigate files (tree) / scroll diff (diff pane) |
+| `h/l` | Switch between file tree and diff pane |
+| left/right | Horizontal scroll in diff pane |
+| `Tab` | Switch between file tree and diff pane |
+| `PgDown/PgUp` | Page scroll in file tree and diff pane |
+| `Ctrl+d/Ctrl+u` | Half-page scroll in file tree and diff pane |
+| `Home/End` | Jump to first/last item |
+| `Enter` | Switch to diff pane (tree) / start annotation (diff pane) |
+| `n/p` | Next/previous changed file; next/prev header in markdown TOC mode (n = next match when search active) |
+| `[` / `]` | Jump to previous/next change hunk in diff |
+
+**Search:**
+
+| Key | Action |
+|-----|--------|
+| `/` | Start search in diff pane |
+| `n` | Next search match (overrides next file when search active) |
+| `N` | Previous search match |
+| `Esc` | Cancel search input / clear search results |
+
+**Annotations:**
+
+| Key | Action |
+|-----|--------|
+| `a` or `Enter` (diff pane) | Annotate current diff line |
+| `A` | Add file-level annotation (stored at top of diff) |
+| `@` | Toggle annotation list popup (navigate and jump to any annotation) |
+| `d` | Delete annotation under cursor |
+| `Esc` | Cancel annotation input |
+
+**View:**
+
+| Key | Action |
+|-----|--------|
+| `v` | Toggle collapsed diff mode (shows final text with change markers) |
+| `w` | Toggle word wrap (long lines wrap with `↪` continuation markers) |
+| `t` | Toggle tree/TOC pane visibility (gives diff full terminal width) |
+| `L` | Toggle line numbers (side-by-side old/new numbers in gutter) |
+| `B` | Toggle git blame gutter (author name + commit age per line) |
+| `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
+| `T` | Open theme selector with live preview |
+| `f` | Toggle filter: all files / annotated only |
+| `?` | Toggle help overlay showing all keybindings |
+| `q` | Quit, output annotations to stdout |
+| `Q` | Discard all annotations and quit (confirms if annotations exist) |
+
+## Custom Keybindings
+
+All keybindings can be customized via `~/.config/revdiff/keybindings` (override path with `--keys` or `REVDIFF_KEYS`).
+
+```
+# map <key> <action> — bind a key
+# unmap <key> — remove a default binding
+map x quit
+unmap q
+map ctrl+d half_page_down
+```
+
+Generate a template with all defaults: `revdiff --dump-keys > ~/.config/revdiff/keybindings`
+
+See the [configuration reference](config.md) for the full list of available actions.
+
+## Output Format
+
+On quit, revdiff outputs annotations to stdout:
+
+```
+## handler.go (file-level)
+consider splitting this file into smaller modules
+
+## handler.go:43 (+)
+use errors.Is() instead of direct comparison
+
+## handler.go:43-67 (+)
+refactor this hunk to reduce nesting
+
+## store.go:18 (-)
+don't remove this validation
+```
+
+Each annotation block: `## filename:line[-end] (type)` where type is `(+)` added, `(-)` removed, or `(file-level)`. The `-end` suffix is included when the annotation covers a line range.
+
+When annotation text contains the keyword "hunk" (case-insensitive, whole word), the output header automatically expands to include the full hunk line range (e.g., `handler.go:43-67 (+)` instead of `handler.go:43 (+)`). This gives AI consumers the range context without any extra steps.
+
+Use `--output` / `-o` flag to write annotations to a file instead of stdout.
+
+## Review History
+
+When you quit with annotations (`q`), revdiff automatically saves a copy of the review session to `~/.config/revdiff/history/<repo-name>/<timestamp>.md`. This is a safety net — if annotations are lost (process crash, agent fails to capture stdout), the history file preserves them.
+
+Each history file contains:
+- Header with path, git refs, and commit hash
+- Full annotation output (same format as stdout)
+- Raw git diff for annotated files only
+
+History auto-save is always on and silent — errors are logged to stderr, never fail the process. No history is saved on discard quit (`Q`) or when there are no annotations. For `--stdin` mode, files are saved under `stdin/` subdirectory; for `--only` without git, the parent directory name is used instead of a repo name.
+
+Override the history directory with `--history-dir`, `REVDIFF_HISTORY_DIR` env var, or `history-dir` in the config file.

--- a/plugins/codex/skills/revdiff/scripts/detect-ref.sh
+++ b/plugins/codex/skills/revdiff/scripts/detect-ref.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# detect-ref.sh - smart ref detection for revdiff skill.
+# source: .claude-plugin/skills/revdiff/scripts/detect-ref.sh (keep in sync)
+#
+# outputs structured info about the current git state so the skill can decide
+# what ref to use or whether to ask the user.
+#
+# output fields:
+#   branch: current branch name
+#   main_branch: detected main/master branch name
+#   is_main: true/false (whether current branch is main/master)
+#   has_uncommitted: true/false
+#   has_staged_only: true/false (changes are staged but nothing unstaged)
+#   suggested_ref: the ref to use (empty = uncommitted, HEAD~1, main branch name, or --all-files for no-commits repos)
+#   use_staged: true/false (pass --staged to revdiff)
+#   needs_ask: true/false (whether the skill should ask the user)
+
+set -euo pipefail
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# detect main branch name from remote HEAD, fallback to master/main check
+main_branch=""
+if remote_head=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null); then
+    main_branch="${remote_head##refs/remotes/origin/}"
+elif git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    main_branch="master"
+elif git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    main_branch="main"
+fi
+
+is_main="false"
+if [ "$branch" = "$main_branch" ]; then
+    is_main="true"
+fi
+
+has_uncommitted="false"
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    has_uncommitted="true"
+fi
+
+# distinguish staged-only vs unstaged changes
+has_unstaged="false"
+if ! git diff --quiet 2>/dev/null; then
+    has_unstaged="true"
+fi
+has_staged_only="false"
+if [ "$has_uncommitted" = "true" ] && [ "$has_unstaged" = "false" ]; then
+    if ! git diff --cached --quiet 2>/dev/null; then
+        has_staged_only="true"
+    fi
+fi
+
+# detect no-commits state (fresh repo after git init)
+has_commits="true"
+if ! git rev-parse HEAD >/dev/null 2>&1; then
+    has_commits="false"
+fi
+
+# decision logic
+suggested_ref=""
+needs_ask="false"
+
+use_staged="false"
+if [ "$has_commits" = "false" ]; then
+    suggested_ref="--all-files" # no commits yet, browse staged files
+elif [ "$is_main" = "true" ]; then
+    if [ "$has_uncommitted" = "true" ]; then
+        if [ "$has_staged_only" = "true" ]; then
+            use_staged="true" # staged-only changes on main
+        fi
+        suggested_ref="" # uncommitted changes on main
+    else
+        suggested_ref="HEAD~1" # last commit on main
+    fi
+else
+    if [ "$has_uncommitted" = "true" ]; then
+        needs_ask="true" # ambiguous: uncommitted on feature branch
+        if [ "$has_staged_only" = "true" ]; then
+            use_staged="true"
+        fi
+    else
+        suggested_ref="$main_branch" # clean feature branch → diff against main
+    fi
+fi
+
+echo "branch: $branch"
+echo "main_branch: $main_branch"
+echo "is_main: $is_main"
+echo "has_uncommitted: $has_uncommitted"
+echo "has_staged_only: $has_staged_only"
+echo "suggested_ref: $suggested_ref"
+echo "use_staged: $use_staged"
+echo "needs_ask: $needs_ask"

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# launch revdiff in a terminal overlay (tmux/zellij/kitty/wezterm/cmux/ghostty/iterm2) and capture annotations.
+# source: .claude-plugin/skills/revdiff/scripts/launch-revdiff.sh (keep in sync)
+#
+# usage: launch-revdiff.sh [ref] [--staged] [--only=file1 ...]
+# output: annotation text from revdiff stdout (empty if no annotations)
+
+set -euo pipefail
+
+# resolve revdiff to absolute path so overlay shells (sh -c) can find it
+# even when /opt/homebrew/bin or similar dirs are not in sh's default PATH
+REVDIFF_BIN=$(command -v revdiff 2>/dev/null || true)
+if [ -z "$REVDIFF_BIN" ]; then
+    echo "error: revdiff not found in PATH" >&2
+    echo "install: brew install umputun/apps/revdiff (or download from https://github.com/umputun/revdiff/releases)" >&2
+    exit 1
+fi
+
+TMPBASE="${TMPDIR:-/tmp}"
+OUTPUT_FILE=$(mktemp "$TMPBASE/revdiff-output-XXXXXX")
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+# shell-quote a single argument for safe embedding in sh -c strings.
+sq() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+REVDIFF_CMD="$(sq "$REVDIFF_BIN")"
+if [ -n "${REVDIFF_CONFIG:-}" ] && [ -f "$REVDIFF_CONFIG" ]; then
+    REVDIFF_CMD="$REVDIFF_CMD $(sq "--config=$REVDIFF_CONFIG")"
+fi
+REVDIFF_CMD="$REVDIFF_CMD $(sq "--output=$OUTPUT_FILE")"
+for arg in "$@"; do
+    REVDIFF_CMD="$REVDIFF_CMD $(sq "$arg")"
+done
+CWD="$(pwd)"
+
+# build descriptive title: "rd: dirname [ref]"
+DIR_NAME=$(basename "$CWD")
+TITLE_REF=""
+SKIP_NEXT=0
+for arg in "$@"; do
+    if [ "$SKIP_NEXT" -eq 1 ]; then SKIP_NEXT=0; continue; fi
+    case "$arg" in
+        -o|--output) SKIP_NEXT=1 ;;
+        --output=*) ;;
+        -*) ;;
+        *) TITLE_REF="$arg"; break ;;
+    esac
+done
+OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
+
+# popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux and wezterm)
+POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
+POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
+
+# tmux: display-popup -E blocks until command exits
+if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+    # -T (title) requires tmux 3.3+; skip on older versions
+    TMUX_ARGS=(tmux display-popup -E -w "$POPUP_W" -h "$POPUP_H")
+    if [[ "$(tmux -V 2>/dev/null)" =~ ([0-9]+)\.([0-9]+) ]]; then
+        if [ "${BASH_REMATCH[1]}" -gt 3 ] || { [ "${BASH_REMATCH[1]}" -eq 3 ] && [ "${BASH_REMATCH[2]}" -ge 3 ]; }; then
+            TMUX_ARGS+=(-T " $OVERLAY_TITLE ")
+        fi
+    fi
+    TMUX_ARGS+=(-d "$CWD" -- sh -c "$REVDIFF_CMD")
+    "${TMUX_ARGS[@]}"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# zellij: floating pane with sentinel file for blocking
+if [ -n "${ZELLIJ:-}" ] && command -v zellij >/dev/null 2>&1; then
+    SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+    rm -f "$SENTINEL"
+
+    LAUNCH_SCRIPT=$(mktemp "$TMPBASE/revdiff-launch-XXXXXX.sh")
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+$REVDIFF_CMD; touch '$SENTINEL'
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    ZELLIJ_W="${POPUP_W%%%}"
+    ZELLIJ_H="${POPUP_H%%%}"
+    zellij run --floating --close-on-exit \
+        --width "$ZELLIJ_W" --height "$ZELLIJ_H" \
+        --name "$OVERLAY_TITLE" --cwd "$CWD" \
+        -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# kitty: overlay with sentinel file for blocking
+KITTY_SOCK="${KITTY_LISTEN_ON:-}"
+if [ -n "$KITTY_SOCK" ] && command -v kitty >/dev/null 2>&1; then
+    SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+    rm -f "$SENTINEL"
+
+    KITTY_ARGS=(kitty @ --to "$KITTY_SOCK" launch --type=overlay --title="$OVERLAY_TITLE" --cwd="$CWD")
+    if [ -n "${KITTY_WINDOW_ID:-}" ]; then
+        KITTY_ARGS+=(--match "window_id:${KITTY_WINDOW_ID}")
+    fi
+    KITTY_ARGS+=(sh -c "$REVDIFF_CMD; touch $(sq "$SENTINEL")")
+
+    "${KITTY_ARGS[@]}" >/dev/null 2>&1
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    rm -f "$SENTINEL"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# wezterm/kaku: split-pane with sentinel file for blocking
+if [ -n "${WEZTERM_PANE:-}" ]; then
+    WEZTERM_CLI=()
+    if command -v wezterm >/dev/null 2>&1; then
+        WEZTERM_CLI=(wezterm cli)
+    elif command -v kaku >/dev/null 2>&1; then
+        WEZTERM_CLI=(kaku cli)
+    fi
+
+    if [ ${#WEZTERM_CLI[@]} -gt 0 ]; then
+        SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+        rm -f "$SENTINEL"
+
+        WEZTERM_PCT="${REVDIFF_POPUP_HEIGHT:-90%}"
+        WEZTERM_PCT="${WEZTERM_PCT%%%}"
+        "${WEZTERM_CLI[@]}" split-pane --bottom --percent "$WEZTERM_PCT" \
+            --pane-id "$WEZTERM_PANE" --cwd "$CWD" -- sh -c "$REVDIFF_CMD; touch $(sq "$SENTINEL")" >/dev/null 2>&1
+
+        while [ ! -f "$SENTINEL" ]; do
+            sleep 0.3
+        done
+        rm -f "$SENTINEL"
+        cat "$OUTPUT_FILE"
+        exit 0
+    fi
+fi
+
+# cmux: split pane via cmux CLI (must precede ghostty — cmux also sets TERM_PROGRAM=ghostty)
+if [ -n "${CMUX_SURFACE_ID:-}" ] && command -v cmux >/dev/null 2>&1; then
+    SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+    rm -f "$SENTINEL"
+
+    LAUNCH_SCRIPT=$(mktemp "$TMPBASE/revdiff-launch-XXXXXX.sh")
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+$REVDIFF_CMD; touch $(sq "$SENTINEL")
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    # capture new surface ref from "OK surface:N ..." output
+    CMUX_NEW=$(cmux new-split down 2>&1) || true
+    CMUX_SURF=$(echo "$CMUX_NEW" | grep -o 'surface:[0-9]*' | head -1)
+
+    # send exec command immediately — the pty input buffer holds the text
+    # until the new pane's shell finishes initializing and reads it
+    if [ -n "$CMUX_SURF" ]; then
+        cmux send --surface "$CMUX_SURF" "exec $(sq "$LAUNCH_SCRIPT")\n" >/dev/null 2>&1
+    else
+        cmux send "exec $(sq "$LAUNCH_SCRIPT")\n" >/dev/null 2>&1
+    fi
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    # close the split pane
+    if [ -n "$CMUX_SURF" ]; then
+        cmux close-surface --surface "$CMUX_SURF" 2>/dev/null || true
+    fi
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# ghostty: split pane via AppleScript (macOS only, requires Ghostty 1.3.0+)
+if [ "${TERM_PROGRAM:-}" = "ghostty" ] && command -v osascript >/dev/null 2>&1; then
+
+    SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+    rm -f "$SENTINEL"
+
+    LAUNCH_SCRIPT=$(mktemp "$TMPBASE/revdiff-launch-XXXXXX.sh")
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+$REVDIFF_CMD; touch $(sq "$SENTINEL")
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" "$CWD" <<'APPLESCRIPT'
+on run argv
+    set launchScript to item 1 of argv
+    set cwd to item 2 of argv
+    tell application "Ghostty"
+        set cfg to new surface configuration
+        set command of cfg to launchScript
+        set initial working directory of cfg to cwd
+        set wait after command of cfg to false
+        set ft to focused terminal of selected tab of front window
+        set newTerm to split ft direction down with configuration cfg
+        perform action "toggle_split_zoom" on newTerm
+        return id of newTerm
+    end tell
+end run
+APPLESCRIPT
+    )
+    if [ $? -ne 0 ]; then
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        exit 1
+    fi
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    # close the split pane (dismisses "press any key" prompt)
+    osascript - "$GHOSTTY_TERM_ID" <<'APPLESCRIPT' 2>/dev/null
+on run argv
+    tell application "Ghostty" to close terminal id (item 1 of argv)
+end run
+APPLESCRIPT
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# iterm2: split pane via AppleScript (macOS only)
+if [ -n "${ITERM_SESSION_ID:-}" ] && command -v osascript >/dev/null 2>&1; then
+    SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+    rm -f "$SENTINEL"
+
+    # use launcher script to avoid single-quote injection in paths
+    LAUNCH_SCRIPT=$(mktemp "$TMPBASE/revdiff-launch-XXXXXX.sh")
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+cd "\$1" && $REVDIFF_CMD; touch "\$2"
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    # ITERM_SESSION_ID format is "w0t0p0:UUID"; AppleScript session id is the UUID part
+    ITERM_UUID="${ITERM_SESSION_ID##*:}"
+
+    # find target session by UUID, auto-detect split direction, capture new session id
+    ITERM_NEW_SESSION=$(osascript - "$ITERM_UUID" "$LAUNCH_SCRIPT" "$CWD" "$SENTINEL" <<'APPLESCRIPT' 2>&1
+on run argv
+    set targetId to item 1 of argv
+    set launchScript to item 2 of argv
+    set cwd to item 3 of argv
+    set sentinel to item 4 of argv
+    set cmd to quoted form of launchScript & " " & quoted form of cwd & " " & quoted form of sentinel
+    tell application id "com.googlecode.iterm2"
+        repeat with w in windows
+            repeat with t in tabs of w
+                repeat with s in sessions of t
+                    if id of s is targetId then
+                        set colCount to columns of s
+                        set rowCount to rows of s
+                        tell s
+                            if colCount >= 160 and colCount > (rowCount * 2) then
+                                set newSession to split vertically with same profile command cmd
+                            else
+                                set newSession to split horizontally with same profile command cmd
+                            end if
+                        end tell
+                        return id of newSession
+                    end if
+                end repeat
+            end repeat
+        end repeat
+    end tell
+    error "session not found: " & targetId
+end run
+APPLESCRIPT
+    ) || {
+        echo "error: failed to open iTerm2 split via osascript: $ITERM_NEW_SESSION" >&2
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        exit 1
+    }
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    # close the split pane to avoid a dead session
+    osascript - "$ITERM_NEW_SESSION" <<'APPLESCRIPT' 2>/dev/null
+on run argv
+    set sid to item 1 of argv
+    tell application id "com.googlecode.iterm2"
+        repeat with w in windows
+            repeat with t in tabs of w
+                repeat with s in sessions of t
+                    if id of s is sid then
+                        tell s to close
+                        return
+                    end if
+                end repeat
+            end repeat
+        end repeat
+    end tell
+end run
+APPLESCRIPT
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# emacs vterm: open revdiff in a new vterm buffer via emacsclient
+if [ "${INSIDE_EMACS:-}" = "vterm" ] && command -v emacsclient >/dev/null 2>&1; then
+    SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+    rm -f "$SENTINEL" && mkfifo "$SENTINEL"
+
+    # use launcher script to avoid shell interpolation issues in elisp strings;
+    # embed all paths directly so vterm-shell needs no arguments
+    LAUNCH_SCRIPT=$(mktemp "$TMPBASE/revdiff-launch-XXXXXX.sh")
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+cd $(sq "$CWD") && $REVDIFF_CMD; echo d > $(sq "$SENTINEL"); exit
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    # find calling vterm shell PID (direct child of Emacs) to tag caller frame
+    EMACS_PID=$(emacsclient --eval '(emacs-pid)' 2>/dev/null | tr -d '"')
+    VTERM_PID=$$
+    if [ -z "$EMACS_PID" ] || ! [ "$EMACS_PID" -gt 0 ] 2>/dev/null; then
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        echo "error: emacs server not reachable" >&2
+        exit 1
+    fi
+    while P=$(ps -o ppid= -p "$VTERM_PID" 2>/dev/null | tr -d ' '); [ "$P" != "$EMACS_PID" ] && [ "$P" != "1" ] && [ -n "$P" ]; do VTERM_PID=$P; done
+
+    # escape backslashes then double quotes for elisp string embedding
+    elisp_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+    ESCAPED_TITLE=$(elisp_escape "$OVERLAY_TITLE")
+    ESCAPED_SCRIPT=$(elisp_escape "$LAUNCH_SCRIPT")
+
+    emacsclient --eval "(progn (require 'cl-lib)
+      (when-let* ((b (cl-find-if (lambda (b) (let ((p (get-buffer-process b))) (and p (= (process-id p) $VTERM_PID)))) (buffer-list)))
+                  (w (get-buffer-window b t)))
+        (set-frame-parameter (window-frame w) 'revdiff-caller t))
+      (let* ((buf (generate-new-buffer \"*revdiff*\"))
+             (win (display-buffer buf '((display-buffer-pop-up-frame)
+                     (pop-up-frame-parameters . ((name . \"$ESCAPED_TITLE\")))))))
+        (set-frame-parameter (window-frame win) 'revdiff-buf (buffer-name buf))))" >/dev/null 2>&1
+    emacsclient --no-wait --eval "(progn (require 'cl-lib)
+      (when-let* ((f (cl-find-if (lambda (f) (string= (frame-parameter f 'name) \"$ESCAPED_TITLE\")) (frame-list)))
+                  (bn (frame-parameter f 'revdiff-buf))
+                  (buf (get-buffer bn)))
+        (with-current-buffer buf
+          (let ((vterm-shell \"$ESCAPED_SCRIPT\"))
+            (vterm-mode)))))" >/dev/null 2>&1
+
+    read -r < "$SENTINEL"
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    emacsclient --no-wait --eval "(progn (require 'cl-lib)
+      (when-let ((f (cl-find-if (lambda (f) (string= (frame-parameter f 'name) \"$ESCAPED_TITLE\")) (frame-list))))
+        (let ((bn (frame-parameter f 'revdiff-buf)))
+          (delete-frame f)
+          (when-let ((b (and bn (get-buffer bn)))) (kill-buffer b))))
+      (when-let ((f (cl-find-if (lambda (f) (frame-parameter f 'revdiff-caller)) (frame-list))))
+        (set-frame-parameter f 'revdiff-caller nil)
+        (select-frame-set-input-focus f)))" >/dev/null 2>&1
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+echo "error: no overlay terminal available (requires tmux, zellij, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm)" >&2
+exit 1

--- a/site/docs.html
+++ b/site/docs.html
@@ -87,6 +87,11 @@
         <a href="#plugin-autodetect">Auto-detection</a>
         <a href="#plugin-planning">Plan review plugin</a>
 
+        <h4>Codex plugin</h4>
+        <a href="#codex-install">Installation</a>
+        <a href="#codex-skills">Skills</a>
+        <a href="#codex-differences">Differences</a>
+
         <h4>Output</h4>
         <a href="#output-format">Output format</a>
         <a href="#integration">Integration</a>
@@ -94,7 +99,7 @@
 
     <main class="docs-content">
         <h1>Documentation</h1>
-        <p>Complete reference for revdiff usage, configuration, themes, keybindings, the pi package, and the Claude Code plugin.</p>
+        <p>Complete reference for revdiff usage, configuration, themes, keybindings, the pi package, the Claude Code plugin, and the Codex plugin.</p>
 
         <h2 id="requirements">Requirements</h2>
         <p><code>git</code> is used to generate diffs. It is optional when using <code>--only</code> for standalone file review or <code>--stdin</code> for scratch-buffer review.</p>
@@ -455,6 +460,33 @@ unmap q</code></div>
         <p>A separate <code>revdiff-planning</code> plugin automatically opens revdiff when Claude exits plan mode, letting you annotate the plan before approving it. If you add annotations, Claude revises the plan and asks again, looping until you're satisfied.</p>
         <div class="code-block"><code>/plugin install revdiff-planning@umputun-revdiff</code></div>
         <p>This plugin is independent from the main <code>revdiff</code> plugin and does not conflict with other planning plugins.</p>
+
+        <!-- codex plugin -->
+        <h2 id="codex-install">Codex plugin</h2>
+        <p>revdiff ships with a <a href="https://github.com/openai/codex">Codex CLI</a> plugin for interactive diff review and plan annotation directly from a Codex session.</p>
+        <div class="code-block"><code><span class="code-comment"># copy plugin to Codex plugins directory</span>
+cp -r plugins/codex ~/.codex/plugins/revdiff
+
+<span class="code-comment"># or, if working from a cloned repo, Codex discovers the plugin</span>
+<span class="code-comment"># automatically via .agents/plugins/marketplace.json</span></code></div>
+        <p>Requirements: <code>revdiff</code> binary on PATH, <code>jq</code> (for <code>/revdiff-plan</code>), and a supported terminal multiplexer.</p>
+
+        <h2 id="codex-skills">Skills</h2>
+        <p>The plugin provides two skills:</p>
+        <ul>
+            <li><code>/revdiff</code> &mdash; same diff review workflow as the Claude Code plugin (detect ref, launch overlay, capture annotations, feedback loop)</li>
+            <li><code>/revdiff-plan</code> &mdash; extracts the last Codex assistant message from session rollout files, opens it in revdiff for annotation, and feeds feedback back</li>
+        </ul>
+        <div class="code-block"><code>/revdiff              <span class="code-comment"># auto-detect ref</span>
+/revdiff HEAD~3       <span class="code-comment"># review last 3 commits</span>
+/revdiff-plan         <span class="code-comment"># review last Codex response</span></code></div>
+
+        <h2 id="codex-differences">Differences from Claude Code plugin</h2>
+        <ul>
+            <li>No hook-based automatic plan review &mdash; Codex lacks hook support, so plan review is manual via <code>/revdiff-plan</code></li>
+            <li>Uses Codex rollout files (<code>~/.codex/sessions/</code>) instead of Claude session logs for message extraction</li>
+            <li>Scripts are portable copies from the Claude Code plugin, not symlinks</li>
+        </ul>
 
         <!-- output -->
         <h2 id="output-format">Output format</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -3,22 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>revdiff — Code Review for AI Agents, Claude Code, and pi</title>
-    <meta name="description" content="TUI for code review in AI coding sessions. Review diffs, plans, and documents with inline annotations. Ships as a Claude Code plugin and a pi package.">
-    <meta name="keywords" content="code review for ai agents, code review for claude code, code review for pi, plan review for claude code, tui diff viewer, terminal code review, inline annotations, claude code plugin, pi package, ai code review tool">
+    <title>revdiff — Code Review for AI Agents, Claude Code, Codex, and pi</title>
+    <meta name="description" content="TUI for code review in AI coding sessions. Review diffs, plans, and documents with inline annotations. Ships as a Claude Code plugin, Codex plugin, and a pi package.">
+    <meta name="keywords" content="code review for ai agents, code review for claude code, code review for codex, code review for pi, plan review for claude code, tui diff viewer, terminal code review, inline annotations, claude code plugin, codex plugin, pi package, ai code review tool">
     <meta name="author" content="umputun">
     <link rel="canonical" href="https://revdiff.com/">
 
-    <meta property="og:title" content="revdiff — Code Review for AI Agents, Claude Code, and pi">
-    <meta property="og:description" content="TUI for code review in AI coding sessions. Review diffs, plans, and documents with inline annotations. Ships as a Claude Code plugin and a pi package.">
+    <meta property="og:title" content="revdiff — Code Review for AI Agents, Claude Code, Codex, and pi">
+    <meta property="og:description" content="TUI for code review in AI coding sessions. Review diffs, plans, and documents with inline annotations. Ships as a Claude Code plugin, Codex plugin, and a pi package.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://revdiff.com">
     <meta property="og:image" content="https://revdiff.com/assets/screenshot.png">
     <meta property="og:site_name" content="revdiff">
 
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="revdiff — Code Review for AI Agents, Claude Code, and pi">
-    <meta name="twitter:description" content="TUI for code review in AI coding sessions. Review diffs, plans, and documents with inline annotations. Ships as a Claude Code plugin and a pi package.">
+    <meta name="twitter:title" content="revdiff — Code Review for AI Agents, Claude Code, Codex, and pi">
+    <meta name="twitter:description" content="TUI for code review in AI coding sessions. Review diffs, plans, and documents with inline annotations. Ships as a Claude Code plugin, Codex plugin, and a pi package.">
     <meta name="twitter:image" content="https://revdiff.com/assets/screenshot.png">
 
     <script type="application/ld+json">
@@ -26,7 +26,7 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "revdiff",
-        "description": "TUI for reviewing diffs, files, and documents with inline annotations. Code review tool for AI agents, Claude Code, and pi.",
+        "description": "TUI for reviewing diffs, files, and documents with inline annotations. Code review tool for AI agents, Claude Code, Codex, and pi.",
         "url": "https://revdiff.com",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux",
@@ -316,6 +316,30 @@
 "review all files exclude vendor"   <span class="code-comment">-- browse project, skip vendor/</span>
 "what themes does revdiff support?" <span class="code-comment">-- ask about config without launching</span>
 "switch revdiff to dracula theme"   <span class="code-comment">-- modify config via conversation</span></code></div>
+        </div>
+    </div>
+</section>
+
+<section class="plugin">
+    <div class="section-inner">
+        <h2>Codex plugin</h2>
+        <p class="section-sub">Same diff review workflow for <a href="https://github.com/openai/codex">Codex CLI</a> sessions. Plus plan review via rollout file extraction.</p>
+        <div class="plugin-flow">
+            <div class="flow-step">
+                <div class="flow-num">1</div>
+                <div class="flow-text">
+                    <h3>Install</h3>
+                    <div class="code-block"><code>cp -r plugins/codex ~/.codex/plugins/revdiff</code></div>
+                </div>
+            </div>
+            <div class="flow-step">
+                <div class="flow-num">2</div>
+                <div class="flow-text">
+                    <h3>Review</h3>
+                    <div class="code-block"><code>/revdiff<br>/revdiff-plan</code></div>
+                    <p>Same <code>/revdiff</code> workflow as Claude Code. <code>/revdiff-plan</code> extracts the last Codex response for annotation.</p>
+                </div>
+            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
Adds a Codex CLI plugin with two skills for interactive diff review and plan annotation. Related to #84

**`revdiff` skill** — port of the Claude Code skill. Detects git ref, launches revdiff in a terminal overlay (tmux/kitty/wezterm/etc.), captures annotations, classifies them (explanation requests vs code-change directives), and feeds back to the agent in a loop.

**`revdiff-plan` skill** — manual plan review. Extracts the last Codex assistant message from the most recent rollout file (`~/.codex/sessions/`), writes it to a temp file, and opens it in revdiff with `--only=` for annotation. Annotations feed back as plan revision feedback.

**Key adaptations from the Claude Code version:**
- No `AskUserQuestion` — uses numbered list prompts and waits for user response
- No `EnterPlanMode` — presents plan as markdown and asks "proceed?"
- Script path resolution via `git rev-parse --show-toplevel` with `$CODEX_HOME` fallback
- Rollout message extraction via `jq` forward scan (no `tac`, macOS-safe)

**Plugin structure:** `plugins/codex/` with `.codex-plugin/plugin.json` manifest, marketplace entry at `.agents/plugins/marketplace.json`

*Tested by installing skills to `~/.codex/skills/` and running both skills in Codex CLI.*