### PR TITLE
feat: add REVDIFF_LAUNCHER for custom terminal override

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -46,14 +46,23 @@ Then uncomment and edit the values you want to change.
 | `--config` | `REVDIFF_CONFIG` | Path to config file | `~/.config/revdiff/config` |
 | `--dump-config` | | Print default config to stdout and exit | |
 
-## Popup Size (Claude Code plugin)
+## Popup Size and Custom Launcher (Claude Code plugin)
 
-When launched via the Claude Code plugin skill, revdiff opens in a terminal overlay. The popup size is configurable via env vars:
+When launched via the Claude Code plugin skill, revdiff opens in a terminal overlay. The overlay behavior is configurable via env vars:
 
 | Env var | Description | Default |
 |---------|-------------|---------|
 | `REVDIFF_POPUP_WIDTH` | Tmux popup width (e.g., `100%`, `80%`) | `90%` |
 | `REVDIFF_POPUP_HEIGHT` | Tmux popup height / wezterm split percent | `90%` |
+| `REVDIFF_LAUNCHER` | Path to a custom launcher script (overrides all built-in terminal detection) | unset |
+
+When `REVDIFF_LAUNCHER` is set, the script is called with the revdiff binary and all args as `$@`. The window title is available as `$REVDIFF_TITLE`.
+
+Example `~/bin/my-revdiff-launcher`:
+```sh
+#!/bin/sh
+exec kitty -t "$REVDIFF_TITLE" "$@"
+```
 
 ## Themes
 

--- a/.claude-plugin/skills/revdiff/references/install.md
+++ b/.claude-plugin/skills/revdiff/references/install.md
@@ -14,7 +14,7 @@ brew install umputun/apps/revdiff
 /plugin install revdiff@umputun-revdiff
 ```
 
-Use: `/revdiff [base] [against]` — opens review session in a terminal overlay (tmux, Zellij, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm).
+Use: `/revdiff [base] [against]` — opens review session in a terminal overlay (tmux, Zellij, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm). Set `REVDIFF_LAUNCHER` to a custom launcher script to override built-in terminal detection.
 
 ### Plan Review Plugin
 

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -50,6 +50,17 @@ OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 
+# custom launcher: REVDIFF_LAUNCHER overrides all terminal-specific launchers.
+# set it to a script that receives the revdiff binary + args as "$@";
+# REVDIFF_TITLE is exported for use as a window title.
+# example ~/bin/my-launcher: #!/bin/sh\nexec kitty -T "$REVDIFF_TITLE" "$@"
+if [ -n "${REVDIFF_LAUNCHER:-}" ]; then
+    export REVDIFF_TITLE="$OVERLAY_TITLE"
+    sh -c "$(sq "$REVDIFF_LAUNCHER") $REVDIFF_CMD"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
 # tmux: display-popup -E blocks until command exits
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     # -T (title) requires tmux 3.3+; skip on older versions

--- a/README.md
+++ b/README.md
@@ -67,7 +67,18 @@ The plugin requires one of the following terminals since Claude Code itself cann
 | **iTerm2** | `osascript` split pane (macOS only) | `$ITERM_SESSION_ID` env var |
 | **Emacs vterm** | New frame via `emacsclient` | `$INSIDE_EMACS` env var |
 
-Priority: tmux → Zellij → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm (first detected wins). If none are available, the plugin exits with an error.
+Priority: `REVDIFF_LAUNCHER` (custom) → tmux → Zellij → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm (first detected wins). If none are available, the plugin exits with an error.
+
+**Custom launcher:** set `REVDIFF_LAUNCHER` to a script that receives the revdiff binary and all args as `$@`. The window title is passed via the `REVDIFF_TITLE` env var. This overrides all built-in terminal detection.
+
+Example `~/bin/my-revdiff-launcher`:
+```sh
+#!/bin/sh
+exec kitty -t "$REVDIFF_TITLE" "$@"
+```
+```bash
+export REVDIFF_LAUNCHER="$HOME/bin/my-revdiff-launcher"
+```
 
 > **Note:** cmux is detected before ghostty because cmux also sets `$TERM_PROGRAM=ghostty`. The cmux block uses the cmux CLI (`new-split` + `send --surface`) instead of Ghostty's AppleScript API.
 

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -38,6 +38,17 @@ PLAN_ABS=$(cd "$(dirname "$PLAN_FILE")" && echo "$(pwd)/$(basename "$PLAN_FILE")
 REVDIFF_CMD="$(sq "$REVDIFF_BIN") $(sq "--only=$PLAN_ABS") $(sq "--output=$OUTPUT_FILE") $(sq --wrap)"
 OVERLAY_TITLE="plan: $(basename "$PLAN_FILE")"
 
+# custom launcher: REVDIFF_LAUNCHER overrides all terminal-specific launchers.
+# set it to a script that receives the revdiff binary + args as "$@";
+# REVDIFF_TITLE is exported for use as a window title.
+# example ~/bin/my-launcher: #!/bin/sh\nexec kitty -t "$REVDIFF_TITLE" "$@"
+if [ -n "${REVDIFF_LAUNCHER:-}" ]; then
+    export REVDIFF_TITLE="$OVERLAY_TITLE"
+    sh -c "$(sq "$REVDIFF_LAUNCHER") $REVDIFF_CMD"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
 # tmux: display-popup -E blocks until command exits
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     # -T (title) requires tmux 3.3+; skip on older versions


### PR DESCRIPTION
## Summary

Claude Code launches hook programs without a terminal. Its integrations currently use a number of custom approaches to launch TUI programs in different terminal emulators.

This works but there are some drawbacks:
- the user temporarily loses access to the Claude Code session and is not able to, say, scroll around to review conversation history
- the overlay is not a pop-up **window** in the window manager sense, and does not stand out in the application switcher (e.g., Alt-Tab)
- the user might want to use a different approach, for example create a separate terminal window and launch `revdiff` in it

## Changes

- Add `REVDIFF_LAUNCHER` env var to bypass all built-in terminal detection and delegate to a user-supplied launcher script
- The script receives the revdiff binary + args as `$@`; the window title is passed via `$REVDIFF_TITLE`
- Applied to both `launch-revdiff.sh` and `launch-plan-review.sh`
- Docs updated in README and Claude Code plugin references

## Usage

For example, to launch a separate Kitty window instead of an overlay:
```sh
# ~/bin/my-revdiff-launcher
#!/bin/sh
exec kitty -T "$REVDIFF_TITLE" "$@"
```

Start Claude Code with a custom revdiff launcher:
```bash
$ export REVDIFF_LAUNCHER="$HOME/bin/my-revdiff-launcher"
$ claude
```

## Test plan

- [x] Set `REVDIFF_LAUNCHER` to a custom script and verify it is invoked instead of built-in terminal detection
- [x] Verify annotations are still captured correctly via the custom launcher
- [x] Verify `REVDIFF_TITLE` is available in the launcher script
- [x] Verify unset `REVDIFF_LAUNCHER` falls through to normal terminal detection unchanged