### PR TITLE
feat: make intra-line word-diff highlighting opt-in

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -27,6 +27,7 @@ Then uncomment and edit the values you want to change.
 | `--collapsed` | `REVDIFF_COLLAPSED` | Start in collapsed diff mode | `false` |
 | `--line-numbers` | `REVDIFF_LINE_NUMBERS` | Show line numbers in diff gutter | `false` |
 | `--blame` | `REVDIFF_BLAME` | Show git blame gutter on startup | `false` |
+| `--word-diff` | `REVDIFF_WORD_DIFF` | Highlight intra-line word-level changes in paired add/remove lines | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
 | `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/` | |

--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -110,6 +110,7 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `t` | Toggle tree/TOC pane visibility (gives diff full terminal width) |
 | `L` | Toggle line numbers (side-by-side old/new numbers in gutter) |
 | `B` | Toggle git blame gutter (author name + commit age per line) |
+| `W` | Toggle intra-line word-diff highlighting for paired add/remove lines |
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
 | `f` | Toggle filter: all files / annotated only |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,13 +46,15 @@ git diff → diff.parseUnifiedDiff() → []DiffLine
   (or: disk file → diff.readFileAsContext() → []DiffLine, all ChangeContext)
   (or: stdin / arbitrary reader → diff.readReaderAsContext() → []DiffLine, all ChangeContext)
   → highlight.HighlightLines() → []string (ANSI foreground-only)
-  → recomputeIntraRanges(): pairs add/remove lines within hunks via pairHunkLines(),
+  → when m.wordDiff is true (opt-in via --word-diff flag or `W` toggle):
+    recomputeIntraRanges() pairs add/remove lines within hunks via pairHunkLines(),
     runs token-level LCS diff (changedTokenRanges) on each pair, stores [][]matchRange
     parallel to diffLines. 30% similarity gate discards ranges for dissimilar pairs.
     Ranges are byte offsets on tab-replaced content, aligning with prepareLineContent output.
+    When wordDiff is off, m.intraRanges stays nil and applyIntraLineHighlight is a no-op.
   → ui.renderDiff() dispatches:
     expanded (default): renderDiffLine() for each line
-      intra-line word-diff: when intraRanges[idx] is non-nil, insertHighlightMarkers()
+      intra-line word-diff: when intraRanges[idx] is non-nil, applyIntraLineHighlight()
       adds WordAddBg/WordRemoveBg ANSI bg markers around changed spans (reverse-video in no-color mode)
     collapsed (`v` toggle): renderCollapsedDiff() → skips removed lines,
       uses buildModifiedSet() to style adds as modify (amber ~) or pure add (green +)
@@ -144,7 +146,7 @@ git diff → diff.parseUnifiedDiff() → []DiffLine
 - Help overlay uses `overlayCenter()` (ANSI-aware compositing via `charmbracelet/x/ansi.Cut`) to render on top of existing content; background (tree pane) remains visible at the edges
 - **ANSI nesting with lipgloss**: `lipgloss.Render()` emits `\033[0m` (full reset) which breaks outer style backgrounds. For styled substrings inside a lipgloss container (status bar separators, search highlights, diff cursor, annotation lines), use raw ANSI sequences via `ansiColor(hex, code)` / `ansiFg(hex)` / `ansiBg(hex)`, or dedicated helpers `diffCursorCell()` and `annotationInline()`. Never use `lipgloss.NewStyle().Render()` for inline elements within a lipgloss-rendered parent.
 - **Background fill for themed panes**: lipgloss pane `Render()` and viewport internal padding emit plain spaces after `\033[0m` reset, causing pane background to show terminal default. Three workarounds: (1) `extendLineBg()` pads individual add/remove/modify lines to full content width with their specific bg color; (2) `padContentBg()` strips viewport trailing spaces and re-pads every line of pane content with DiffBg/TreeBg; (3) `BorderBackground()` is set on pane border styles to match pane bg. Context and line-number styles also set DiffBg explicitly via `contextStyle()`/`lineNumberStyle()`/`contextHighlightStyle()`. **Ordering constraint**: `extendLineBg()` must be called AFTER `applyHorizontalScroll()` — extending before scroll causes bg fill to be computed for the wrong visible width. `styleDiffContent()` does NOT call `extendLineBg` internally; callers handle it via `changeBgColor()`.
