### PR TITLE
Add Mercurial VCS support

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -26,7 +26,7 @@ Then uncomment and edit the values you want to change.
 | `--wrap` | `REVDIFF_WRAP` | Enable line wrapping in diff view | `false` |
 | `--collapsed` | `REVDIFF_COLLAPSED` | Start in collapsed diff mode | `false` |
 | `--line-numbers` | `REVDIFF_LINE_NUMBERS` | Show line numbers in diff gutter | `false` |
-| `--blame` | `REVDIFF_BLAME` | Show git blame gutter on startup | `false` |
+| `--blame` | `REVDIFF_BLAME` | Show blame gutter on startup | `false` |
 | `--word-diff` | `REVDIFF_WORD_DIFF` | Highlight intra-line word-level changes in paired add/remove lines | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |

--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -109,7 +109,7 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `w` | Toggle word wrap (long lines wrap with `↪` continuation markers) |
 | `t` | Toggle tree/TOC pane visibility (gives diff full terminal width) |
 | `L` | Toggle line numbers (side-by-side old/new numbers in gutter) |
-| `B` | Toggle git blame gutter (author name + commit age per line) |
+| `B` | Toggle blame gutter (author name + commit age per line) |
 | `W` | Toggle intra-line word-diff highlighting for paired add/remove lines |
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
@@ -130,7 +130,7 @@ The status bar shows a fixed row of mode indicators on the right side. All ten s
 | `≋` | `/` | Search active |
 | `⊟` | `t` | Tree/TOC pane hidden (diff uses full width) |
 | `#` | `L` | Line numbers visible in gutter |
-| `b` | `B` | Git blame gutter visible |
+| `b` | `B` | Blame gutter visible |
 | `±` | `W` | Intra-line word-diff highlighting |
 | `✓` | `Space` | Reviewed count (increments when a file is marked reviewed) |
 | `∅` | `u` | Untracked files visible in tree |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ TUI for reviewing diffs, files, and documents with inline annotations, built wit
 
 ## Project Structure
 - `app/` - entry point (`main.go`), CLI flags, wiring
-- `app/diff/` - git interaction, unified diff parsing (`parseUnifiedDiff`, `DiffLine`)
+- `app/diff/` - VCS interaction (git + hg), unified diff parsing (`parseUnifiedDiff`, `DiffLine`), VCS detection (`vcs.go`), Mercurial support (`hg.go`, `hgblame.go`)
 - `app/ui/` - bubbletea TUI package. All files share one `Model` struct — methods are split across files by concern to keep code files under ~500 lines and test files around ~1000 lines (soft target). Each source file has a matching `_test.go` file. See `app/ui/doc.go` for package-level documentation.
   - `model.go` - Model struct, NewModel, Init, Update, handleKey, view toggles
   - `view.go` - View(), status bar, ANSI helpers
@@ -37,12 +37,13 @@ TUI for reviewing diffs, files, and documents with inline annotations, built wit
 - `app/ui/mocks/` - moq-generated mocks (never edit manually)
 
 ## Key Interfaces (consumer-side, in `app/ui/`)
-- `Renderer` - `ChangedFiles()`, `FileDiff()` - implemented by `diff.Git`, `diff.FallbackRenderer`, `diff.FileReader`, `diff.DirectoryReader`, `diff.StdinReader`, `diff.ExcludeFilter`
+- `Renderer` - `ChangedFiles()`, `FileDiff()` - implemented by `diff.Git`, `diff.Hg`, `diff.FallbackRenderer`, `diff.FileReader`, `diff.DirectoryReader`, `diff.StdinReader`, `diff.ExcludeFilter`
 - `SyntaxHighlighter` - `HighlightLines()` - implemented by `highlight.Highlighter`
 
 ## Data Flow
 ```
-git diff → diff.parseUnifiedDiff() → []DiffLine
+DetectVCS() → VCSGit | VCSHg | VCSNone
+  git diff / hg diff --git → diff.parseUnifiedDiff() → []DiffLine
   (or: disk file → diff.readFileAsContext() → []DiffLine, all ChangeContext)
   (or: stdin / arbitrary reader → diff.readReaderAsContext() → []DiffLine, all ChangeContext)
   → highlight.HighlightLines() → []string (ANSI foreground-only)
@@ -67,7 +68,7 @@ git diff → diff.parseUnifiedDiff() → []DiffLine
     blameGutter(dl, now) formats " author age" gutter via m.styles.LineNumber,
     prepended after lineNumGutter in renderDiffLine, renderWrappedDiffLine, renderCollapsedAddLine, renderDeletePlaceholder
     blame data loaded async via loadBlame() → blameLoadedMsg; keyed by NewNum (blank for removed lines/dividers)
-    blameAuthorLen capped at 8; blameGutterWidth() = W+5; Blamer interface (optional, nil when git unavailable)
+    blameAuthorLen capped at 8; blameGutterWidth() = W+5; Blamer interface (optional, nil when no VCS available)
   when wrap mode is on (`w` toggle, orthogonal to above):
     wrapContent() splits long lines via ansi.Wrap,
     continuation lines get `↪` gutter marker, cursorViewportY() sums wrapped line counts.
@@ -140,7 +141,7 @@ git diff → diff.parseUnifiedDiff() → []DiffLine
 - Highlighted lines are pre-computed once per file load, stored parallel to `diffLines`
 - `DiffLine.Content` has no `+`/`-` prefix - prefix is re-added at render time
 - Tab replacement happens at render time in `renderDiffLine`, not in diff parsing
-- `run()` resolves git repo root via `git rev-parse --show-toplevel`; if git is unavailable and `--only` is set, uses `FileReader` for standalone file review. `--stdin` skips git lookup entirely, validates non-TTY stdin, reads payload before starting Bubble Tea, and reopens `/dev/tty` for interactive key input.
+- `run()` detects VCS via `diff.DetectVCS()` (walks up looking for `.git`/`.hg`); if no VCS is found and `--only` is set, uses `FileReader` for standalone file review. `--stdin` skips VCS lookup entirely, validates non-TTY stdin, reads payload before starting Bubble Tea, and reopens `/dev/tty` for interactive key input. `--all-files` is git-only (not supported in hg repos).
 - `--all-files` mode uses `DirectoryReader` (git ls-files) to list all tracked files; `--exclude` wraps any renderer with `ExcludeFilter` for prefix-based filtering. `--all-files` is mutually exclusive with refs, `--staged`, and `--only`. `--stdin` is mutually exclusive with refs, `--staged`, `--only`, `--all-files`, and `--exclude`.
 - `diff.readReaderAsContext()` is the shared parser for file-backed and stdin-backed context-only views. Preserve its behavior if you change binary detection, line-length handling, or line numbering.
 - Help overlay uses `overlayCenter()` (ANSI-aware compositing via `charmbracelet/x/ansi.Cut`) to render on top of existing content; background (tree pane) remains visible at the edges

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Built for a specific use case: reviewing code changes, plans, and documents with
 - Word wrap mode: wraps long lines at viewport boundary with `↪` continuation markers, toggle with `w`
 - Horizontal scroll overflow indicators: truncated diff lines show `«` / `»` markers at the edges to signal hidden content off-screen
 - Line numbers: side-by-side old/new line number gutter, toggle with `L`
-- Git blame gutter: shows author name and commit age per line, toggle with `B`
+- Mercurial support: auto-detects hg repos, translates git-style refs (HEAD, HEAD~N) to Mercurial revsets
+- Blame gutter: shows author name and commit age per line, toggle with `B`
 - Annotate any line in the diff (added, removed, or context) plus file-level notes
 - Single-file auto-detection: when a diff contains exactly one file, hides the tree pane and gives full terminal width to the diff view
 - Two-pane TUI: file tree (left) + colorized diff viewport (right)
@@ -36,7 +37,7 @@ Built for a specific use case: reviewing code changes, plans, and documents with
 
 ## Requirements
 
-- `git` (used to generate diffs; optional when using `--only` or `--stdin`)
+- `git` or `hg` (used to generate diffs; optional when using `--only` or `--stdin`)
 
 ## Installation
 
@@ -235,7 +236,7 @@ Positional arguments support several forms:
 | `--collapsed` | Start in collapsed diff mode, env: `REVDIFF_COLLAPSED` | `false` |
 | `--cross-file-hunks` | Allow `[` and `]` to continue into adjacent files, env: `REVDIFF_CROSS_FILE_HUNKS` | `false` |
 | `--line-numbers` | Show line numbers in diff gutter, env: `REVDIFF_LINE_NUMBERS` | `false` |
-| `--blame` | Show git blame gutter on startup, env: `REVDIFF_BLAME` | `false` |
+| `--blame` | Show blame gutter on startup, env: `REVDIFF_BLAME` | `false` |
 | `--word-diff` | Highlight intra-line word-level changes in paired add/remove lines, env: `REVDIFF_WORD_DIFF` | `false` |
 | `--no-confirm-discard` | Skip confirmation when discarding annotations with Q, env: `REVDIFF_NO_CONFIRM_DISCARD` | `false` |
 | `--chroma-style` | Chroma color theme for syntax highlighting, env: `REVDIFF_CHROMA_STYLE` | `catppuccin-macchiato` |
@@ -245,7 +246,7 @@ Positional arguments support several forms:
 | `--init-themes` | Write bundled theme files to themes dir and exit | |
 | `--init-all-themes` | Write all gallery themes (bundled + community) to themes dir and exit | |
 | `--install-theme` | Install theme(s) from gallery or local file path and exit (repeatable) | |
-| `-A`, `--all-files` | Browse all git-tracked files, not just diffs | `false` |
+| `-A`, `--all-files` | Browse all git-tracked files, not just diffs (git only) | `false` |
 | `--stdin` | Review stdin as a scratch buffer (piped or redirected input only) | `false` |
 | `--stdin-name` | Synthetic file name for stdin content; enables extension-based highlighting/TOC | `scratch-buffer` |
 | `-X`, `--exclude` | Exclude files matching prefix, may be repeated, env: `REVDIFF_EXCLUDE` (comma-separated) | |
@@ -541,7 +542,7 @@ Override the history directory with `--history-dir`, `REVDIFF_HISTORY_DIR` env v
 | `w` | Toggle word wrap (long lines wrap with `↪` continuation markers) |
 | `t` | Toggle tree/TOC pane visibility (gives diff full terminal width) |
 | `L` | Toggle line numbers (side-by-side old/new numbers in gutter) |
-| `B` | Toggle git blame gutter (author name + commit age per line) |
+| `B` | Toggle blame gutter (author name + commit age per line) |
 | `W` | Toggle intra-line word-diff highlighting for paired add/remove lines |
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
@@ -562,7 +563,7 @@ The status bar shows a fixed row of mode indicators on the right side. All ten s
 | `≋` | `/` | Search active |
 | `⊟` | `t` | Tree/TOC pane hidden (diff uses full width) |
 | `#` | `L` | Line numbers visible in gutter |
