### PR TITLE
Add lint-scripts CI job, fix SC2181 shellcheck warnings

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -193,7 +193,7 @@ $REVDIFF_CMD; touch $(sq "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" "$CWD" <<'APPLESCRIPT'
+    if ! GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" "$CWD" <<'APPLESCRIPT'
 on run argv
     set launchScript to item 1 of argv
     set cwd to item 2 of argv
@@ -209,8 +209,7 @@ on run argv
     end tell
 end run
 APPLESCRIPT
-    )
-    if [ $? -ne 0 ]; then
+    ); then
         rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
         exit 1
     fi

--- a/.github/scripts/validate-frontmatter.py
+++ b/.github/scripts/validate-frontmatter.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Validate YAML frontmatter in all markdown files."""
+
+import os
+import sys
+
+import yaml
+
+failed = False
+for root, dirs, files in os.walk("."):
+    dirs[:] = [d for d in dirs if d not in (".git", "vendor")]
+    for f in files:
+        if not f.endswith(".md"):
+            continue
+        path = os.path.join(root, f)
+        with open(path) as fh:
+            content = fh.read()
+        if not content.startswith("---\n"):
+            continue
+        end = content.find("\n---\n", 4)
+        if end == -1:
+            continue
+        frontmatter = content[4:end]
+        try:
+            yaml.safe_load(frontmatter)
+        except yaml.YAMLError as e:
+            print(f"FAIL: {path}")
+            print(f"  {e}")
+            failed = True
+
+if failed:
+    sys.exit(1)
+print("All markdown frontmatter is valid YAML")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,20 @@ jobs:
         run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  lint-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: validate YAML frontmatter in markdown files
+        run: |
+          pip install pyyaml
+          python3 .github/scripts/validate-frontmatter.py
+
+      - name: shellcheck
+        run: |
+          find . -name '*.sh' -not -path './.git/*' -not -path './vendor/*' -print0 | xargs -0 shellcheck

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -195,7 +195,7 @@ $REVDIFF_CMD; touch $(sq "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" "$CWD" <<'APPLESCRIPT'
+    if ! GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" "$CWD" <<'APPLESCRIPT'
 on run argv
     set launchScript to item 1 of argv
     set cwd to item 2 of argv
@@ -211,8 +211,7 @@ on run argv
     end tell
 end run
 APPLESCRIPT
-    )
-    if [ $? -ne 0 ]; then
+    ); then
         rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
         exit 1
     fi

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -175,7 +175,7 @@ $REVDIFF_CMD; touch $(sq "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" <<'APPLESCRIPT'
+    if ! GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" <<'APPLESCRIPT'
 on run argv
     set launchScript to item 1 of argv
     tell application "Ghostty"
@@ -189,8 +189,7 @@ on run argv
     end tell
 end run
 APPLESCRIPT
-    )
-    if [ $? -ne 0 ]; then
+    ); then
         rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
         exit 1
     fi


### PR DESCRIPTION
## Summary

- Add `lint-scripts` CI job: validates YAML frontmatter via standalone `.github/scripts/validate-frontmatter.py` and runs `shellcheck` on all `.sh` files (excludes `vendor/`)
- Fix SC2181 in 3 scripts: replace `if [ $? -ne 0 ]` after command substitution with `if !` idiom
  - `.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh`
  - `plugins/codex/skills/revdiff/scripts/launch-revdiff.sh`
  - `plugins/revdiff-planning/scripts/launch-plan-review.sh`

Mirrors umputun/cc-thingz#10 CI checks for this repo. No shfmt reformat — only the SC2181 fix.