-- Status bar mode icons (`▼ ◉ ↩ ≋ ⊟ # @`) are always rendered on the right side via `statusModeIcons()`. `@` indicates blame gutter active via `B` toggle. `⊟` indicates tree/TOC pane hidden via `t` toggle. Active modes use `StatusFg`, inactive use `Muted` — both via raw ANSI fg sequences. Graceful degradation on narrow terminals drops left segments: search position first (`statusSegmentsNoSearch`), then line number and hunk info (`statusSegmentsMinimal`), then truncates filename.
+- Status bar mode icons (`▼ ◉ ↩ ≋ ⊟ # b ± ✓ ∅`) are always rendered on the right side via `statusModeIcons()`. `▼` collapsed mode (`v`), `◉` filter (`f`), `↩` wrap (`w`), `≋` search active, `⊟` tree/TOC pane hidden (`t`), `#` line numbers (`L`), `b` blame gutter (`B`), `±` intra-line word-diff (`W`), `✓` reviewed count, `∅` untracked visible (`u`). Active modes use `StatusFg`, inactive use `Muted` — both via raw ANSI fg sequences. Graceful degradation on narrow terminals drops left segments: search position first (`statusSegmentsNoSearch`), then line number and hunk info (`statusSegmentsMinimal`), then truncates filename.
 - Search and hunk navigation both use `centerViewportOnCursor()` to center the target in the middle of the viewport. Use `syncViewportToCursor()` only for cursor movements that should keep the cursor barely visible (j/k scrolling).
 - Single-file mode (`m.singleFile`): when diff has exactly one file, tree pane is hidden, `treeWidth = 0`, diff gets full width (`m.width - 2` for borders, content width `m.width - 4` including right padding). Pane-switching keys (tab, h, l) and file navigation (n/p, f) become no-ops. Search nav (n/N) still works. Detection happens in `handleFilesLoaded`. Exception: when the file is markdown and full-context (all `ChangeContext` lines), an `mdTOC` pane replaces the tree pane with header navigation — see `app/ui/mdtoc.go`.
 - Tree pane toggle (`t` key): `m.treeHidden` hides the tree/TOC pane and gives diff full width. Orthogonal to `singleFile` — sets `treeWidth = 0`, forces `focus = paneDiff`, blocks `togglePane()`/`handleSwitchToTree()`. `handleViewToggle()` dispatches `v`, `w`, `t`, and `L` keys. `handleFileLoaded` respects `treeHidden` when setting up mdTOC layout.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Built for a specific use case: reviewing code changes, plans, and documents with
 
 - Structured annotation output to stdout - pipe into AI agents, scripts, or other tools
 - Full-file diff view with syntax highlighting
-- Intra-line word-diff: highlights the specific changed words within paired add/remove lines using a brighter background overlay, always on
+- Intra-line word-diff: highlights the specific changed words within paired add/remove lines using a brighter background overlay, off by default — enable with `--word-diff` or toggle with `W`
 - Collapsed diff mode: shows final text with change markers, toggle with `v`
 - Word wrap mode: wraps long lines at viewport boundary with `↪` continuation markers, toggle with `w`
 - Line numbers: side-by-side old/new line number gutter, toggle with `L`
@@ -235,6 +235,7 @@ Positional arguments support several forms:
 | `--cross-file-hunks` | Allow `[` and `]` to continue into adjacent files, env: `REVDIFF_CROSS_FILE_HUNKS` | `false` |
 | `--line-numbers` | Show line numbers in diff gutter, env: `REVDIFF_LINE_NUMBERS` | `false` |
 | `--blame` | Show git blame gutter on startup, env: `REVDIFF_BLAME` | `false` |
+| `--word-diff` | Highlight intra-line word-level changes in paired add/remove lines, env: `REVDIFF_WORD_DIFF` | `false` |
 | `--no-confirm-discard` | Skip confirmation when discarding annotations with Q, env: `REVDIFF_NO_CONFIRM_DISCARD` | `false` |
 | `--chroma-style` | Chroma color theme for syntax highlighting, env: `REVDIFF_CHROMA_STYLE` | `catppuccin-macchiato` |
 | `--theme` | Load color theme from `~/.config/revdiff/themes/`, env: `REVDIFF_THEME` | |
@@ -534,6 +535,7 @@ Override the history directory with `--history-dir`, `REVDIFF_HISTORY_DIR` env v
 | `t` | Toggle tree/TOC pane visibility (gives diff full terminal width) |
 | `L` | Toggle line numbers (side-by-side old/new numbers in gutter) |
 | `B` | Toggle git blame gutter (author name + commit age per line) |
+| `W` | Toggle intra-line word-diff highlighting for paired add/remove lines |
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
 | `f` | Toggle filter: all files / annotated only (shown when annotations exist) |
@@ -580,7 +582,7 @@ Then edit to taste. Modal keys (annotation input, search input, confirm discard)
 
 **Annotations:** `confirm` (annotate line / select file), `annotate_file`, `delete_annotation`, `annot_list`
 
-**View:** `toggle_collapsed`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_hunk`, `theme_select`, `filter`
+**View:** `toggle_collapsed`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_word_diff`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `theme_select`, `filter`
 
 **Quit:** `quit`, `discard_quit`, `help`, `dismiss`
 