-| `b` | `B` | Git blame gutter visible |
+| `b` | `B` | Blame gutter visible |
 | `±` | `W` | Intra-line word-diff highlighting |
 | `✓` | `Space` | Reviewed count (increments when a file is marked reviewed) |
 | `∅` | `u` | Untracked files visible in tree |

--- a/app/diff/diff.go
+++ b/app/diff/diff.go
@@ -41,7 +41,7 @@ type DiffLine struct {
 	IsPlaceholder bool       // true for non-content placeholders (broken symlink, non-regular file, too-long lines)
 }
 
-// FileStatus represents the change type of a file in a git diff.
+// FileStatus represents the change type of a file in a VCS diff.
 type FileStatus string
 
 const (
@@ -52,7 +52,7 @@ const (
 	FileUntracked FileStatus = "?"
 )
 
-// FileEntry represents a file with its change status from git diff.
+// FileEntry represents a file with its change status from a VCS diff.
 type FileEntry struct {
 	Path   string     // file path relative to repo root
 	Status FileStatus // file change status, empty for non-git renderers
@@ -176,15 +176,20 @@ func (g *Git) diffArgs(ref string, staged bool) []string {
 
 // runGit executes a git command in the working directory and returns its output.
 func (g *Git) runGit(args ...string) (string, error) {
-	cmd := exec.CommandContext(context.Background(), "git", args...) //nolint:gosec // args constructed internally, not user input
-	cmd.Dir = g.workDir
+	return runVCS(g.workDir, "git", args...)
+}
+
+// runVCS executes a VCS command in the given directory and returns its output.
+func runVCS(workDir, binary string, args ...string) (string, error) {
+	cmd := exec.CommandContext(context.Background(), binary, args...) //nolint:gosec // args constructed internally, not user input
+	cmd.Dir = workDir
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), string(exitErr.Stderr))
+			return "", fmt.Errorf("%s %s: %s", binary, strings.Join(args, " "), string(exitErr.Stderr))
 		}
-		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		return "", fmt.Errorf("%s %s: %w", binary, strings.Join(args, " "), err)
 	}
 	return string(out), nil
 }

--- a/app/diff/fallback.go
+++ b/app/diff/fallback.go
@@ -11,18 +11,18 @@ import (
 	"strings"
 )
 
-// FallbackRenderer wraps a *Git renderer and knows about --only file paths.
+// FallbackRenderer wraps a VCS renderer and knows about --only file paths.
 // it delegates to the inner renderer, falling back to disk read for --only files
-// that are not present in the git diff.
+// that are not present in the diff.
 type FallbackRenderer struct {
-	inner   *Git
+	inner   renderer
 	only    []string
 	workDir string
 }
 
 // NewFallbackRenderer creates a FallbackRenderer that delegates to inner and falls back
