### PR TITLE
feat: add history fallback to revdiff skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "revdiff",
       "source": "./",
       "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
   "author": {
     "name": "umputun",

--- a/.claude-plugin/skills/revdiff/SKILL.md
+++ b/.claude-plugin/skills/revdiff/SKILL.md
@@ -123,14 +123,9 @@ The script:
      cat "$output_file"
    fi
    ```
-4. If it has content, process as annotations below.
-5. If step 4 produced nothing (temp file missing, cleaned up by the script's trap, or user ran revdiff outside the plugin), try the persistent history directory as a tertiary fallback:
-   ```bash
-   ${CLAUDE_SKILL_DIR}/scripts/read-latest-history.sh
-   ```
-   History files contain the annotations in the same `## file:line (type)` format plus the raw git diff for annotated files. If neither source produces content, the user quit without annotating.
+4. If it has content, process as annotations below. If empty or no file, the user quit without annotating.
 
-This fallback chain is safe because revdiff writes both the temp output file and the history file atomically on exit — there is never a partial read. See `references/usage.md` "Review History" for directory layout details.
+This fallback is safe because revdiff writes the output file atomically on exit — there is never a partial read.
 
 If the script produces output, the user made annotations. The output format is:
 

--- a/.claude-plugin/skills/revdiff/SKILL.md
+++ b/.claude-plugin/skills/revdiff/SKILL.md
@@ -24,6 +24,16 @@ If the user asks a question about revdiff (configuration, themes, keybindings, i
 - `references/config.md` — config file, options, colors, chroma themes
 - `references/usage.md` — examples, key bindings, output format
 
+## Using Existing Review History
+
+If the user says things like "locate my review", "use my latest revdiff annotations", "pull up the review I just did in another terminal", or "what did I annotate earlier" — the user ran revdiff outside this plugin flow and wants Claude to process the stored annotations. Read the most recent file from the persistent history directory via the helper script, then process the annotations through Step 3.5 classification as if they had come from a fresh launcher call:
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/read-latest-history.sh
+```
+
+The script resolves the history dir from `$REVDIFF_HISTORY_DIR` (default `~/.config/revdiff/history`), finds the repo subdir via `git rev-parse --show-toplevel` basename, and prints the newest `.md` file found. Each history file contains a header (path, refs, commit hash), the annotations in `## file:line (type)` format, and the raw git diff for annotated files. See `references/usage.md` "Review History" section for directory layout, stdin/only handling, and override options.
+
 ## How It Works
 
 1. Launch revdiff in a terminal overlay (tmux popup, Zellij floating pane, kitty overlay, wezterm/Kaku split-pane, cmux split, ghostty split+zoom, iTerm2 split pane, or Emacs vterm frame)
@@ -113,9 +123,14 @@ The script:
      cat "$output_file"
    fi
    ```
-4. If it has content, process as annotations below. If empty or no file, the user quit without annotating.
+4. If it has content, process as annotations below.
+5. If step 4 produced nothing (temp file missing, cleaned up by the script's trap, or user ran revdiff outside the plugin), try the persistent history directory as a tertiary fallback:
+   ```bash
+   ${CLAUDE_SKILL_DIR}/scripts/read-latest-history.sh
+   ```
+   History files contain the annotations in the same `## file:line (type)` format plus the raw git diff for annotated files. If neither source produces content, the user quit without annotating.
 
-This fallback is safe because revdiff writes the output file atomically on exit — there is never a partial read.
+This fallback chain is safe because revdiff writes both the temp output file and the history file atomically on exit — there is never a partial read. See `references/usage.md` "Review History" for directory layout details.
 
 If the script produces output, the user made annotations. The output format is:
 

--- a/.claude-plugin/skills/revdiff/scripts/read-latest-history.sh
+++ b/.claude-plugin/skills/revdiff/scripts/read-latest-history.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# read-latest-history.sh - print the most recent revdiff review history file to stdout.
+# used by the skill as a fallback when the live launcher output is unavailable
+# (temp file cleaned up, or user ran revdiff outside the plugin flow).
+#
+# resolves the history dir from $REVDIFF_HISTORY_DIR, falling back to
+# ~/.config/revdiff/history. resolves the repo subdir from `git rev-parse
+# --show-toplevel` basename, falling back to the cwd basename.
+#
+# prints file contents if found, prints nothing if not. exits 0 in both cases.
+
+set -euo pipefail
+
+hist_dir="${REVDIFF_HISTORY_DIR:-$HOME/.config/revdiff/history}"
+repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+repo_dir="$hist_dir/$repo"
+
+# find newest .md via -nt comparison instead of `ls -t` (shellcheck SC2012,
+# and -nt is portable across macos/linux without find -printf tricks).
+latest=""
+for f in "$repo_dir"/*.md; do
+    [ -e "$f" ] || continue
+    if [ -z "$latest" ] || [ "$f" -nt "$latest" ]; then
+        latest="$f"
+    fi
+done
+
+if [ -n "$latest" ]; then
+    cat "$latest"
+fi

--- a/.claude-plugin/skills/revdiff/scripts/read-latest-history.sh
+++ b/.claude-plugin/skills/revdiff/scripts/read-latest-history.sh
@@ -9,9 +9,14 @@
 #
 # prints file contents if found, prints nothing if not. exits 0 in both cases.
 
-set -euo pipefail
+set -uo pipefail  # not -e: final cat must not abort the fallback on permission/race errors
 
-hist_dir="${REVDIFF_HISTORY_DIR:-$HOME/.config/revdiff/history}"
+# resolve hist_dir defensively so unset HOME doesn't trip set -u
+hist_dir="${REVDIFF_HISTORY_DIR:-}"
+if [ -z "$hist_dir" ]; then
+    hist_dir="${HOME:-}/.config/revdiff/history"
+fi
+
 repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
 repo_dir="$hist_dir/$repo"
 

--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ History auto-save is always on and silent — errors are logged to stderr, never
 
 Override the history directory with `--history-dir`, `REVDIFF_HISTORY_DIR` env var, or `history-dir` in the config file.
 
+In the Claude Code and Codex plugins, you can also tell the agent to use a past review by saying things like "locate my latest revdiff review" or "use the annotations from the review I just did in another terminal". The plugin reads the newest history file for the current repo via the helper script `read-latest-history.sh` and processes the annotations as if they had come from a fresh launcher call. This is useful for standalone revdiff runs outside the plugin, or when the live launcher output is unavailable (e.g., a broken custom launcher or a crashed agent).
+
 ### Key Bindings
 
 **Navigation:**

--- a/plugins/codex/skills/revdiff/SKILL.md
+++ b/plugins/codex/skills/revdiff/SKILL.md
@@ -137,14 +137,9 @@ The script:
      cat "$output_file"
    fi
    ```
-4. If it has content, process as annotations below.
-5. If step 4 produced nothing (temp file missing, cleaned up by the script's trap, or user ran revdiff outside the plugin), try the persistent history directory as a tertiary fallback:
-   ```bash
-   $SCRIPT_DIR/read-latest-history.sh
-   ```
-   History files contain the annotations in the same `## file:line (type)` format plus the raw git diff for annotated files. If neither source produces content, the user quit without annotating.
+4. If it has content, process as annotations below. If empty or no file, the user quit without annotating.
 
-This fallback chain is safe because revdiff writes both the temp output file and the history file atomically on exit — there is never a partial read. See `references/usage.md` "Review History" for directory layout details.
+This fallback is safe because revdiff writes the output file atomically on exit — there is never a partial read.
 
 If the script produces output, the user made annotations. The output format is:
 

--- a/plugins/codex/skills/revdiff/SKILL.md
+++ b/plugins/codex/skills/revdiff/SKILL.md
@@ -37,6 +37,16 @@ If the user asks a question about revdiff (configuration, themes, keybindings, i
 - `references/config.md` — config file, options, colors, chroma themes
 - `references/usage.md` — examples, key bindings, output format
 
+## Using Existing Review History
+
+If the user says things like "locate my review", "use my latest revdiff annotations", "pull up the review I just did in another terminal", or "what did I annotate earlier" — the user ran revdiff outside this plugin flow and wants Codex to process the stored annotations. Read the most recent file from the persistent history directory via the helper script, then process the annotations through Step 3.5 classification as if they had come from a fresh launcher call:
+
+```bash
+$SCRIPT_DIR/read-latest-history.sh
+```
+
+The script resolves the history dir from `$REVDIFF_HISTORY_DIR` (default `~/.config/revdiff/history`), finds the repo subdir via `git rev-parse --show-toplevel` basename, and prints the newest `.md` file found. Each history file contains a header (path, refs, commit hash), the annotations in `## file:line (type)` format, and the raw git diff for annotated files. See `references/usage.md` "Review History" section for directory layout, stdin/only handling, and override options.
+
 ## How It Works
 
 1. Launch revdiff in a terminal overlay (tmux popup, Zellij floating pane, kitty overlay, wezterm/Kaku split-pane, cmux split, ghostty split+zoom, iTerm2 split pane, or Emacs vterm frame)
@@ -127,9 +137,14 @@ The script:
      cat "$output_file"
    fi
    ```
-4. If it has content, process as annotations below. If empty or no file, the user quit without annotating.
+4. If it has content, process as annotations below.
+5. If step 4 produced nothing (temp file missing, cleaned up by the script's trap, or user ran revdiff outside the plugin), try the persistent history directory as a tertiary fallback:
+   ```bash
+   $SCRIPT_DIR/read-latest-history.sh
+   ```
+   History files contain the annotations in the same `## file:line (type)` format plus the raw git diff for annotated files. If neither source produces content, the user quit without annotating.
 
-This fallback is safe because revdiff writes the output file atomically on exit — there is never a partial read.
+This fallback chain is safe because revdiff writes both the temp output file and the history file atomically on exit — there is never a partial read. See `references/usage.md` "Review History" for directory layout details.
 
 If the script produces output, the user made annotations. The output format is:
 

--- a/plugins/codex/skills/revdiff/scripts/read-latest-history.sh
+++ b/plugins/codex/skills/revdiff/scripts/read-latest-history.sh
@@ -11,9 +11,14 @@
 #
 # prints file contents if found, prints nothing if not. exits 0 in both cases.
 
-set -euo pipefail
+set -uo pipefail  # not -e: final cat must not abort the fallback on permission/race errors
 
-hist_dir="${REVDIFF_HISTORY_DIR:-$HOME/.config/revdiff/history}"
+# resolve hist_dir defensively so unset HOME doesn't trip set -u
+hist_dir="${REVDIFF_HISTORY_DIR:-}"
+if [ -z "$hist_dir" ]; then
+    hist_dir="${HOME:-}/.config/revdiff/history"
+fi
+
 repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
 repo_dir="$hist_dir/$repo"
 

--- a/plugins/codex/skills/revdiff/scripts/read-latest-history.sh
+++ b/plugins/codex/skills/revdiff/scripts/read-latest-history.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# read-latest-history.sh - print the most recent revdiff review history file to stdout.
+# source: .claude-plugin/skills/revdiff/scripts/read-latest-history.sh (keep in sync)
+#
+# used by the skill as a fallback when the live launcher output is unavailable
+# (temp file cleaned up, or user ran revdiff outside the plugin flow).
+#
+# resolves the history dir from $REVDIFF_HISTORY_DIR, falling back to
+# ~/.config/revdiff/history. resolves the repo subdir from `git rev-parse
+# --show-toplevel` basename, falling back to the cwd basename.
+#
+# prints file contents if found, prints nothing if not. exits 0 in both cases.
+
+set -euo pipefail
+
+hist_dir="${REVDIFF_HISTORY_DIR:-$HOME/.config/revdiff/history}"
+repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+repo_dir="$hist_dir/$repo"
+
+# find newest .md via -nt comparison instead of `ls -t` (shellcheck SC2012,
+# and -nt is portable across macos/linux without find -printf tricks).
+latest=""
+for f in "$repo_dir"/*.md; do
+    [ -e "$f" ] || continue
+    if [ -z "$latest" ] || [ "$f" -nt "$latest" ]; then
+        latest="$f"
+    fi
+done
+
+if [ -n "$latest" ]; then
+    cat "$latest"
+fi

--- a/site/docs.html
+++ b/site/docs.html
@@ -289,6 +289,7 @@ revdiff --only=/tmp/draft-comment.md</code></div>
         <p>Each history file contains a header with path, git refs, and commit hash, the full annotation output (same format as stdout), and the raw git diff for annotated files only.</p>
         <p>History auto-save is always on and silent &mdash; errors are logged to stderr, never fail the process. No history is saved on discard quit (<code>Q</code>) or when there are no annotations. For <code>--stdin</code> mode, files are saved under a <code>stdin/</code> subdirectory; for <code>--only</code> without git, the parent directory name is used instead of a repo name.</p>
         <p>Override the directory with <code>--history-dir</code>, <code>REVDIFF_HISTORY_DIR</code> env var, or <code>history-dir</code> in the config file.</p>
+        <p>In the Claude Code and Codex plugins, you can also tell the agent to use a past review by saying things like &ldquo;locate my latest revdiff review&rdquo; or &ldquo;use the annotations from the review I just did in another terminal&rdquo;. The plugin reads the newest history file for the current repo via the helper script <code>read-latest-history.sh</code> and processes the annotations as if they had come from a fresh launcher call. This is useful for standalone revdiff runs outside the plugin, or when the live launcher output is unavailable (e.g., a broken custom launcher or a crashed agent).</p>
 
         <!-- configuration -->
         <h2 id="config-file">Config file</h2>


### PR DESCRIPTION
Adds a tertiary fallback to the revdiff Claude Code and Codex skills: when the live launcher output is missing or empty (trap cleanup, broken custom launcher, or standalone `revdiff` outside the plugin), the skill reads the newest `.md` from `~/.config/revdiff/history/<repo>/`. Also adds a **Using Existing Review History** skill section so queries like *"locate my latest revdiff review"* route to the same helper.

**Changes**

- New `scripts/read-latest-history.sh` helper — resolves `$REVDIFF_HISTORY_DIR` or the default path, finds the repo subdir via `git rev-parse --show-toplevel` basename, prints the newest `.md` via `-nt` comparison (portable macOS/Linux, shellcheck-clean)
- SKILL.md updates in both `.claude-plugin/` and `plugins/codex/` — new section plus an extended Step 3 fallback chain
- Byte-identical script copy under `plugins/codex/skills/revdiff/scripts/` with a `source:` header per the existing sync convention
- `README.md` and `site/docs.html` — one paragraph in the existing Review History section describing the plugin-side workflow
- Plugin version bumped to `0.7.2` in `plugin.json` and `marketplace.json`