--- a/app/keymap/keymap.go
+++ b/app/keymap/keymap.go
@@ -45,6 +45,7 @@ const (
 	ActionToggleTree       Action = "toggle_tree"
 	ActionToggleLineNums   Action = "toggle_line_numbers"
 	ActionToggleBlame      Action = "toggle_blame"
+	ActionToggleWordDiff   Action = "toggle_word_diff"
 	ActionToggleHunk       Action = "toggle_hunk"
 	ActionToggleUntracked  Action = "toggle_untracked"
 	ActionMarkReviewed     Action = "mark_reviewed"
@@ -69,7 +70,8 @@ var validActions = map[Action]bool{
 	ActionSearch:  true,
 	ActionConfirm: true, ActionAnnotateFile: true, ActionDeleteAnnotation: true, ActionAnnotList: true,
 	ActionToggleCollapsed: true, ActionToggleWrap: true, ActionToggleTree: true,
-	ActionToggleLineNums: true, ActionToggleBlame: true, ActionToggleHunk: true, ActionMarkReviewed: true, ActionFilter: true, ActionToggleUntracked: true,
+	ActionToggleLineNums: true, ActionToggleBlame: true, ActionToggleWordDiff: true, ActionToggleHunk: true,
+	ActionMarkReviewed: true, ActionFilter: true, ActionToggleUntracked: true,
 	ActionQuit: true, ActionDiscardQuit: true, ActionHelp: true, ActionDismiss: true, ActionThemeSelect: true,
 }
 
@@ -146,6 +148,7 @@ func defaultDescriptions() []HelpEntry {
 		{ActionToggleTree, "toggle tree pane", "View"},
 		{ActionToggleLineNums, "toggle line numbers", "View"},
 		{ActionToggleBlame, "toggle blame gutter", "View"},
+		{ActionToggleWordDiff, "toggle word-diff highlighting", "View"},
 		{ActionToggleHunk, "toggle hunk in collapsed", "View"},
 		{ActionToggleUntracked, "show/hide untracked files", "View"},
 		{ActionMarkReviewed, "mark file as reviewed", "View"},
@@ -194,6 +197,7 @@ func defaultBindings() map[string]Action {
 		"t":      ActionToggleTree,
 		"L":      ActionToggleLineNums,
 		"B":      ActionToggleBlame,
+		"W":      ActionToggleWordDiff,
 		".":      ActionToggleHunk,
 		" ":      ActionMarkReviewed,
 		"u":      ActionToggleUntracked,

--- a/app/keymap/keymap_test.go
+++ b/app/keymap/keymap_test.go
@@ -36,7 +36,8 @@ func TestDefault_allExpectedBindings(t *testing.T) {
 		{"a", ActionConfirm}, {"enter", ActionConfirm},
 		{"A", ActionAnnotateFile}, {"d", ActionDeleteAnnotation}, {"@", ActionAnnotList},
 		{"v", ActionToggleCollapsed}, {"w", ActionToggleWrap}, {"t", ActionToggleTree},
-		{"L", ActionToggleLineNums}, {"B", ActionToggleBlame}, {".", ActionToggleHunk}, {" ", ActionMarkReviewed}, {"f", ActionFilter},
+		{"L", ActionToggleLineNums}, {"B", ActionToggleBlame}, {"W", ActionToggleWordDiff},
+		{".", ActionToggleHunk}, {" ", ActionMarkReviewed}, {"f", ActionFilter},
 		{"u", ActionToggleUntracked},
 		{"q", ActionQuit}, {"Q", ActionDiscardQuit}, {"?", ActionHelp}, {"T", ActionThemeSelect}, {"esc", ActionDismiss},
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -39,6 +39,7 @@ type options struct {
 	CrossFileHunks   bool     `long:"cross-file-hunks" ini-name:"cross-file-hunks" env:"REVDIFF_CROSS_FILE_HUNKS" description:"allow [ and ] to jump across file boundaries"`
 	LineNumbers      bool     `long:"line-numbers" ini-name:"line-numbers" env:"REVDIFF_LINE_NUMBERS" description:"show line numbers in diff gutter"`
 	Blame            bool     `long:"blame" ini-name:"blame" env:"REVDIFF_BLAME" description:"show git blame gutter on startup"`
+	WordDiff         bool     `long:"word-diff" ini-name:"word-diff" env:"REVDIFF_WORD_DIFF" description:"highlight intra-line word-level changes in paired add/remove lines"`
 	ChromaStyle      string   `long:"chroma-style" ini-name:"chroma-style" env:"REVDIFF_CHROMA_STYLE" default:"catppuccin-macchiato" description:"chroma style for syntax highlighting"`
 	AllFiles         bool     `long:"all-files" short:"A" no-ini:"true" description:"browse all git-tracked files, not just diffs"`
 	Stdin            bool     `long:"stdin" no-ini:"true" description:"review stdin as a scratch buffer"`
@@ -392,6 +393,7 @@ func run(opts options) error {
 		CrossFileHunks:   opts.CrossFileHunks,
 		LineNumbers:      opts.LineNumbers,
 		ShowBlame:        opts.Blame,
+		WordDiff:         opts.WordDiff,
 		TabWidth:         opts.TabWidth,
 		Ref:              opts.ref(),
 		Staged:           opts.Staged,

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -227,6 +227,37 @@ func TestParseArgs_Blame(t *testing.T) {
 	})
 }
 
+func TestParseArgs_WordDiff(t *testing.T) {
+	t.Run("default off", func(t *testing.T) {
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.False(t, opts.WordDiff)
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		opts, err := parseArgs(append(noConfigArgs(t), "--word-diff"))
+		require.NoError(t, err)
+		assert.True(t, opts.WordDiff)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("REVDIFF_WORD_DIFF", "true")
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.True(t, opts.WordDiff)
+	})
+
+	t.Run("config file", func(t *testing.T) {
+		cfgDir := t.TempDir()
+		cfgPath := filepath.Join(cfgDir, "config")
+		err := os.WriteFile(cfgPath, []byte("[Application Options]\nword-diff = true\n"), 0o600)
+		require.NoError(t, err)
+		opts, err := parseArgs([]string{"--config", cfgPath})
+		require.NoError(t, err)
+		assert.True(t, opts.WordDiff)
+	})
+}
+
 func TestParseArgs_OutputFlag(t *testing.T) {
 	opts, err := parseArgs([]string{"-o", "/tmp/out.txt"})
 	require.NoError(t, err)

--- a/app/ui/diffview_test.go
+++ b/app/ui/diffview_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
@@ -450,6 +451,7 @@ func TestModel_ApplyIntraLineHighlight(t *testing.T) {
 	t.Run("paired add/remove lines get bg markers", func(t *testing.T) {
 		m := testModel(nil, nil)
 		m.styles = newStyles(Colors{AddBg: "#1a3320", RemoveBg: "#331a1a", WordAddBg: "#2d5a3a", WordRemoveBg: "#5a2d2d"})
+		m.wordDiff = true
 		m.diffLines = []diff.DiffLine{
 			{OldNum: 1, Content: "hello world", ChangeType: diff.ChangeRemove},
 			{NewNum: 1, Content: "hello earth", ChangeType: diff.ChangeAdd},
@@ -471,6 +473,7 @@ func TestModel_ApplyIntraLineHighlight(t *testing.T) {
 	t.Run("pure add block produces no markers", func(t *testing.T) {
 		m := testModel(nil, nil)
 		m.styles = newStyles(Colors{AddBg: "#1a3320", WordAddBg: "#2d5a3a"})
+		m.wordDiff = true
 		m.diffLines = []diff.DiffLine{
 			{NewNum: 1, Content: "new line one", ChangeType: diff.ChangeAdd},
 			{NewNum: 2, Content: "new line two", ChangeType: diff.ChangeAdd},
@@ -489,6 +492,7 @@ func TestModel_ApplyIntraLineHighlight(t *testing.T) {
 		m := testModel(nil, nil)
 		m.noColors = true
 		m.styles = plainStyles()
+		m.wordDiff = true
 		m.diffLines = []diff.DiffLine{
 			{OldNum: 1, Content: "hello world", ChangeType: diff.ChangeRemove},
 			{NewNum: 1, Content: "hello earth", ChangeType: diff.ChangeAdd},
@@ -534,6 +538,7 @@ func TestModel_RenderDiffWithIntraLine(t *testing.T) {
 			WordAddBg: "#2d5a3a", WordRemoveBg: "#5a2d2d",
 			DiffBg: "#1e1e1e",
 		})
+		m.wordDiff = true
 		result, _ := m.Update(fileLoadedMsg{file: "a.go", lines: lines})
 		m = result.(Model)
 
@@ -556,6 +561,7 @@ func TestModel_RenderDiffWithIntraLine(t *testing.T) {
 			WordAddBg: "#2d5a3a", WordRemoveBg: "#5a2d2d",
 		})
 		m.tabSpaces = "    "
+		m.wordDiff = true
 		result, _ := m.Update(fileLoadedMsg{file: "a.go", lines: lines})
 		m = result.(Model)
 
@@ -583,6 +589,7 @@ func TestModel_WrapModeWithIntraLine(t *testing.T) {
 	m.width = 50
 	m.treeWidth = 0
 	m.singleFile = true
+	m.wordDiff = true
 
 	result, _ := m.Update(fileLoadedMsg{file: "a.go", lines: lines})
 	m = result.(Model)
@@ -591,6 +598,91 @@ func TestModel_WrapModeWithIntraLine(t *testing.T) {
 	output := m.renderDiff()
 	// verify word-diff markers are present in wrapped output
 	assert.Contains(t, output, "\033[48;2;", "wrapped output should contain word-diff bg markers")
+}
+
+func TestModel_WordDiffOptIn(t *testing.T) {
+	lines := []diff.DiffLine{
+		{OldNum: 1, Content: "old value here", ChangeType: diff.ChangeRemove},
+		{NewNum: 1, Content: "new value here", ChangeType: diff.ChangeAdd},
+	}
+	colors := Colors{AddBg: "#1a3320", RemoveBg: "#331a1a", WordAddBg: "#2d5a3a", WordRemoveBg: "#5a2d2d"}
+
+	t.Run("default off: no ranges computed", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+		m.styles = newStyles(colors)
+		result, _ := m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+		m = result.(Model)
+
+		assert.False(t, m.wordDiff, "wordDiff should default to false")
+		assert.Nil(t, m.intraRanges, "intraRanges should be nil when wordDiff is off")
+	})
+
+	t.Run("enabled: ranges computed on file load and bg markers in render", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+		m.styles = newStyles(colors)
+		m.wordDiff = true
+		result, _ := m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+		m = result.(Model)
+
+		require.NotNil(t, m.intraRanges, "intraRanges should be computed when wordDiff is on")
+		assert.Contains(t, m.renderDiff(), "\033[48;2;", "rendered output should contain word-diff bg markers")
+	})
+
+	t.Run("toggleWordDiff flips state and recomputes", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+		m.styles = newStyles(colors)
+		m.ready = true
+		m.width = 200
+		m.height = 30
+		m.viewport.Width = 196
+		m.viewport.Height = 28
+		result, _ := m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+		m = result.(Model)
+		m.focus = paneDiff
+
+		assert.Nil(t, m.intraRanges, "initial state: no ranges")
+
+		m.toggleWordDiff()
+		assert.True(t, m.wordDiff, "should be enabled after toggle")
+		assert.NotNil(t, m.intraRanges, "ranges computed after enabling")
+
+		m.toggleWordDiff()
+		assert.False(t, m.wordDiff, "should be disabled after second toggle")
+		assert.Nil(t, m.intraRanges, "ranges cleared after disabling")
+	})
+
+	t.Run("toggleWordDiff is no-op when no file loaded", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.focus = paneDiff
+		m.toggleWordDiff()
+		assert.False(t, m.wordDiff, "should stay off with no file")
+	})
+
+	t.Run("W key flips wordDiff through Update dispatch", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+		m.styles = newStyles(colors)
+		m.ready = true
+		m.width = 200
+		m.height = 30
+		m.viewport.Width = 196
+		m.viewport.Height = 28
+		result, _ := m.Update(fileLoadedMsg{file: "a.go", lines: lines})
+		m = result.(Model)
+		m.focus = paneDiff
+
+		require.False(t, m.wordDiff, "initial state: off")
+		require.Nil(t, m.intraRanges, "initial state: no ranges")
+
+		result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'W'}})
+		m = result.(Model)
+		assert.True(t, m.wordDiff, "W key should enable wordDiff")
+		assert.NotNil(t, m.intraRanges, "ranges should be computed after W")
+
+		result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'W'}})
+		m = result.(Model)
+		assert.False(t, m.wordDiff, "second W should disable wordDiff")
+		assert.Nil(t, m.intraRanges, "ranges should be cleared after second W")
+	})
 }
 
 func TestModel_UpdateRestoreBg(t *testing.T) {

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -94,6 +94,7 @@ type Model struct {
 	lineNumbers    bool // true when line numbers are shown in gutter
 	lineNumWidth   int  // digit width for line number columns (max digits across old/new nums)
 
+	wordDiff       bool                     // true when intra-line word-diff highlighting is enabled
 	blamer         Blamer                   // optional blame provider (nil when git unavailable)
 	showBlame      bool                     // true when blame gutter is shown
 	blameData      map[int]diff.BlameLine   // blame info keyed by 1-based new line number
@@ -167,6 +168,7 @@ type ModelConfig struct {
 	CrossFileHunks   bool                     // allow [ and ] to jump across file boundaries
 	LineNumbers      bool                     // show line numbers in diff gutter
 	ShowBlame        bool                     // show blame gutter on startup when available
+	WordDiff         bool                     // enable intra-line word-diff highlighting on startup
 	Only             []string                 // show only these files (match by exact path or path suffix)
 	WorkDir          string                   // working directory for resolving absolute --only paths
 	Keymap           *keymap.Keymap           // custom key bindings (nil uses defaults)
@@ -212,6 +214,7 @@ func NewModel(renderer Renderer, store *annotation.Store, highlighter SyntaxHigh
 		crossFileHunks:   cfg.CrossFileHunks,
 		lineNumbers:      cfg.LineNumbers,
 		collapsed:        collapsedState{enabled: cfg.Collapsed},
+		wordDiff:         cfg.WordDiff,
 		showBlame:        cfg.ShowBlame && cfg.Blamer != nil,
 		showUntracked:    false,
 		loadUntracked:    cfg.LoadUntracked,
@@ -318,7 +321,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleFileAnnotateKey()
 	case keymap.ActionMarkReviewed:
 		return m.handleMarkReviewed()
-	case keymap.ActionToggleCollapsed, keymap.ActionToggleWrap, keymap.ActionToggleTree, keymap.ActionToggleLineNums, keymap.ActionToggleBlame, keymap.ActionToggleUntracked:
+	case keymap.ActionToggleCollapsed, keymap.ActionToggleWrap, keymap.ActionToggleTree, keymap.ActionToggleLineNums,
+		keymap.ActionToggleBlame, keymap.ActionToggleWordDiff, keymap.ActionToggleUntracked:
 		return m.handleViewToggle(action)
 	case keymap.ActionNextHunk, keymap.ActionPrevHunk:
 		return m.handleHunkNav(action == keymap.ActionNextHunk)
@@ -457,6 +461,19 @@ func (m *Model) toggleBlame() tea.Cmd {
 	return nil
 }
 
+// toggleWordDiff toggles intra-line word-diff highlighting on/off.
+// recomputeIntraRanges honors the new wordDiff state: it populates ranges
+// when enabling and clears them when disabling.
+// no-op when the diff pane is not focused or no file is loaded.
+func (m *Model) toggleWordDiff() {
+	if m.focus != paneDiff || m.currFile == "" {
+		return
+	}
+	m.wordDiff = !m.wordDiff
+	m.recomputeIntraRanges()
+	m.viewport.SetContent(m.renderDiff())
+}
+
 // toggleUntracked toggles visibility of untracked files in the tree.
 func (m *Model) toggleUntracked() tea.Cmd {
 	m.showUntracked = !m.showUntracked
@@ -477,6 +494,8 @@ func (m Model) handleViewToggle(action keymap.Action) (tea.Model, tea.Cmd) {
 	case keymap.ActionToggleBlame:
 		cmd := m.toggleBlame()
 		return m, cmd
+	case keymap.ActionToggleWordDiff:
+		m.toggleWordDiff()
 	case keymap.ActionToggleUntracked:
 		cmd := m.toggleUntracked()
 		return m, cmd

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -347,7 +347,7 @@ func (m Model) effectiveStatusFg() string {
 	return m.styles.colors.Muted
 }
 
-// statusModeIcons returns combined mode indicator icons (▼ collapsed, ◉ filter, ↩ wrap, ≋ search).
+// statusModeIcons returns combined mode indicator icons (one per view toggle).
 // all icons are always shown; active modes use status foreground, inactive use muted color.
 func (m Model) statusModeIcons() string {
 	type indicator struct {
@@ -362,6 +362,7 @@ func (m Model) statusModeIcons() string {
 		{"⊟", m.treeHidden},
 		{"#", m.lineNumbers},
 		{"b", m.showBlame},
+		{"±", m.wordDiff},
 		{"✓", m.tree.reviewedCount() > 0},
 		{"∅", m.showUntracked},
 	}

--- a/app/ui/view_test.go
+++ b/app/ui/view_test.go
@@ -157,7 +157,7 @@ func TestModel_StatusBarFilenameTruncationWideChars(t *testing.T) {
 	m.fileAdds = 1
 	m.fileRemoves = 0
 	m.focus = paneDiff
-	m.width = 42
+	m.width = 45
 
 	status := m.statusBarText()
 	assert.Contains(t, status, "…", "should truncate wide-char filename with ellipsis")
@@ -1268,6 +1268,18 @@ func TestModel_StatusModeIconsBlame(t *testing.T) {
 	icons := m.statusModeIcons()
 	assert.Contains(t, icons, "b")
 	assert.NotContains(t, icons, "@")
+}
+
+func TestModel_StatusModeIconsWordDiff(t *testing.T) {
+	m := testModel(nil, nil)
+	icons := m.statusModeIcons()
+	assert.Contains(t, icons, "±", "word-diff icon should always be present")
+
+	m.wordDiff = true
+	colors := Colors{Muted: "#6c6c6c", StatusFg: "#202020"}
+	m.styles = newStyles(colors)
+	icons = m.statusModeIcons()
+	assert.Contains(t, icons, "\033[38;2;32;32;32m±", "active word-diff icon uses status fg")
 }
 
 func TestModel_ReviewedStatusBar(t *testing.T) {

--- a/app/ui/worddiff.go
+++ b/app/ui/worddiff.go
@@ -246,7 +246,13 @@ const similarityThreshold = 30
 // recomputeIntraRanges walks m.diffLines, finds contiguous change blocks,
 // pairs remove/add lines, runs word-diff, and stores results in m.intraRanges.
 // applies a 30% similarity gate: pairs with <30% common tokens get no ranges.
+// no-op when m.wordDiff is off: clears m.intraRanges to nil so callers don't
+// need to duplicate the guard at each call site.
 func (m *Model) recomputeIntraRanges() {
+	if !m.wordDiff {
+		m.intraRanges = nil
+		return
+	}
 	n := len(m.diffLines)
 	m.intraRanges = make([][]matchRange, n)
 

--- a/app/ui/worddiff_test.go
+++ b/app/ui/worddiff_test.go
@@ -449,6 +449,7 @@ func TestPassesSimilarityGateFromKeep_WhitespaceOnly(t *testing.T) {
 
 func TestModel_RecomputeIntraRanges(t *testing.T) {
 	m := testModel(nil, nil)
+	m.wordDiff = true
 	m.tabSpaces = "    "
 	m.diffLines = []diff.DiffLine{
 		{Content: "context before", ChangeType: diff.ChangeContext},
@@ -474,6 +475,7 @@ func TestModel_RecomputeIntraRanges(t *testing.T) {
 
 func TestModel_RecomputeIntraRanges_IdenticalPair(t *testing.T) {
 	m := testModel(nil, nil)
+	m.wordDiff = true
 	m.tabSpaces = "    "
 	m.diffLines = []diff.DiffLine{
 		{Content: "same line content", ChangeType: diff.ChangeRemove},
@@ -489,6 +491,7 @@ func TestModel_RecomputeIntraRanges_IdenticalPair(t *testing.T) {
 
 func TestModel_RecomputeIntraRanges_PureAddBlock(t *testing.T) {
 	m := testModel(nil, nil)
+	m.wordDiff = true
 	m.tabSpaces = "    "
 	m.diffLines = []diff.DiffLine{
 		{Content: "context", ChangeType: diff.ChangeContext},
@@ -506,6 +509,7 @@ func TestModel_RecomputeIntraRanges_PureAddBlock(t *testing.T) {
 
 func TestModel_RecomputeIntraRanges_DissimilarPair(t *testing.T) {
 	m := testModel(nil, nil)
+	m.wordDiff = true
 	m.tabSpaces = "    "
 	m.diffLines = []diff.DiffLine{
 		{Content: "alpha bravo charlie delta echo foxtrot golf hotel india juliet", ChangeType: diff.ChangeRemove},
@@ -521,6 +525,7 @@ func TestModel_RecomputeIntraRanges_DissimilarPair(t *testing.T) {
 
 func TestModel_RecomputeIntraRanges_TabContent(t *testing.T) {
 	m := testModel(nil, nil)
+	m.wordDiff = true
 	m.tabSpaces = "    "
 	m.diffLines = []diff.DiffLine{
 		{Content: "\treturn foo(bar)", ChangeType: diff.ChangeRemove},
@@ -542,6 +547,7 @@ func TestModel_RecomputeIntraRanges_TabContent(t *testing.T) {
 
 func TestModel_RecomputeIntraRanges_MultipleBlocks(t *testing.T) {
 	m := testModel(nil, nil)
+	m.wordDiff = true
 	m.tabSpaces = "    "
 	m.diffLines = []diff.DiffLine{
 		{Content: "old first", ChangeType: diff.ChangeRemove},

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -27,6 +27,7 @@ Then uncomment and edit the values you want to change.
 | `--collapsed` | `REVDIFF_COLLAPSED` | Start in collapsed diff mode | `false` |
 | `--line-numbers` | `REVDIFF_LINE_NUMBERS` | Show line numbers in diff gutter | `false` |
 | `--blame` | `REVDIFF_BLAME` | Show git blame gutter on startup | `false` |
+| `--word-diff` | `REVDIFF_WORD_DIFF` | Highlight intra-line word-level changes in paired add/remove lines | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
 | `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/` | |

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -110,6 +110,7 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `t` | Toggle tree/TOC pane visibility (gives diff full terminal width) |
 | `L` | Toggle line numbers (side-by-side old/new numbers in gutter) |
 | `B` | Toggle git blame gutter (author name + commit age per line) |
+| `W` | Toggle intra-line word-diff highlighting for paired add/remove lines |
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
 | `f` | Toggle filter: all files / annotated only |

--- a/site/docs.html
+++ b/site/docs.html
@@ -241,6 +241,7 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>--collapsed</code></td><td>Start in collapsed diff mode</td><td><code>false</code></td></tr>
                 <tr><td><code>--cross-file-hunks</code></td><td>Allow <code>[</code> and <code>]</code> to continue into adjacent files</td><td><code>false</code></td></tr>
                 <tr><td><code>--line-numbers</code></td><td>Show line numbers in diff gutter</td><td><code>false</code></td></tr>
+                <tr><td><code>--word-diff</code></td><td>Highlight intra-line word-level changes in paired add/remove lines</td><td><code>false</code></td></tr>
                 <tr><td><code>--no-confirm-discard</code></td><td>Skip discard confirmation</td><td><code>false</code></td></tr>
                 <tr><td><code>--chroma-style</code></td><td>Syntax highlighting theme</td><td><code>catppuccin-macchiato</code></td></tr>
                 <tr><td><code>--theme</code></td><td>Load color theme from <code>~/.config/revdiff/themes/</code></td><td></td></tr>
@@ -377,6 +378,7 @@ color-border = #6272a4
                 <tr><td><code>t</code></td><td>Toggle tree/TOC pane visibility</td></tr>
                 <tr><td><code>L</code></td><td>Toggle line numbers</td></tr>
                 <tr><td><code>B</code></td><td>Toggle git blame gutter (author + commit age)</td></tr>
+                <tr><td><code>W</code></td><td>Toggle intra-line word-diff highlighting</td></tr>
                 <tr><td><code>.</code></td><td>Expand/collapse hunk (collapsed mode)</td></tr>
                 <tr><td><code>T</code></td><td>Theme selector with live preview</td></tr>
                 <tr><td><code>f</code></td><td>Filter: all files / annotated only</td></tr>
@@ -401,7 +403,7 @@ unmap q</code></div>
         <p><strong>Pane:</strong> <code>toggle_pane</code>, <code>focus_tree</code>, <code>focus_diff</code></p>
         <p><strong>Search:</strong> <code>search</code></p>
         <p><strong>Annotations:</strong> <code>confirm</code>, <code>annotate_file</code>, <code>delete_annotation</code>, <code>annot_list</code></p>
-        <p><strong>View:</strong> <code>toggle_collapsed</code>, <code>toggle_wrap</code>, <code>toggle_tree</code>, <code>toggle_line_numbers</code>, <code>toggle_hunk</code>, <code>theme_select</code>, <code>filter</code></p>
+        <p><strong>View:</strong> <code>toggle_collapsed</code>, <code>toggle_wrap</code>, <code>toggle_tree</code>, <code>toggle_line_numbers</code>, <code>toggle_blame</code>, <code>toggle_word_diff</code>, <code>toggle_hunk</code>, <code>toggle_untracked</code>, <code>mark_reviewed</code>, <code>theme_select</code>, <code>filter</code></p>
         <p><strong>Quit:</strong> <code>quit</code>, <code>discard_quit</code>, <code>help</code>, <code>dismiss</code></p>
 
         <!-- claude code plugin -->


### PR DESCRIPTION
The intra-line word-diff feature landed in #87 as always-on. It clashes with certain themes where the brighter add/remove overlay reads as a confusing extra swath of color instead of a useful hint (example attached to the original discussion).

This PR makes it opt-in, off by default.

**Enable via any of**:
- `--word-diff` CLI flag
- `REVDIFF_WORD_DIFF=true` env var
- `word-diff = true` in `~/.config/revdiff/config`
- `W` key at runtime

**Status indicator**: `±` appears on the status bar when active (muted when off, status fg when on). The help overlay picks up the new binding automatically from `keymap.HelpSections()`.

**Implementation**: `recomputeIntraRanges` now gates on `m.wordDiff` internally — early-returns with `m.intraRanges = nil` when off. Both `handleFileLoaded` and `toggleWordDiff` call it without duplicating the guard. No other rendering code changed; `applyIntraLineHighlight` is a no-op when ranges are nil, which is the existing behavior.

**Tests**: `TestParseArgs_WordDiff` covers flag/env/config-file activation. `TestModel_WordDiffOptIn` covers default-off, enabled-on-load (with rendered output assertion), direct toggle, toggle no-op without file, and the full `Update()` → `W` key → `handleViewToggle` → `toggleWordDiff` dispatch path. Existing `TestModel_RecomputeIntraRanges*` and `TestModel_ApplyIntraLineHighlight` subtests were updated to set `m.wordDiff = true` since `recomputeIntraRanges` now honors the flag.

**Docs**: README.md, CLAUDE.md, site/docs.html, and both plugin reference docs (.claude-plugin + codex) updated. While touching the View action lists, added `mark_reviewed` and `toggle_untracked` which were already missing before this PR. Plugin version bump deferred to next release cut.