-// to reading files from disk for --only patterns not found in the git diff.
-func NewFallbackRenderer(inner *Git, only []string, workDir string) *FallbackRenderer {
+// to reading files from disk for --only patterns not found in the diff.
+func NewFallbackRenderer(inner renderer, only []string, workDir string) *FallbackRenderer {
 	return &FallbackRenderer{inner: inner, only: only, workDir: workDir}
 }
 
@@ -31,7 +31,7 @@ func NewFallbackRenderer(inner *Git, only []string, workDir string) *FallbackRen
 func (fr *FallbackRenderer) ChangedFiles(ref string, staged bool) ([]FileEntry, error) {
 	entries, err := fr.inner.ChangedFiles(ref, staged)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fallback changed files: %w", err)
 	}
 
 	for _, pattern := range fr.only {
@@ -50,14 +50,14 @@ func (fr *FallbackRenderer) ChangedFiles(ref string, staged bool) ([]FileEntry, 
 }
 
 // FileDiff returns the diff for a file. for files outside the repo (absolute paths
-// that escape workDir), it skips the inner git renderer entirely and reads from disk.
+// that escape workDir), it skips the inner renderer entirely and reads from disk.
 // for in-repo files, it calls the inner renderer first; if the result is empty
 // (no error, no lines) and the file matches an --only pattern, it falls back to
 // reading the file from disk as all-context lines.
 func (fr *FallbackRenderer) FileDiff(ref, file string, staged bool) ([]DiffLine, error) {
 	resolved := resolvePath(fr.workDir, file)
 
-	// skip inner git renderer for files outside the repo — git would reject them
+	// skip inner renderer for files outside the repo — VCS would reject them
 	// with "is outside repository" error
 	if !fr.isInsideWorkDir(resolved) {
 		if _, statErr := os.Stat(resolved); statErr == nil {
@@ -68,7 +68,7 @@ func (fr *FallbackRenderer) FileDiff(ref, file string, staged bool) ([]DiffLine,
 
 	lines, err := fr.inner.FileDiff(ref, file, staged)
 	if err != nil {
-		return lines, err // propagate git errors, don't mask with fallback
+		return lines, fmt.Errorf("fallback file diff %s: %w", file, err)
 	}
 	if len(lines) > 0 {
 		return lines, nil

--- a/app/diff/hg.go
+++ b/app/diff/hg.go
@@ -100,10 +100,23 @@ func parseStatus(out string) []FileEntry {
 }
 
 // revFlag builds revision arguments from a ref string using the given flag name.
-// handles range refs (A..B) producing two separate flags (e.g. -r A -r B).
+// handles triple-dot (A...B) and double-dot (A..B) range refs, producing two separate flags.
 func (h *Hg) revFlag(flag, ref string) []string {
 	if ref == "" {
 		return nil
+	}
+
+	// check triple-dot first so "A...B" isn't mis-split on ".."
+	if left, right, ok := strings.Cut(ref, "..."); ok {
+		l := translateRef(left)
+		r := translateRef(right)
+		if l == "" {
+			l = "0"
+		}
+		if r == "" {
+			r = "."
+		}
+		return []string{flag, fmt.Sprintf("ancestor(%s,%s)", l, r), flag, r}
 	}
 
 	if left, right, ok := strings.Cut(ref, ".."); ok {

--- a/app/diff/hg.go
+++ b/app/diff/hg.go
@@ -1,0 +1,162 @@
+package diff
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Hg provides methods to extract changed files and build full-file diff views for Mercurial repos.
+type Hg struct {
+	workDir string // working directory for hg commands
+}
+
+// NewHg creates a new Hg diff renderer rooted at the given working directory.
+func NewHg(workDir string) *Hg {
+	return &Hg{workDir: workDir}
+}
+
+// UntrackedFiles returns untracked files using hg status.
+func (h *Hg) UntrackedFiles() ([]string, error) {
+	out, err := h.runHg("status", "--no-status", "--unknown")
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+// hgStatusRe matches hg status output lines: "M path/to/file" or "? path/to/file".
+var hgStatusRe = regexp.MustCompile(`^([MAR?!]) (.+)$`)
+
+// hgStatusToFileStatus converts an hg status letter to a FileStatus.
+// hg uses "R" for removed (not renamed), mapping to FileDeleted.
+// returns empty string for unknown or skipped statuses.
+func hgStatusToFileStatus(status string) FileStatus {
+	switch FileStatus(status) {
+	case FileModified:
+		return FileModified
+	case FileAdded:
+		return FileAdded
+	case "R": // hg "R" = removed, not renamed
+		return FileDeleted
+	default:
+		return ""
+	}
+}
+
+// ChangedFiles returns a list of files changed relative to the given ref with their change status.
+// if ref is empty, shows uncommitted changes. staged flag is ignored (hg has no staging area).
+func (h *Hg) ChangedFiles(ref string, _ bool) ([]FileEntry, error) {
+	if ref != "" {
+		return h.changedFilesFromDiff(ref)
+	}
+
+	// uncommitted changes: use hg status
+	out, err := h.runHg("status", "--color=never")
+	if err != nil {
+		return nil, fmt.Errorf("get changed files: %w", err)
+	}
+
+	return parseStatus(out), nil
+}
+
+// changedFilesFromDiff lists changed files between revisions using hg status --rev.
+func (h *Hg) changedFilesFromDiff(ref string) ([]FileEntry, error) {
+	revArgs := h.revFlag("--rev", ref)
+	args := make([]string, 0, 2+len(revArgs))
+	args = append(args, "status", "--color=never")
+	args = append(args, revArgs...)
+
+	out, err := h.runHg(args...)
+	if err != nil {
+		return nil, fmt.Errorf("get changed files: %w", err)
+	}
+
+	return parseStatus(out), nil
+}
+
+// parseStatus parses hg status output into file entries.
+func parseStatus(out string) []FileEntry {
+	var entries []FileEntry
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		m := hgStatusRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		status, path := m[1], m[2]
+		fs := hgStatusToFileStatus(status)
+		if fs == "" {
+			continue
+		}
+		entries = append(entries, FileEntry{Path: path, Status: fs})
+	}
+	return entries
+}
+
+// revFlag builds revision arguments from a ref string using the given flag name.
+// handles range refs (A..B) producing two separate flags (e.g. -r A -r B).
+func (h *Hg) revFlag(flag, ref string) []string {
+	if ref == "" {
+		return nil
+	}
+
+	if left, right, ok := strings.Cut(ref, ".."); ok {
+		l := translateRef(left)
+		r := translateRef(right)
+		if l == "" {
+			l = "0"
+		}
+		if r == "" {
+			r = "."
+		}
+		return []string{flag, l, flag, r}
+	}
+
+	return []string{flag, translateRef(ref)}
+}
+
+// FileDiff returns the full-file diff view for a single file.
+// staged flag is ignored (hg has no staging area).
+func (h *Hg) FileDiff(ref, file string, _ bool) ([]DiffLine, error) {
+	rArgs := h.revFlag("-r", ref)
+	args := make([]string, 0, 5+len(rArgs))
+	args = append(args, "diff", "--git", "--color=never")
+	args = append(args, rArgs...)
+	args = append(args, fullFileContext, "--", file)
+
+	out, err := h.runHg(args...)
+	if err != nil {
+		return nil, fmt.Errorf("get file diff for %s: %w", file, err)
+	}
+
+	return parseUnifiedDiff(out)
+}
+
+// translateRef converts git-style refs to mercurial revset syntax.
+// HEAD -> ".", HEAD~N -> ".~N", HEAD^ -> ".^", HEAD^N (N>1) -> "pN(.)".
+func translateRef(ref string) string {
+	switch {
+	case ref == "HEAD":
+		return "."
+	case strings.HasPrefix(ref, "HEAD~"):
+		return ".~" + ref[5:]
+	case ref == "HEAD^" || ref == "HEAD^1":
+		return ".^"
+	case strings.HasPrefix(ref, "HEAD^"):
+		// HEAD^N where N>1 means "Nth parent" — use mercurial pN() function
+		return "p" + ref[5:] + "(.)"
+	default:
+		return ref
+	}
+}
+
+// runHg executes a mercurial command in the working directory and returns its output.
+func (h *Hg) runHg(args ...string) (string, error) {
+	return runVCS(h.workDir, "hg", args...)
+}

--- a/app/diff/hg.go
+++ b/app/diff/hg.go
@@ -37,7 +37,7 @@ var hgStatusRe = regexp.MustCompile(`^([MAR?!]) (.+)$`)
 // hgStatusToFileStatus converts an hg status letter to a FileStatus.
 // hg uses "R" for removed (not renamed), mapping to FileDeleted.
 // returns empty string for unknown or skipped statuses.
-func hgStatusToFileStatus(status string) FileStatus {
+func (h *Hg) hgStatusToFileStatus(status string) FileStatus {
 	switch FileStatus(status) {
 	case FileModified:
 		return FileModified
@@ -63,7 +63,7 @@ func (h *Hg) ChangedFiles(ref string, _ bool) ([]FileEntry, error) {
 		return nil, fmt.Errorf("get changed files: %w", err)
 	}
 
-	return parseStatus(out), nil
+	return h.parseStatus(out), nil
 }
 
 // changedFilesFromDiff lists changed files between revisions using hg status --rev.
@@ -78,11 +78,11 @@ func (h *Hg) changedFilesFromDiff(ref string) ([]FileEntry, error) {
 		return nil, fmt.Errorf("get changed files: %w", err)
 	}
 
-	return parseStatus(out), nil
+	return h.parseStatus(out), nil
 }
 
 // parseStatus parses hg status output into file entries.
-func parseStatus(out string) []FileEntry {
+func (h *Hg) parseStatus(out string) []FileEntry {
 	var entries []FileEntry
 	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
 		m := hgStatusRe.FindStringSubmatch(line)
@@ -90,7 +90,7 @@ func parseStatus(out string) []FileEntry {
 			continue
 		}
 		status, path := m[1], m[2]
-		fs := hgStatusToFileStatus(status)
+		fs := h.hgStatusToFileStatus(status)
 		if fs == "" {
 			continue
 		}

--- a/app/diff/hg_e2e_test.go
+++ b/app/diff/hg_e2e_test.go
@@ -1,0 +1,205 @@
+package diff
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHg_E2E_FullPipeline tests the complete flow: detect VCS → create renderer → list files → diff → blame.
+// mirrors what main.go does for a real hg repo.
+func TestHg_E2E_FullPipeline(t *testing.T) {
+	if _, err := exec.LookPath("hg"); err != nil {
+		t.Skip("hg not available")
+	}
+
+	dir := setupHgRepo(t)
+
+	// create initial content
+	writeFile(t, dir, "hello.txt", "line one\nline two\nline three\n")
+	writeFile(t, dir, "readme.md", "# readme\n")
+	hgCmd(t, dir, "add", "hello.txt", "readme.md")
+	hgCmd(t, dir, "commit", "-m", "initial commit")
+
+	// make changes
+	writeFile(t, dir, "hello.txt", "line one modified\nline two\nline three\nline four\n")
+	writeFile(t, dir, "new.txt", "new file content\n")
+	hgCmd(t, dir, "add", "new.txt")
+	writeFile(t, dir, "untracked.txt", "untracked\n")
+
+	// step 1: detect VCS from a subdirectory
+	sub := filepath.Join(dir, "subdir")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	vcsType, root := DetectVCS(sub)
+	assert.Equal(t, VCSHg, vcsType)
+	assert.Equal(t, dir, root)
+
+	// step 2: create Hg renderer (same as main.go)
+	h := NewHg(root)
+
+	// step 3: list changed files
+	entries, err := h.ChangedFiles("", false)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "expected hello.txt (modified) and new.txt (added)")
+
+	paths := FileEntryPaths(entries)
+	assert.Contains(t, paths, "hello.txt")
+	assert.Contains(t, paths, "new.txt")
+
+	// verify statuses
+	for _, e := range entries {
+		switch e.Path {
+		case "hello.txt":
+			assert.Equal(t, FileModified, e.Status)
+		case "new.txt":
+			assert.Equal(t, FileAdded, e.Status)
+		}
+	}
+
+	// step 4: get file diff (goes through parseUnifiedDiff)
+	lines, err := h.FileDiff("", "hello.txt", false)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	// verify diff content
+	var adds, removes, ctx int
+	for _, l := range lines {
+		switch l.ChangeType { //nolint:exhaustive // only counting relevant types
+		case ChangeAdd:
+			adds++
+		case ChangeRemove:
+			removes++
+		case ChangeContext:
+			ctx++
+		}
+	}
+	assert.Equal(t, 1, removes, "expected 1 removed line (line one)")
+	assert.Equal(t, 2, adds, "expected 2 added lines (line one modified + line four)")
+	assert.Equal(t, 2, ctx, "expected 2 context lines (line two + line three)")
+
+	// step 5: new file diff should be all additions
+	newLines, err := h.FileDiff("", "new.txt", false)
+	require.NoError(t, err)
+	require.NotEmpty(t, newLines)
+	for _, l := range newLines {
+		if l.ChangeType == ChangeDivider {
+			continue
+		}
+		assert.Equal(t, ChangeAdd, l.ChangeType)
+	}
+
+	// step 6: blame (uses hg annotate)
+	blame, err := h.FileBlame("", "hello.txt", false)
+	require.NoError(t, err)
+	// blame only covers committed lines (3 from initial commit)
+	assert.Len(t, blame, 3)
+	for _, bl := range blame {
+		assert.Equal(t, "Test User", bl.Author)
+		assert.False(t, bl.Time.IsZero())
+	}
+
+	// step 7: untracked files
+	untracked, err := h.UntrackedFiles()
+	require.NoError(t, err)
+	assert.Contains(t, untracked, "untracked.txt")
+	assert.NotContains(t, untracked, "hello.txt")
+	assert.NotContains(t, untracked, "new.txt")
+}
+
+// TestHg_E2E_RefDiff tests diffs between committed revisions.
+func TestHg_E2E_RefDiff(t *testing.T) {
+	if _, err := exec.LookPath("hg"); err != nil {
+		t.Skip("hg not available")
+	}
+
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "original\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "rev 0")
+
+	writeFile(t, dir, "hello.txt", "modified\n")
+	hgCmd(t, dir, "commit", "-m", "rev 1")
+
+	writeFile(t, dir, "hello.txt", "final\n")
+	hgCmd(t, dir, "commit", "-m", "rev 2")
+
+	// diff rev 0 to rev 2
+	entries, err := h.ChangedFiles("0..2", false)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "hello.txt", entries[0].Path)
+
+	lines, err := h.FileDiff("0..2", "hello.txt", false)
+	require.NoError(t, err)
+
+	var adds, removes int
+	for _, l := range lines {
+		switch l.ChangeType { //nolint:exhaustive // only counting relevant types
+		case ChangeAdd:
+			adds++
+		case ChangeRemove:
+			removes++
+		}
+	}
+	assert.Equal(t, 1, adds, "expected 'final' added")
+	assert.Equal(t, 1, removes, "expected 'original' removed")
+
+	// blame at specific revision
+	blame, err := h.FileBlame("0..2", "hello.txt", false)
+	require.NoError(t, err)
+	assert.Len(t, blame, 1) // "final" is one line
+	assert.Equal(t, "Test User", blame[1].Author)
+}
+
+// TestGit_E2E_StillWorks verifies git repos still work after the refactoring.
+func TestGit_E2E_StillWorks(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	writeFile(t, dir, "hello.txt", "line one\n")
+	gitCmd(t, dir, "add", "hello.txt")
+	gitCmd(t, dir, "commit", "-m", "init")
+
+	writeFile(t, dir, "hello.txt", "line one modified\n")
+
+	// detect VCS
+	vcsType, root := DetectVCS(dir)
+	assert.Equal(t, VCSGit, vcsType)
+	assert.Equal(t, dir, root)
+
+	// use Git renderer
+	g := NewGit(root)
+
+	entries, err := g.ChangedFiles("", false)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "hello.txt", entries[0].Path)
+	assert.Equal(t, FileModified, entries[0].Status)
+
+	lines, err := g.FileDiff("", "hello.txt", false)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	var adds, removes int
+	for _, l := range lines {
+		switch l.ChangeType { //nolint:exhaustive // only counting relevant types
+		case ChangeAdd:
+			adds++
+		case ChangeRemove:
+			removes++
+		}
+	}
+	assert.Equal(t, 1, adds)
+	assert.Equal(t, 1, removes)
+
+	// blame on worktree — uncommitted line shows "Not Committed Yet"
+	blame, err := g.FileBlame("", "hello.txt", false)
+	require.NoError(t, err)
+	assert.Len(t, blame, 1)
+	assert.NotEmpty(t, blame[1].Author)
+}

--- a/app/diff/hg_test.go
+++ b/app/diff/hg_test.go
@@ -71,6 +71,8 @@ func TestHg_RevFlag(t *testing.T) {
 		{name: "range --rev", flag: "--rev", ref: "main..feature", want: []string{"--rev", "main", "--rev", "feature"}},
 		{name: "left empty", flag: "-r", ref: "..HEAD", want: []string{"-r", "0", "-r", "."}},
 		{name: "right empty", flag: "-r", ref: "main..", want: []string{"-r", "main", "-r", "."}},
+		{name: "triple dot", flag: "-r", ref: "main...feature", want: []string{"-r", "ancestor(main,feature)", "-r", "feature"}},
+		{name: "triple dot HEAD", flag: "-r", ref: "HEAD~3...HEAD", want: []string{"-r", "ancestor(.~3,.)", "-r", "."}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/app/diff/hg_test.go
+++ b/app/diff/hg_test.go
@@ -1,0 +1,304 @@
+package diff
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupHgRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("hg"); err != nil {
+		t.Skip("hg not available")
+	}
+	dir := t.TempDir()
+	hgCmd(t, dir, "init")
+	err := os.WriteFile(filepath.Join(dir, ".hg", "hgrc"), []byte("[ui]\nusername = Test User <test@test.com>\n"), 0o600)
+	require.NoError(t, err)
+	return dir
+}
+
+func hgCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("hg", args...) //nolint:gosec // args constructed internally
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "hg %v failed: %s", args, string(out))
+}
+
+func TestTranslateRef(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "HEAD", ref: "HEAD", want: "."},
+		{name: "HEAD~1", ref: "HEAD~1", want: ".~1"},
+		{name: "HEAD~3", ref: "HEAD~3", want: ".~3"},
+		{name: "HEAD^", ref: "HEAD^", want: ".^"},
+		{name: "HEAD^1", ref: "HEAD^1", want: ".^"},
+		{name: "HEAD^2", ref: "HEAD^2", want: "p2(.)"},
+		{name: "HEAD^3", ref: "HEAD^3", want: "p3(.)"},
+		{name: "bare hash", ref: "abc123", want: "abc123"},
+		{name: "bookmark", ref: "main", want: "main"},
+		{name: "empty", ref: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, translateRef(tt.ref))
+		})
+	}
+}
+
+func TestHg_RevFlag(t *testing.T) {
+	h := &Hg{}
+
+	tests := []struct {
+		name string
+		flag string
+		ref  string
+		want []string
+	}{
+		{name: "empty", flag: "-r", ref: "", want: nil},
+		{name: "single ref -r", flag: "-r", ref: "HEAD", want: []string{"-r", "."}},
+		{name: "range -r", flag: "-r", ref: "main..feature", want: []string{"-r", "main", "-r", "feature"}},
+		{name: "HEAD range -r", flag: "-r", ref: "HEAD~3..HEAD", want: []string{"-r", ".~3", "-r", "."}},
+		{name: "single ref --rev", flag: "--rev", ref: "HEAD", want: []string{"--rev", "."}},
+		{name: "range --rev", flag: "--rev", ref: "main..feature", want: []string{"--rev", "main", "--rev", "feature"}},
+		{name: "left empty", flag: "-r", ref: "..HEAD", want: []string{"-r", "0", "-r", "."}},
+		{name: "right empty", flag: "-r", ref: "main..", want: []string{"-r", "main", "-r", "."}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, h.revFlag(tt.flag, tt.ref))
+		})
+	}
+}
+
+func TestHg_ChangedFiles_Uncommitted(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	// create and commit a file
+	writeFile(t, dir, "hello.txt", "hello\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "init")
+
+	// modify the file
+	writeFile(t, dir, "hello.txt", "hello world\n")
+
+	entries, err := h.ChangedFiles("", false)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "hello.txt", entries[0].Path)
+	assert.Equal(t, FileModified, entries[0].Status)
+}
+
+func TestHg_ChangedFiles_Added(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "hello\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "init")
+
+	writeFile(t, dir, "new.txt", "new file\n")
+	hgCmd(t, dir, "add", "new.txt")
+
+	entries, err := h.ChangedFiles("", false)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "new.txt", entries[0].Path)
+	assert.Equal(t, FileAdded, entries[0].Status)
+}
+
+func TestHg_ChangedFiles_NoChanges(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "hello\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "init")
+
+	entries, err := h.ChangedFiles("", false)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestHg_ChangedFiles_Deleted(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "hello\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "init")
+
+	hgCmd(t, dir, "remove", "hello.txt")
+
+	entries, err := h.ChangedFiles("", false)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "hello.txt", entries[0].Path)
+	assert.Equal(t, FileDeleted, entries[0].Status)
+}
+
+func TestHg_FileDiff_Uncommitted(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "line one\nline two\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "init")
+
+	writeFile(t, dir, "hello.txt", "line one\nline modified\nline three\n")
+
+	lines, err := h.FileDiff("", "hello.txt", false)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	// should have mix of context, add, and remove lines
+	var adds, removes, ctx int
+	for _, l := range lines {
+		switch l.ChangeType { //nolint:exhaustive // only counting relevant types
+		case ChangeAdd:
+			adds++
+		case ChangeRemove:
+			removes++
+		case ChangeContext:
+			ctx++
+		}
+	}
+	assert.Positive(t, adds, "expected some added lines")
+	assert.Positive(t, removes, "expected some removed lines")
+	assert.Positive(t, ctx, "expected some context lines")
+}
+
+func TestHg_FileDiff_NewFile(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "line one\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "init")
+
+	writeFile(t, dir, "new.txt", "new content\n")
+	hgCmd(t, dir, "add", "new.txt")
+
+	lines, err := h.FileDiff("", "new.txt", false)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	// all lines should be additions
+	for _, l := range lines {
+		if l.ChangeType == ChangeDivider {
+			continue
+		}
+		assert.Equal(t, ChangeAdd, l.ChangeType, "new file lines should be additions")
+	}
+}
+
+func TestHg_FileDiff_WithRef(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "original\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "first")
+
+	writeFile(t, dir, "hello.txt", "modified\n")
+	hgCmd(t, dir, "commit", "-m", "second")
+
+	// diff between revisions
+	lines, err := h.FileDiff("0..1", "hello.txt", false)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	var adds, removes int
+	for _, l := range lines {
+		switch l.ChangeType { //nolint:exhaustive // only counting relevant types
+		case ChangeAdd:
+			adds++
+		case ChangeRemove:
+			removes++
+		}
+	}
+	assert.Equal(t, 1, adds)
+	assert.Equal(t, 1, removes)
+}
+
+func TestHg_UntrackedFiles(t *testing.T) {
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "tracked.txt", "tracked\n")
+	hgCmd(t, dir, "add", "tracked.txt")
+	hgCmd(t, dir, "commit", "-m", "init")
+
+	writeFile(t, dir, "untracked.txt", "untracked\n")
+
+	files, err := h.UntrackedFiles()
+	require.NoError(t, err)
+	assert.Contains(t, files, "untracked.txt")
+	assert.NotContains(t, files, "tracked.txt")
+}
+
+func TestParseStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []FileEntry
+	}{
+		{
+			name:  "modified file",
+			input: "M hello.txt\n",
+			want:  []FileEntry{{Path: "hello.txt", Status: FileModified}},
+		},
+		{
+			name:  "multiple statuses",
+			input: "M a.txt\nA b.txt\nR c.txt\n",
+			want: []FileEntry{
+				{Path: "a.txt", Status: FileModified},
+				{Path: "b.txt", Status: FileAdded},
+				{Path: "c.txt", Status: FileDeleted},
+			},
+		},
+		{
+			name:  "skips untracked",
+			input: "M a.txt\n? untracked.txt\n",
+			want:  []FileEntry{{Path: "a.txt", Status: FileModified}},
+		},
+		{
+			name:  "empty",
+			input: "",
+			want:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseStatus(tt.input))
+		})
+	}
+}
+
+func TestHgStatusToFileStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   FileStatus
+	}{
+		{"M", FileModified},
+		{"A", FileAdded},
+		{"R", FileDeleted},
+		{"?", ""},
+		{"!", ""},
+		{"I", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, hgStatusToFileStatus(tt.status))
+		})
+	}
+}

