### PR TITLE
docs: add AUR install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Built for a specific use case: reviewing code changes, plans, and documents with
 brew install umputun/apps/revdiff
 ```
 
+**Arch Linux (AUR):**
+
+```bash
+paru -S revdiff
+```
+
 **Binary releases:** download from [GitHub Releases](https://github.com/umputun/revdiff/releases) (deb, rpm, archives for linux/darwin amd64/arm64).
 
 ## Claude Code Plugin


### PR DESCRIPTION
Packaged revdiff for the AUR for convenience - the PKGBUILD pulls prebuilt binaries from the GitHub Releases page.
https://aur.archlinux.org/packages/revdiff

This PR just adds a short note to the README so Arch users know they can install it via paru -S revdiff (or any other AUR helper).