### PR TITLE
fix(ui): match --only patterns with ./ prefix and absolute entries

### DIFF
--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -288,9 +288,9 @@ func (m Model) computeBlameAuthorLen() int {
 
 // filterOnly returns only files matching the --only patterns, or all files if no filter is set.
 // matches by exact path or path suffix (e.g. "model.go" matches "ui/model.go").
-// both entries and patterns are also normalized to workDir-relative form for matching,
-// so "./CLAUDE.md" matches "CLAUDE.md" and an absolute entry from FileReader
-// ("/repo/CLAUDE.md") matches a relative pattern ("CLAUDE.md").
+// when workDir is set, both entries and patterns are also normalized to workDir-relative
+// form for matching, so "./CLAUDE.md" matches "CLAUDE.md" and an absolute entry from
+// FileReader ("/repo/CLAUDE.md") matches a relative pattern ("CLAUDE.md").
 func (m Model) filterOnly(entries []diff.FileEntry) []diff.FileEntry {
 	if len(m.cfg.only) == 0 {
 		return entries

--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -288,8 +288,9 @@ func (m Model) computeBlameAuthorLen() int {
 
 // filterOnly returns only files matching the --only patterns, or all files if no filter is set.
 // matches by exact path or path suffix (e.g. "model.go" matches "ui/model.go").
-// when a pattern is an absolute path, it is also resolved relative to workDir for matching
-// (e.g. "/repo/README.md" with workDir="/repo" matches "README.md").
+// both entries and patterns are also normalized to workDir-relative form for matching,
+// so "./CLAUDE.md" matches "CLAUDE.md" and an absolute entry from FileReader
+// ("/repo/CLAUDE.md") matches a relative pattern ("CLAUDE.md").
 func (m Model) filterOnly(entries []diff.FileEntry) []diff.FileEntry {
 	if len(m.cfg.only) == 0 {
 		return entries
@@ -297,21 +298,44 @@ func (m Model) filterOnly(entries []diff.FileEntry) []diff.FileEntry {
 	var filtered []diff.FileEntry
 	for _, e := range entries {
 		for _, pattern := range m.cfg.only {
-			if e.Path == pattern || strings.HasSuffix(e.Path, "/"+pattern) {
+			if m.entryMatchesOnly(e.Path, pattern) {
 				filtered = append(filtered, e)
 				break
-			}
-			// resolve absolute pattern relative to workDir for matching against repo-relative files
-			if m.cfg.workDir != "" && filepath.IsAbs(pattern) {
-				rel, err := filepath.Rel(m.cfg.workDir, pattern)
-				if err == nil && !strings.HasPrefix(rel, "..") && (e.Path == rel || strings.HasSuffix(e.Path, "/"+rel)) {
-					filtered = append(filtered, e)
-					break
-				}
 			}
 		}
 	}
 	return filtered
+}
+
+// entryMatchesOnly reports whether a file entry matches a single --only pattern.
+// checks exact match, suffix match, and workDir-normalized equality/suffix.
+// normalization handles "./" prefixes, absolute patterns, and absolute entries uniformly.
+func (m Model) entryMatchesOnly(entry, pattern string) bool {
+	if entry == pattern || strings.HasSuffix(entry, "/"+pattern) {
+		return true
+	}
+	if m.cfg.workDir == "" {
+		return false
+	}
+	entryRel := m.workDirRel(entry)
+	patternRel := m.workDirRel(pattern)
+	if entryRel == "" || patternRel == "" {
+		return false
+	}
+	return entryRel == patternRel || strings.HasSuffix(entryRel, "/"+patternRel)
+}
+
+// workDirRel returns path as workDir-relative, or "" if path escapes workDir.
+// relative input is joined with workDir first; absolute input is used as-is.
+func (m Model) workDirRel(path string) string {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(m.cfg.workDir, path)
+	}
+	rel, err := filepath.Rel(m.cfg.workDir, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return ""
+	}
+	return rel
 }
 
 // computeFileStats counts added and removed lines in the current file.

--- a/app/ui/loaders_test.go
+++ b/app/ui/loaders_test.go
@@ -269,6 +269,53 @@ func TestModel_FilterOnly(t *testing.T) {
 		files := toEntries("ui/model.go", "diff/diff.go")
 		assert.Empty(t, m.filterOnly(files))
 	})
+
+	t.Run("dot-slash prefix matches relative entry", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.cfg.only = []string{"./CLAUDE.md"}
+		m.cfg.workDir = "/repo"
+		files := toEntries("CLAUDE.md", "ui/model.go")
+		assert.Equal(t, []string{"CLAUDE.md"}, diff.FileEntryPaths(m.filterOnly(files)))
+	})
+
+	t.Run("dot-slash prefix matches absolute entry", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.cfg.only = []string{"./CLAUDE.md"}
+		m.cfg.workDir = "/repo"
+		files := toEntries("/repo/CLAUDE.md", "/repo/ui/model.go")
+		assert.Equal(t, []string{"/repo/CLAUDE.md"}, diff.FileEntryPaths(m.filterOnly(files)))
+	})
+
+	t.Run("dot-slash prefix with subdirectory", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.cfg.only = []string{"./ui/model.go"}
+		m.cfg.workDir = "/repo"
+		files := toEntries("ui/model.go", "diff/diff.go")
+		assert.Equal(t, []string{"ui/model.go"}, diff.FileEntryPaths(m.filterOnly(files)))
+	})
+
+	t.Run("relative pattern matches absolute entry", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.cfg.only = []string{"CLAUDE.md"}
+		m.cfg.workDir = "/repo"
+		files := toEntries("/repo/CLAUDE.md", "/repo/ui/model.go")
+		assert.Equal(t, []string{"/repo/CLAUDE.md"}, diff.FileEntryPaths(m.filterOnly(files)))
+	})
+
+	t.Run("dot-slash prefix no workDir falls through to exact/suffix", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.cfg.only = []string{"./CLAUDE.md"}
+		files := toEntries("CLAUDE.md", "ui/model.go")
+		assert.Empty(t, m.filterOnly(files))
+	})
+
+	t.Run("relative pattern escaping workDir does not match", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.cfg.only = []string{"../other/CLAUDE.md"}
+		m.cfg.workDir = "/repo"
+		files := toEntries("CLAUDE.md", "ui/model.go")
+		assert.Empty(t, m.filterOnly(files))
+	})
 }
 
 func TestModel_FilterOnlyNoMatchShowsMessage(t *testing.T) {


### PR DESCRIPTION
`-F/--only` dropped matching files when the pattern started with `./`. `filterOnly` only resolved against `workDir` for absolute patterns, so:

- git mode: entry `CLAUDE.md` vs pattern `./CLAUDE.md` - no match
- no-VCS mode: `FileReader` returns absolute paths, entry `/repo/CLAUDE.md` vs pattern `./CLAUDE.md` - no match

Normalize both entry and pattern to `workDir`-relative form before comparing, mirroring `FallbackRenderer.pathMatches`. Preserves existing exact/suffix fast path.

Fixes #127