--- a/app/diff/hg_test.go
+++ b/app/diff/hg_test.go
@@ -248,7 +248,8 @@ func TestHg_UntrackedFiles(t *testing.T) {
 	assert.NotContains(t, files, "tracked.txt")
 }
 
-func TestParseStatus(t *testing.T) {
+func TestHg_ParseStatus(t *testing.T) {
+	h := &Hg{}
 	tests := []struct {
 		name  string
 		input string
@@ -281,12 +282,13 @@ func TestParseStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, parseStatus(tt.input))
+			assert.Equal(t, tt.want, h.parseStatus(tt.input))
 		})
 	}
 }
 
-func TestHgStatusToFileStatus(t *testing.T) {
+func TestHg_StatusToFileStatus(t *testing.T) {
+	h := &Hg{}
 	tests := []struct {
 		status string
 		want   FileStatus
@@ -300,7 +302,7 @@ func TestHgStatusToFileStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
-			assert.Equal(t, tt.want, hgStatusToFileStatus(tt.status))
+			assert.Equal(t, tt.want, h.hgStatusToFileStatus(tt.status))
 		})
 	}
 }

--- a/app/diff/hgblame.go
+++ b/app/diff/hgblame.go
@@ -1,0 +1,87 @@
+package diff
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// hgAnnotateTemplate is the template for hg annotate that produces tab-separated output:
+// rev\tnode\tauthor\tepoch offset\tline_content
+const hgAnnotateTemplate = `{lines % "{rev}\t{node|short}\t{author|person}\t{date|hgdate}\t{line}"}`
+
+// FileBlame returns blame information for each line of a file.
+// for mercurial, staged flag is ignored (no staging area).
+func (h *Hg) FileBlame(ref, file string, _ bool) (map[int]BlameLine, error) {
+	args := []string{"annotate", "-T", hgAnnotateTemplate}
+	if targetRef := h.blameTargetRef(ref); targetRef != "" {
+		args = append(args, "-r", targetRef)
+	}
+	args = append(args, file)
+
+	out, err := h.runHg(args...)
+	if err != nil {
+		return nil, fmt.Errorf("annotate %s: %w", file, err)
+	}
+	return h.parseAnnotate(out)
+}
+
+// blameTargetRef extracts the target revision for hg annotate from a ref.
+// unlike Git.blameTargetRef (which returns "" for single refs to blame the worktree),
+// hg needs the revision passed explicitly since it has no staging area distinction.
+func (h *Hg) blameTargetRef(ref string) string {
+	// check triple-dot first so "A...B" isn't mis-split on ".."
+	if left, right, ok := strings.Cut(ref, "..."); ok {
+		if left == "" || right == "" {
+			return ""
+		}
+		return translateRef(right)
+	}
+	if left, right, ok := strings.Cut(ref, ".."); ok {
+		if left == "" || right == "" {
+			return ""
+		}
+		return translateRef(right)
+	}
+	if ref != "" {
+		return translateRef(ref)
+	}
+	return ""
+}
+
+// parseAnnotate parses hg annotate template output into a map of line number to BlameLine.
+// each line is: rev\tnode\tauthor\tepoch offset\tline_content
+func (h *Hg) parseAnnotate(raw string) (map[int]BlameLine, error) {
+	result := make(map[int]BlameLine)
+	lineNum := 0
+
+	for line := range strings.SplitSeq(raw, "\n") {
+		// skip trailing empty element from final newline, but count all other lines
+		if line == "" {
+			continue
+		}
+		lineNum++
+
+		// split into at most 5 fields: rev, node, author, hgdate, content
+		parts := strings.SplitN(line, "\t", 5)
+		if len(parts) < 4 { // malformed line — still counted, just not parsed
+			continue
+		}
+
+		author := parts[2]
+
+		// parse hgdate format: "epoch offset" (e.g. "1775860468 -7200")
+		var authorTime time.Time
+		dateParts := strings.Fields(parts[3])
+		if len(dateParts) >= 1 {
+			if epoch, err := strconv.ParseInt(dateParts[0], 10, 64); err == nil {
+				authorTime = time.Unix(epoch, 0)
+			}
+		}
+
+		result[lineNum] = BlameLine{Author: author, Time: authorTime}
+	}
+
+	return result, nil
+}

--- a/app/diff/hgblame_test.go
+++ b/app/diff/hgblame_test.go
@@ -1,0 +1,112 @@
+package diff
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHg_ParseAnnotate(t *testing.T) {
+	h := &Hg{}
+
+	raw := "0\t6c394a888c81\tTest User\t1775860468 -7200\tline one\n" +
+		"1\t3721fe584e35\tAnother Dev\t1775860469 -7200\tline two\n"
+
+	result, err := h.parseAnnotate(raw)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	assert.Equal(t, "Test User", result[1].Author)
+	assert.Equal(t, int64(1775860468), result[1].Time.Unix())
+
+	assert.Equal(t, "Another Dev", result[2].Author)
+	assert.Equal(t, int64(1775860469), result[2].Time.Unix())
+}
+
+func TestHg_ParseAnnotate_Empty(t *testing.T) {
+	h := &Hg{}
+	result, err := h.parseAnnotate("")
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestHg_ParseAnnotate_BlankLineContent(t *testing.T) {
+	h := &Hg{}
+
+	// line with empty content (5th field is empty or missing)
+	raw := "0\t6c394a888c81\tTest User\t1775860468 -7200\t\n" +
+		"0\t6c394a888c81\tTest User\t1775860468 -7200\thello\n"
+
+	result, err := h.parseAnnotate(raw)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, "Test User", result[1].Author)
+	assert.Equal(t, "Test User", result[2].Author)
+}
+
+func TestHg_ParseAnnotate_MalformedLines(t *testing.T) {
+	h := &Hg{}
+
+	// malformed line with fewer than 4 fields is skipped but counted
+	raw := "bad\tdata\n" +
+		"0\t6c394a888c81\tTest User\t1775860468 -7200\tline one\n"
+
+	result, err := h.parseAnnotate(raw)
+	require.NoError(t, err)
+	// line 1 is malformed (skipped), line 2 is valid at lineNum=2
+	require.Len(t, result, 1)
+	assert.Equal(t, "Test User", result[2].Author)
+}
+
+func TestHg_BlameTargetRef(t *testing.T) {
+	h := &Hg{}
+
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "empty", ref: "", want: ""},
+		{name: "single ref", ref: "HEAD", want: "."},
+		{name: "single hash", ref: "abc123", want: "abc123"},
+		{name: "double dot", ref: "main..feature", want: "feature"},
+		{name: "triple dot", ref: "main...feature", want: "feature"},
+		{name: "HEAD range", ref: "HEAD~3..HEAD", want: "."},
+		{name: "left empty double dot", ref: "..feature", want: ""},
+		{name: "right empty double dot", ref: "main..", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, h.blameTargetRef(tt.ref))
+		})
+	}
+}
+
+func TestHg_FileBlame_Integration(t *testing.T) {
+	if _, err := exec.LookPath("hg"); err != nil {
+		t.Skip("hg not available")
+	}
+
+	dir := setupHgRepo(t)
+	h := NewHg(dir)
+
+	writeFile(t, dir, "hello.txt", "line one\n")
+	hgCmd(t, dir, "add", "hello.txt")
+	hgCmd(t, dir, "commit", "-m", "first")
+
+	writeFile(t, dir, "hello.txt", "line one\nline two\n")
+	hgCmd(t, dir, "commit", "-m", "second")
+
+	blame, err := h.FileBlame("", "hello.txt", false)
+	require.NoError(t, err)
+	require.Len(t, blame, 2)
+
+	// both lines should have "Test User" as author
+	assert.Equal(t, "Test User", blame[1].Author)
+	assert.Equal(t, "Test User", blame[2].Author)
+
+	// second line should have a later or equal timestamp
+	assert.False(t, blame[2].Time.Before(blame[1].Time))
+}

--- a/app/diff/vcs.go
+++ b/app/diff/vcs.go
@@ -1,0 +1,41 @@
+package diff
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// VCSType identifies a version control system.
+type VCSType string
+
+const (
+	VCSGit  VCSType = "git"
+	VCSHg   VCSType = "hg"
+	VCSNone VCSType = ""
+)
+
+// DetectVCS walks up from startDir looking for .git or .hg directories.
+// returns the VCS type and repo root path. If no VCS is found, returns VCSNone and empty string.
+// when both .git and .hg exist in the same directory, git takes precedence.
+func DetectVCS(startDir string) (VCSType, string) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return VCSNone, ""
+	}
+
+	for {
+		// check .git first (takes precedence); .git can be a file in worktrees/submodules
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return VCSGit, dir
+		}
+		if info, err := os.Stat(filepath.Join(dir, ".hg")); err == nil && info.IsDir() {
+			return VCSHg, dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return VCSNone, ""
+		}
+		dir = parent
+	}
+}

--- a/app/diff/vcs_test.go
+++ b/app/diff/vcs_test.go
@@ -1,0 +1,70 @@
+package diff
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectVCS_Git(t *testing.T) {
+	dir := t.TempDir()
+	err := os.Mkdir(filepath.Join(dir, ".git"), 0o750)
+	require.NoError(t, err)
+
+	vcs, root := DetectVCS(dir)
+	assert.Equal(t, VCSGit, vcs)
+	assert.Equal(t, dir, root)
+}
+
+func TestDetectVCS_Hg(t *testing.T) {
+	dir := t.TempDir()
+	err := os.Mkdir(filepath.Join(dir, ".hg"), 0o750)
+	require.NoError(t, err)
+
+	vcs, root := DetectVCS(dir)
+	assert.Equal(t, VCSHg, vcs)
+	assert.Equal(t, dir, root)
+}
+
+func TestDetectVCS_GitTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o750))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hg"), 0o750))
+
+	vcs, root := DetectVCS(dir)
+	assert.Equal(t, VCSGit, vcs)
+	assert.Equal(t, dir, root)
+}
+
+func TestDetectVCS_WalksUp(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hg"), 0o750))
+
+	sub := filepath.Join(dir, "deep", "nested")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+
+	vcs, root := DetectVCS(sub)
+	assert.Equal(t, VCSHg, vcs)
+	assert.Equal(t, dir, root)
+}
+
+func TestDetectVCS_GitWorktree(t *testing.T) {
+	// in git worktrees and submodules, .git is a file (not a directory)
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /some/other/path\n"), 0o600)
+	require.NoError(t, err)
+
+	vcs, root := DetectVCS(dir)
+	assert.Equal(t, VCSGit, vcs)
+	assert.Equal(t, dir, root)
+}
+
+func TestDetectVCS_None(t *testing.T) {
+	dir := t.TempDir()
+	vcs, root := DetectVCS(dir)
+	assert.Equal(t, VCSNone, vcs)
+	assert.Empty(t, root)
+}

--- a/app/main.go
+++ b/app/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -38,10 +36,10 @@ type options struct {
 	Collapsed        bool     `long:"collapsed" ini-name:"collapsed" env:"REVDIFF_COLLAPSED" description:"start in collapsed diff mode"`
 	CrossFileHunks   bool     `long:"cross-file-hunks" ini-name:"cross-file-hunks" env:"REVDIFF_CROSS_FILE_HUNKS" description:"allow [ and ] to jump across file boundaries"`
 	LineNumbers      bool     `long:"line-numbers" ini-name:"line-numbers" env:"REVDIFF_LINE_NUMBERS" description:"show line numbers in diff gutter"`
-	Blame            bool     `long:"blame" ini-name:"blame" env:"REVDIFF_BLAME" description:"show git blame gutter on startup"`
+	Blame            bool     `long:"blame" ini-name:"blame" env:"REVDIFF_BLAME" description:"show blame gutter on startup"`
 	WordDiff         bool     `long:"word-diff" ini-name:"word-diff" env:"REVDIFF_WORD_DIFF" description:"highlight intra-line word-level changes in paired add/remove lines"`
 	ChromaStyle      string   `long:"chroma-style" ini-name:"chroma-style" env:"REVDIFF_CHROMA_STYLE" default:"catppuccin-macchiato" description:"chroma style for syntax highlighting"`
-	AllFiles         bool     `long:"all-files" short:"A" no-ini:"true" description:"browse all git-tracked files, not just diffs"`
+	AllFiles         bool     `long:"all-files" short:"A" no-ini:"true" description:"browse all tracked files, not just diffs (git only)"`
 	Stdin            bool     `long:"stdin" no-ini:"true" description:"review stdin as a scratch buffer"`
 	StdinName        string   `long:"stdin-name" no-ini:"true" description:"synthetic file name for stdin content"`
 	Exclude          []string `long:"exclude" short:"X" ini-name:"exclude" env:"REVDIFF_EXCLUDE" env-delim:"," description:"exclude files matching prefix (may be repeated)"`
@@ -366,20 +364,16 @@ func run(opts options) error {
 		defer tty.Close()
 		programOptions = append(programOptions, tea.WithInput(tty))
 	} else {
-		var gitErr error
-		gitRoot, gitErr = gitTopLevel()
-		renderer, workDir, err = makeRenderer(opts.Only, opts.Exclude, opts.AllFiles, gitRoot, gitErr)
+		var setup vcsSetup
+		setup, err = setupVCSRenderer(opts)
 		if err != nil {
 			return err
 		}
-
-		// blame and untracked listing are only available when git is present
-		var g *diff.Git
-		if gitErr == nil {
-			g = diff.NewGit(gitRoot)
-			blamer = g
-			untrackedFn = g.UntrackedFiles
-		}
+		renderer = setup.renderer
+		gitRoot = setup.gitRoot
+		workDir = setup.workDir
+		blamer = setup.blamer
+		untrackedFn = setup.untrackedFn
 	}
 
 	model := ui.NewModel(renderer, store, hl, ui.ModelConfig{
@@ -499,58 +493,95 @@ func saveHistory(r histReq) {
 	})
 }
 
-// makeRenderer selects the appropriate renderer based on git availability and flags.
-// if --all-files is set, returns DirectoryReader (requires git repo).
-// if git is available with --only, it wraps diff.Git with FallbackRenderer.
-// if git is available without --only, it returns diff.Git directly.
-// if git is unavailable and --only is set, it uses FileReader to read files directly from disk.
-// if git is unavailable and --only is not set, it returns an error.
-// when --exclude prefixes are present, wraps the result with ExcludeFilter.
-func makeRenderer(only, exclude []string, allFiles bool, gitRoot string, gitErr error) (ui.Renderer, string, error) {
-	var r ui.Renderer
-	var workDir string
+type vcsSetup struct {
+	renderer    ui.Renderer
+	gitRoot     string // set only when VCS is git; used by history module to run git commands
+	workDir     string
+	blamer      ui.Blamer
+	untrackedFn func() ([]string, error)
+}
 
-	switch {
-	case allFiles && gitErr == nil:
-		r = diff.NewDirectoryReader(gitRoot)
-		workDir = gitRoot
-	case allFiles:
-		return nil, "", errors.New("--all-files requires a git repository")
-	case gitErr == nil && len(only) > 0:
-		r = diff.NewFallbackRenderer(diff.NewGit(gitRoot), only, gitRoot)
-		workDir = gitRoot
-	case gitErr == nil:
-		r = diff.NewGit(gitRoot)
-		workDir = gitRoot
-	case len(only) > 0:
-		cwd, err := os.Getwd()
-		if err != nil {
-			return nil, "", fmt.Errorf("get working directory: %w", err)
-		}
-		r = diff.NewFileReader(only, cwd)
-		workDir = cwd
-	default:
-		return nil, "", fmt.Errorf("find git root: %w", gitErr)
+// setupVCSRenderer detects the VCS and creates the appropriate renderer, blamer, and untracked function.
+func setupVCSRenderer(opts options) (vcsSetup, error) {
+	cwd, cwdErr := os.Getwd()
+	if cwdErr != nil {
+		cwd = "."
 	}
+	vcsType, vcsRoot := diff.DetectVCS(cwd)
 
+	switch vcsType {
+	case diff.VCSGit:
+		g := diff.NewGit(vcsRoot)
+		r, workDir, err := makeGitRenderer(g, opts.Only, opts.Exclude, opts.AllFiles, vcsRoot)
+		if err != nil {
+			return vcsSetup{}, err
+		}
+		return vcsSetup{renderer: r, gitRoot: vcsRoot, workDir: workDir, blamer: g, untrackedFn: g.UntrackedFiles}, nil
+	case diff.VCSHg:
+		if opts.Staged {
+			fmt.Fprintln(os.Stderr, "warning: --staged ignored in mercurial repository (no staging area)")
+		}
+		h := diff.NewHg(vcsRoot)
+		r, workDir, err := makeHgRenderer(h, opts.Only, opts.Exclude, opts.AllFiles, vcsRoot)
+		if err != nil {
+			return vcsSetup{}, err
+		}
+		return vcsSetup{renderer: r, workDir: workDir, blamer: h, untrackedFn: h.UntrackedFiles}, nil
+	default:
+		r, workDir, err := makeNoVCSRenderer(opts.Only, opts.Exclude, cwd)
+		if err != nil {
+			return vcsSetup{}, err
+		}
+		return vcsSetup{renderer: r, workDir: workDir}, nil
+	}
+}
+
+// makeGitRenderer selects the appropriate git renderer based on flags.
+// reuses the provided *Git instance as the default renderer to avoid double allocation.
+func makeGitRenderer(g *diff.Git, only, exclude []string, allFiles bool, repoRoot string) (ui.Renderer, string, error) { //nolint:unparam // error kept for consistency with makeHgRenderer/makeNoVCSRenderer
+	var r ui.Renderer
+	switch {
+	case allFiles:
+		r = diff.NewDirectoryReader(repoRoot)
+	case len(only) > 0:
+		r = diff.NewFallbackRenderer(g, only, repoRoot)
+	default:
+		r = g
+	}
 	if len(exclude) > 0 {
 		r = diff.NewExcludeFilter(r, exclude)
 	}
-	return r, workDir, nil
+	return r, repoRoot, nil
 }
 
-// gitTopLevel returns the root directory of the current git repository.
-func gitTopLevel() (string, error) {
-	cmd := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplevel")
-	out, err := cmd.Output()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return "", fmt.Errorf("git rev-parse --show-toplevel: %s", strings.TrimSpace(string(exitErr.Stderr)))
-		}
-		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
+// makeHgRenderer selects the appropriate mercurial renderer based on flags.
+// reuses the provided *Hg instance as the default renderer to avoid double allocation.
+func makeHgRenderer(h *diff.Hg, only, exclude []string, allFiles bool, repoRoot string) (ui.Renderer, string, error) {
+	var r ui.Renderer
+	switch {
+	case allFiles:
+		return nil, "", errors.New("--all-files is not supported in mercurial repositories")
+	case len(only) > 0:
+		r = diff.NewFileReader(only, repoRoot)
+	default:
+		r = h
 	}
-	return strings.TrimSpace(string(out)), nil
+	if len(exclude) > 0 {
+		r = diff.NewExcludeFilter(r, exclude)
+	}
+	return r, repoRoot, nil
+}
+
+// makeNoVCSRenderer creates a renderer when no VCS is detected.
+func makeNoVCSRenderer(only, exclude []string, cwd string) (ui.Renderer, string, error) {
+	if len(only) == 0 {
+		return nil, "", errors.New("no git or mercurial repository found (use --only to review standalone files)")
+	}
+	var r ui.Renderer = diff.NewFileReader(only, cwd)
+	if len(exclude) > 0 {
+		r = diff.NewExcludeFilter(r, exclude)
+	}
+	return r, cwd, nil
 }
 
 // defaultThemesDir returns ~/.config/revdiff/themes.

--- a/app/main.go
+++ b/app/main.go
@@ -562,7 +562,7 @@ func makeHgRenderer(h *diff.Hg, only, exclude []string, allFiles bool, repoRoot 
 	case allFiles:
 		return nil, "", errors.New("--all-files is not supported in mercurial repositories")
 	case len(only) > 0:
-		r = diff.NewFileReader(only, repoRoot)
+		r = diff.NewFallbackRenderer(h, only, repoRoot)
 	default:
 		r = h
 	}

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -528,18 +528,20 @@ func TestDefaultConfigPath(t *testing.T) {
 	assert.Contains(t, path, "config")
 }
 
-func TestMakeRenderer_GitWithOnly(t *testing.T) {
+func TestMakeGitRenderer_WithOnly(t *testing.T) {
 	dir := t.TempDir()
-	renderer, workDir, err := makeRenderer([]string{"file.md"}, nil, false, dir, nil)
+	g := diff.NewGit(dir)
+	renderer, workDir, err := makeGitRenderer(g, []string{"file.md"}, nil, false, dir)
 	require.NoError(t, err)
 	require.NotNil(t, renderer)
 	assert.IsType(t, &diff.FallbackRenderer{}, renderer)
 	assert.Equal(t, dir, workDir)
 }
 
-func TestMakeRenderer_GitWithoutOnly(t *testing.T) {
+func TestMakeGitRenderer_WithoutOnly(t *testing.T) {
 	dir := t.TempDir()
-	renderer, workDir, err := makeRenderer(nil, nil, false, dir, nil)
+	g := diff.NewGit(dir)
+	renderer, workDir, err := makeGitRenderer(g, nil, nil, false, dir)
 	require.NoError(t, err)
 	require.NotNil(t, renderer)
 	// with no --only, returns *diff.Git directly without FallbackRenderer wrapper
@@ -547,25 +549,22 @@ func TestMakeRenderer_GitWithoutOnly(t *testing.T) {
 	assert.Equal(t, dir, workDir)
 }
 
-func TestMakeRenderer_NoGitWithOnly(t *testing.T) {
+func TestMakeNoVCSRenderer_WithOnly(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Chdir(tmpDir) // set cwd for FileReader
-	gitErr := errors.New("not a git repository")
 
-	renderer, workDir, err := makeRenderer([]string{"file.md"}, nil, false, "", gitErr)
+	renderer, workDir, err := makeNoVCSRenderer([]string{"file.md"}, nil, tmpDir)
 	require.NoError(t, err)
 	require.NotNil(t, renderer)
 	assert.IsType(t, &diff.FileReader{}, renderer)
 	assert.Equal(t, tmpDir, workDir)
 }
 
-func TestMakeRenderer_NoGitNoOnly(t *testing.T) {
-	gitErr := errors.New("not a git repository")
-	renderer, workDir, err := makeRenderer(nil, nil, false, "", gitErr)
+func TestMakeNoVCSRenderer_NoOnly(t *testing.T) {
+	renderer, workDir, err := makeNoVCSRenderer(nil, nil, "/tmp")
 	require.Error(t, err)
 	assert.Nil(t, renderer)
 	assert.Empty(t, workDir)
-	assert.Contains(t, err.Error(), "find git root")
+	assert.Contains(t, err.Error(), "no git or mercurial repository found")
 }
 
 func TestParseArgs_AllFilesFlag(t *testing.T) {
@@ -674,34 +673,66 @@ func TestParseArgs_StdinConflicts(t *testing.T) {
 	}
 }
 
-func TestMakeRenderer_AllFiles(t *testing.T) {
+func TestMakeGitRenderer_AllFiles(t *testing.T) {
 	dir := t.TempDir()
-	renderer, workDir, err := makeRenderer(nil, nil, true, dir, nil)
+	g := diff.NewGit(dir)
+	renderer, workDir, err := makeGitRenderer(g, nil, nil, true, dir)
 	require.NoError(t, err)
 	require.NotNil(t, renderer)
 	assert.IsType(t, &diff.DirectoryReader{}, renderer)
 	assert.Equal(t, dir, workDir)
 }
 
-func TestMakeRenderer_AllFilesNoGit(t *testing.T) {
-	gitErr := errors.New("not a git repository")
-	_, _, err := makeRenderer(nil, nil, true, "", gitErr)
+func TestMakeHgRenderer_AllFilesUnsupported(t *testing.T) {
+	_, _, err := makeHgRenderer(diff.NewHg(""), nil, nil, true, "")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--all-files requires a git repository")
+	assert.Contains(t, err.Error(), "--all-files is not supported in mercurial")
 }
 
-func TestMakeRenderer_WithExclude(t *testing.T) {
+func TestMakeHgRenderer_Default(t *testing.T) {
 	dir := t.TempDir()
-	renderer, workDir, err := makeRenderer(nil, []string{"vendor"}, false, dir, nil)
+	h := diff.NewHg(dir)
+	renderer, workDir, err := makeHgRenderer(h, nil, nil, false, dir)
+	require.NoError(t, err)
+	require.NotNil(t, renderer)
+	assert.IsType(t, &diff.Hg{}, renderer)
+	assert.Equal(t, dir, workDir)
+}
+
+func TestMakeHgRenderer_WithOnly(t *testing.T) {
+	dir := t.TempDir()
+	h := diff.NewHg(dir)
+	renderer, workDir, err := makeHgRenderer(h, []string{"file.go"}, nil, false, dir)
+	require.NoError(t, err)
+	require.NotNil(t, renderer)
+	assert.IsType(t, &diff.FileReader{}, renderer)
+	assert.Equal(t, dir, workDir)
+}
+
+func TestMakeHgRenderer_WithExclude(t *testing.T) {
+	dir := t.TempDir()
+	h := diff.NewHg(dir)
+	renderer, workDir, err := makeHgRenderer(h, nil, []string{"vendor"}, false, dir)
 	require.NoError(t, err)
 	require.NotNil(t, renderer)
 	assert.IsType(t, &diff.ExcludeFilter{}, renderer)
 	assert.Equal(t, dir, workDir)
 }
 
-func TestMakeRenderer_AllFilesWithExclude(t *testing.T) {
+func TestMakeGitRenderer_WithExclude(t *testing.T) {
 	dir := t.TempDir()
-	renderer, workDir, err := makeRenderer(nil, []string{"vendor", "mocks"}, true, dir, nil)
+	g := diff.NewGit(dir)
+	renderer, workDir, err := makeGitRenderer(g, nil, []string{"vendor"}, false, dir)
+	require.NoError(t, err)
+	require.NotNil(t, renderer)
+	assert.IsType(t, &diff.ExcludeFilter{}, renderer)
+	assert.Equal(t, dir, workDir)
+}
+
+func TestMakeGitRenderer_AllFilesWithExclude(t *testing.T) {
+	dir := t.TempDir()
+	g := diff.NewGit(dir)
+	renderer, workDir, err := makeGitRenderer(g, nil, []string{"vendor", "mocks"}, true, dir)
 	require.NoError(t, err)
 	require.NotNil(t, renderer)
 	// should be ExcludeFilter wrapping DirectoryReader
@@ -759,20 +790,19 @@ func TestDefaultKeysPath(t *testing.T) {
 	assert.Contains(t, path, "keybindings")
 }
 
-func TestGitTopLevel(t *testing.T) {
-	t.Run("inside repo", func(t *testing.T) {
-		root, err := gitTopLevel()
-		require.NoError(t, err)
-		assert.DirExists(t, root)
-		assert.NotEmpty(t, root)
-	})
+func TestDetectVCS_Git(t *testing.T) {
+	// this test runs from inside the revdiff repo (which is a git repo)
+	vcsType, root := diff.DetectVCS(".")
+	assert.Equal(t, diff.VCSGit, vcsType)
+	assert.DirExists(t, root)
+	assert.NotEmpty(t, root)
+}
 
-	t.Run("outside repo", func(t *testing.T) {
-		t.Chdir(t.TempDir())
-		_, err := gitTopLevel()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "git rev-parse --show-toplevel")
-	})
+func TestDetectVCS_None(t *testing.T) {
+	t.Chdir(t.TempDir())
+	vcsType, root := diff.DetectVCS(".")
+	assert.Equal(t, diff.VCSNone, vcsType)
+	assert.Empty(t, root)
 }
 
 func TestApplyTheme(t *testing.T) {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -791,11 +791,13 @@ func TestDefaultKeysPath(t *testing.T) {
 }
 
 func TestDetectVCS_Git(t *testing.T) {
-	// this test runs from inside the revdiff repo (which is a git repo)
+	repoRoot := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(repoRoot, ".git"), 0o750))
+	t.Chdir(repoRoot)
+
 	vcsType, root := diff.DetectVCS(".")
 	assert.Equal(t, diff.VCSGit, vcsType)
-	assert.DirExists(t, root)
-	assert.NotEmpty(t, root)
+	assert.Equal(t, repoRoot, root)
 }
 
 func TestDetectVCS_None(t *testing.T) {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -705,7 +705,7 @@ func TestMakeHgRenderer_WithOnly(t *testing.T) {
 	renderer, workDir, err := makeHgRenderer(h, []string{"file.go"}, nil, false, dir)
 	require.NoError(t, err)
 	require.NotNil(t, renderer)
-	assert.IsType(t, &diff.FileReader{}, renderer)
+	assert.IsType(t, &diff.FallbackRenderer{}, renderer)
 	assert.Equal(t, dir, workDir)
 }
 
@@ -791,13 +791,11 @@ func TestDefaultKeysPath(t *testing.T) {
 }
 
 func TestDetectVCS_Git(t *testing.T) {
-	repoRoot := t.TempDir()
-	require.NoError(t, os.Mkdir(filepath.Join(repoRoot, ".git"), 0o750))
-	t.Chdir(repoRoot)
-
+	// this test runs from inside the revdiff repo (which is a git repo)
 	vcsType, root := diff.DetectVCS(".")
 	assert.Equal(t, diff.VCSGit, vcsType)
-	assert.Equal(t, repoRoot, root)
+	assert.DirExists(t, root)
+	assert.NotEmpty(t, root)
 }
 
 func TestDetectVCS_None(t *testing.T) {

--- a/app/ui/doc.go
+++ b/app/ui/doc.go
@@ -26,6 +26,6 @@
 //   - styles.go — lipgloss style definitions, theme color integration
 //
 // The key interfaces consumed by Model are [Renderer] (provides changed files and diffs),
-// [SyntaxHighlighter] (provides ANSI-highlighted lines), and [Blamer] (provides git blame data).
+// [SyntaxHighlighter] (provides ANSI-highlighted lines), and [Blamer] (provides blame data).
 // All three are defined in this package and implemented externally.
 package ui

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -31,7 +31,7 @@ type SyntaxHighlighter interface {
 	StyleName() string
 }
 
-// Blamer provides git blame information for files.
+// Blamer provides blame information for files.
 type Blamer interface {
 	FileBlame(ref, file string, staged bool) (map[int]diff.BlameLine, error)
 }

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -26,7 +26,7 @@ Then uncomment and edit the values you want to change.
 | `--wrap` | `REVDIFF_WRAP` | Enable line wrapping in diff view | `false` |
 | `--collapsed` | `REVDIFF_COLLAPSED` | Start in collapsed diff mode | `false` |
 | `--line-numbers` | `REVDIFF_LINE_NUMBERS` | Show line numbers in diff gutter | `false` |
-| `--blame` | `REVDIFF_BLAME` | Show git blame gutter on startup | `false` |
+| `--blame` | `REVDIFF_BLAME` | Show blame gutter on startup | `false` |
 | `--word-diff` | `REVDIFF_WORD_DIFF` | Highlight intra-line word-level changes in paired add/remove lines | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -109,7 +109,7 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `w` | Toggle word wrap (long lines wrap with `↪` continuation markers) |
 | `t` | Toggle tree/TOC pane visibility (gives diff full terminal width) |
 | `L` | Toggle line numbers (side-by-side old/new numbers in gutter) |
-| `B` | Toggle git blame gutter (author name + commit age per line) |
+| `B` | Toggle blame gutter (author name + commit age per line) |
 | `W` | Toggle intra-line word-diff highlighting for paired add/remove lines |
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
@@ -130,7 +130,7 @@ The status bar shows a fixed row of mode indicators on the right side. All ten s
 | `≋` | `/` | Search active |
 | `⊟` | `t` | Tree/TOC pane hidden (diff uses full width) |
 | `#` | `L` | Line numbers visible in gutter |
-| `b` | `B` | Git blame gutter visible |
+| `b` | `B` | Blame gutter visible |
 | `±` | `W` | Intra-line word-diff highlighting |
 | `✓` | `Space` | Reviewed count (increments when a file is marked reviewed) |
 | `∅` | `u` | Untracked files visible in tree |

--- a/site/docs.html
+++ b/site/docs.html
@@ -104,7 +104,7 @@
         <p>Complete reference for revdiff usage, configuration, themes, keybindings, the pi package, the Claude Code plugin, and the Codex plugin.</p>
 
         <h2 id="requirements">Requirements</h2>
-        <p><code>git</code> is used to generate diffs. It is optional when using <code>--only</code> for standalone file review or <code>--stdin</code> for scratch-buffer review.</p>
+        <p><code>git</code> or <code>hg</code> (Mercurial) is used to generate diffs. VCS is optional when using <code>--only</code> for standalone file review or <code>--stdin</code> for scratch-buffer review.</p>
 
         <h2 id="installation">Installation</h2>
         <h3>Homebrew (macOS/Linux)</h3>
@@ -446,7 +446,7 @@ color-border = #6272a4
                 <tr><td><code>w</code></td><td>Toggle word wrap</td></tr>
                 <tr><td><code>t</code></td><td>Toggle tree/TOC pane visibility</td></tr>
                 <tr><td><code>L</code></td><td>Toggle line numbers</td></tr>
-                <tr><td><code>B</code></td><td>Toggle git blame gutter (author + commit age)</td></tr>
+                <tr><td><code>B</code></td><td>Toggle blame gutter (author + commit age)</td></tr>
                 <tr><td><code>W</code></td><td>Toggle intra-line word-diff highlighting</td></tr>
                 <tr><td><code>.</code></td><td>Expand/collapse hunk (collapsed mode)</td></tr>
                 <tr><td><code>T</code></td><td>Theme selector with live preview</td></tr>
@@ -468,7 +468,7 @@ color-border = #6272a4
                 <tr><td><code>≋</code></td><td><code>/</code></td><td>Search active</td></tr>
                 <tr><td><code>⊟</code></td><td><code>t</code></td><td>Tree/TOC pane hidden (diff uses full width)</td></tr>
                 <tr><td><code>#</code></td><td><code>L</code></td><td>Line numbers visible in gutter</td></tr>
-                <tr><td><code>b</code></td><td><code>B</code></td><td>Git blame gutter visible</td></tr>
+                <tr><td><code>b</code></td><td><code>B</code></td><td>Blame gutter visible</td></tr>
                 <tr><td><code>±</code></td><td><code>W</code></td><td>Intra-line word-diff highlighting</td></tr>
                 <tr><td><code>✓</code></td><td><code>Space</code></td><td>Reviewed count (increments when a file is marked reviewed)</td></tr>
                 <tr><td><code>∅</code></td><td><code>u</code></td><td>Untracked files visible in tree</td></tr>

--- a/site/index.html
+++ b/site/index.html
@@ -115,7 +115,7 @@
             <div class="feature-card">
                 <div class="feature-icon"><span class="glyph add">+</span><span class="glyph remove">-</span></div>
                 <h3>Full-file diff view</h3>
-                <p>Syntax-highlighted diffs with added, removed, and context lines. Collapsed mode shows final text with change markers. Git blame gutter shows who wrote each line.</p>
+                <p>Syntax-highlighted diffs with added, removed, and context lines. Collapsed mode shows final text with change markers. Blame gutter shows who wrote each line.</p>
             </div>
             <div class="feature-card">
                 <div class="feature-icon"><span class="glyph annotation">#</span></div>
@@ -135,7 +135,7 @@
             <div class="feature-card">
                 <div class="feature-icon"><span class="glyph accent">A</span></div>
                 <h3>All-files mode</h3>
-                <p>Browse and annotate all git-tracked files with <code>--all-files</code>. Filter with <code>--exclude</code>. Review standalone files with <code>--only</code> or piped output with <code>--stdin</code>.</p>
+                <p>Browse and annotate all tracked files with <code>--all-files</code> (git). Filter with <code>--exclude</code>. Review standalone files with <code>--only</code> or piped output with <code>--stdin</code>.</p>
             </div>
             <div class="feature-card">
                 <div class="feature-icon"><span class="glyph accent" aria-label="Pi integration">P</span></div>
@@ -145,7 +145,7 @@
             <div class="feature-card">
                 <div class="feature-icon"><span class="glyph accent">v</span></div>
                 <h3>Collapsed &amp; wrap modes</h3>
-                <p>Collapsed mode (<code>v</code>) shows final text with change markers. Word wrap (<code>w</code>) for long lines. Line numbers (<code>L</code>) and git blame (<code>B</code>) gutters.</p>
+                <p>Collapsed mode (<code>v</code>) shows final text with change markers. Word wrap (<code>w</code>) for long lines. Line numbers (<code>L</code>) and blame (<code>B</code>) gutters.</p>
             </div>
             <div class="feature-card">
                 <div class="feature-icon"><span class="glyph accent">&para;</span></div>
@@ -156,6 +156,11 @@
                 <div class="feature-icon"><span class="glyph accent">~</span></div>
                 <h3>Themes &amp; keybindings</h3>
                 <p>7 bundled color themes with interactive selector (<code>T</code>) and live preview. 23 customizable color keys. Full keybinding remapping. Community theme gallery.</p>
+            </div>
+            <div class="feature-card">
+                <div class="feature-icon"><span class="glyph accent">&#x2387;</span></div>
+                <h3>Git &amp; Mercurial</h3>
+                <p>Works with Git and Mercurial repositories. Auto-detects the VCS. Diffs, blame, and untracked file listing work across both backends.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Auto-detect Mercurial repos via `DetectVCS()` walking up directories for `.hg`
- `Hg` struct implements `Renderer` and `Blamer` interfaces using `hg status`, `hg diff --git`, and `hg annotate`
- Git-style ref translation: `HEAD`→`.`, `HEAD~N`→`.~N`, `HEAD^`→`.^`, `HEAD^N`→`pN(.)`
- `--staged` warns when used with hg (no staging area), `--all-files` returns error (git only)
- Shared `runVCS()` helper eliminates duplicate command execution between Git and Hg
- Documentation updated across README, CLAUDE.md, site/docs.html, site/index.html, plugin references
- 37 new test cases covering VCS detection, renderer, blame, ref translation, and E2E with real hg repos