### PR TITLE
Add --description overlay for agent-supplied diff context (#130)

### DIFF
--- a/.claude-plugin/skills/revdiff/SKILL.md
+++ b/.claude-plugin/skills/revdiff/SKILL.md
@@ -95,6 +95,32 @@ The script outputs structured fields:
 - On main + clean → `HEAD~1` (last commit)
 - On feature branch + clean → main branch name (full branch diff)
 
+### Step 1.5: Compose a Description (when you have context)
+
+If you have meaningful context about the diff — you just implemented the code, you're running revdiff as part of a larger workflow, or the user has been discussing the change — write a short markdown description and pass it to the launcher so the reviewer sees it the moment revdiff pops up.
+
+Write 2–6 lines of markdown that cover: what changed, why, and anything specific you want the user to look at. Save it to a temp file and pass both flags on the launcher command line:
+
+```bash
+DESC_FILE="$(mktemp -t revdiff-desc.XXXXXX.md)"
+cat > "$DESC_FILE" <<'MARKDOWN'
+# Added --description overlay
+
+- New `D` hotkey toggles a markdown overlay with the CLI-supplied description.
+- `--description-file` reads from a path to avoid shell-escape pain.
+- `--description-auto-open` opens the overlay on startup (agent mode).
+
+Please check the auto-open timing on narrow terminals.
+MARKDOWN
+# launcher call below will pass: --description-file="$DESC_FILE" --description-auto-open
+```
+
+Skip this step when the user explicitly invoked `revdiff <ref>` without any conversation backstory (you don't know what's in the diff, so inventing context would mislead the reviewer). Also skip for the explanation loop (Step 3.5) — the explanation markdown is already the content being reviewed.
+
+The launcher passes all remaining arguments through to revdiff verbatim, so append `--description-file="$DESC_FILE"` and `--description-auto-open` to the launcher call in Step 2 when you composed a description.
+
+After the review loop exits (Step 7), remove the temp file: `rm -f "$DESC_FILE"`.
+
 ### Step 2: Launch Review
 
 Run the launcher through the override-chain resolver:

--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -41,6 +41,9 @@ Then uncomment and edit the values you want to change.
 | `-X`, `--exclude` | `REVDIFF_EXCLUDE` | Exclude files matching prefix (may be repeated; comma-separated in env) | |
 | `-F`, `--only` | | Show only matching files (may be repeated, matches by path or suffix) | |
 | `-o`, `--output` | `REVDIFF_OUTPUT` | Write annotations to file instead of stdout | |
+| `--description` | | Markdown description shown in the description overlay (press `D` to toggle); useful for agents attaching context to a diff | |
+| `--description-file` | | Path to markdown file shown in the description overlay (mutually exclusive with `--description`) | |
+| `--description-auto-open` | | Open the description overlay on startup when a description is set | `false` |
 | `--history-dir` | `REVDIFF_HISTORY_DIR` | Directory for review history auto-saves | `~/.config/revdiff/history/` |
 | `--keys` | `REVDIFF_KEYS` | Path to keybindings file | `~/.config/revdiff/keybindings` |
 | `--dump-keys` | | Print effective keybindings to stdout and exit | |

--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -123,6 +123,7 @@ While the annotation input is active, press `Ctrl+E` to hand off the current tex
 | `f` | Toggle filter: all files / annotated only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle commit info popup (subject + body of commits in the current ref range; git/hg/jj only) |
+| `D` | Toggle description overlay (shows `--description` / `--description-file` content) |
 | `R` | Reload diff from VCS (warns if annotations exist) |
 | `q` | Quit, output annotations to stdout |
 | `Q` | Discard all annotations and quit (confirms if annotations exist) |
@@ -143,6 +144,7 @@ The status bar shows a fixed row of mode indicators on the right side. All ten s
 | `±` | `W` | Intra-line word-diff highlighting |
 | `✓` | `Space` | Reviewed count (increments when a file is marked reviewed) |
 | `∅` | `u` | Untracked files visible in tree |
+| `§` | `D` | Description overlay available (a `--description` / `--description-file` was supplied) |
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Built for a specific use case: reviewing code changes, plans, and documents with
 - Status line with filename, diff stats, hunk position, line number, and mode indicators
 - Help overlay (`?`) showing all keybindings organized by section
 - Commit info popup (`i`) showing subject + body of every commit in the current ref range (git/hg/jj), useful for restoring the narrative context when reviewing PR-style diffs
+- Description overlay (`D`) showing an agent-supplied markdown description of the diff (`--description` / `--description-file`), with opt-in auto-open via `--description-auto-open` — keeps context visible when revdiff pops up from a Claude Code / Codex session
 - Markdown TOC navigation: single-file markdown files in context-only mode show a table-of-contents pane with header navigation and active section tracking
 - All-files mode: browse and annotate all tracked files with `--all-files` (git `ls-files` or jj `file list`), filter with `--include` and `--exclude`
 - No-VCS file review: `--only` files outside a VCS repo (or not in any diff) are shown as context-only with full annotation support
@@ -309,6 +310,9 @@ Positional arguments support several forms:
 | `-A`, `--all-files` | Browse all tracked files, not just diffs (git or jj) | `false` |
 | `--stdin` | Review stdin as a scratch buffer (piped or redirected input only) | `false` |
 | `--stdin-name` | Synthetic file name for stdin content; enables extension-based highlighting/TOC | `scratch-buffer` |
+| `--description` | Markdown description shown in the description overlay (press `D` to toggle); useful for agents attaching context to a diff | |
+| `--description-file` | Path to markdown file shown in the description overlay (mutually exclusive with `--description`) | |
+| `--description-auto-open` | Open the description overlay on startup when `--description` or `--description-file` is set | `false` |
 | `-I`, `--include` | Include only files matching prefix, may be repeated, env: `REVDIFF_INCLUDE` (comma-separated) | |
 | `-X`, `--exclude` | Exclude files matching prefix, may be repeated, env: `REVDIFF_EXCLUDE` (comma-separated) | |
 | `-F`, `--only` | Show only matching files by exact path or suffix, may be repeated (e.g. `--only=model.go`) | |
@@ -626,6 +630,7 @@ While the annotation input is active, press `Ctrl+E` to hand off the current tex
 | `f` | Toggle filter: all files / annotated only (shown when annotations exist) |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle commit info popup (subject + body of commits in the current ref range; git/hg/jj only) |
+| `D` | Toggle description overlay (shows `--description` / `--description-file` content; hint when neither is set) |
 | `R` | Reload diff from VCS (warns if annotations exist) |
 | `q` | Quit, output annotations to stdout |
 | `Q` | Discard all annotations and quit (confirms if annotations exist) |
@@ -646,6 +651,7 @@ The status bar shows a fixed row of mode indicators on the right side. All ten s
 | `±` | `W` | Intra-line word-diff highlighting |
 | `✓` | `Space` | Reviewed count (increments when a file is marked reviewed) |
 | `∅` | `u` | Untracked files visible in tree |
+| `§` | `D` | Description overlay available (a `--description` / `--description-file` was supplied) |
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.
 

--- a/app/config.go
+++ b/app/config.go
@@ -17,38 +17,41 @@ type options struct {
 		Against string `positional-arg-name:"against" description:"second git ref for two-ref diff (e.g. revdiff main feature)"`
 	} `positional-args:"yes"`
 
-	Staged           bool     `long:"staged" ini-name:"staged" env:"REVDIFF_STAGED" description:"show staged changes"`
-	TreeWidth        int      `long:"tree-width" ini-name:"tree-width" env:"REVDIFF_TREE_WIDTH" default:"2" description:"file tree panel width in units (1-10, default 2 of 10)"`
-	TabWidth         int      `long:"tab-width" ini-name:"tab-width" env:"REVDIFF_TAB_WIDTH" default:"4" description:"number of spaces per tab character"`
-	NoColors         bool     `long:"no-colors" ini-name:"no-colors" env:"REVDIFF_NO_COLORS" description:"disable all colors including syntax highlighting"`
-	NoStatusBar      bool     `long:"no-status-bar" ini-name:"no-status-bar" env:"REVDIFF_NO_STATUS_BAR" description:"hide the status bar"`
-	NoConfirmDiscard bool     `long:"no-confirm-discard" ini-name:"no-confirm-discard" env:"REVDIFF_NO_CONFIRM_DISCARD" description:"skip confirmation prompt when discarding annotations with Q"`
-	Wrap             bool     `long:"wrap" ini-name:"wrap" env:"REVDIFF_WRAP" description:"enable line wrapping in diff view"`
-	Collapsed        bool     `long:"collapsed" ini-name:"collapsed" env:"REVDIFF_COLLAPSED" description:"start in collapsed diff mode"`
-	CrossFileHunks   bool     `long:"cross-file-hunks" ini-name:"cross-file-hunks" env:"REVDIFF_CROSS_FILE_HUNKS" description:"allow [ and ] to jump across file boundaries"`
-	LineNumbers      bool     `long:"line-numbers" ini-name:"line-numbers" env:"REVDIFF_LINE_NUMBERS" description:"show line numbers in diff gutter"`
-	Blame            bool     `long:"blame" ini-name:"blame" env:"REVDIFF_BLAME" description:"show blame gutter on startup"`
-	WordDiff         bool     `long:"word-diff" ini-name:"word-diff" env:"REVDIFF_WORD_DIFF" description:"highlight intra-line word-level changes in paired add/remove lines"`
-	ChromaStyle      string   `long:"chroma-style" ini-name:"chroma-style" env:"REVDIFF_CHROMA_STYLE" default:"catppuccin-macchiato" description:"chroma style for syntax highlighting"`
-	AllFiles         bool     `long:"all-files" short:"A" no-ini:"true" description:"browse all tracked files, not just diffs (git and jj only)"`
-	Stdin            bool     `long:"stdin" no-ini:"true" description:"review stdin as a scratch buffer"`
-	StdinName        string   `long:"stdin-name" no-ini:"true" description:"synthetic file name for stdin content"`
-	Exclude          []string `long:"exclude" short:"X" ini-name:"exclude" env:"REVDIFF_EXCLUDE" env-delim:"," description:"exclude files matching prefix (may be repeated)"`
-	Include          []string `long:"include" short:"I" ini-name:"include" env:"REVDIFF_INCLUDE" env-delim:"," description:"include only files matching prefix (may be repeated)"`
-	Only             []string `long:"only" short:"F" no-ini:"true" description:"show only these files (may be repeated)"`
-	HistoryDir       string   `long:"history-dir" ini-name:"history-dir" env:"REVDIFF_HISTORY_DIR" description:"directory for review history auto-saves"`
-	Output           string   `long:"output" short:"o" env:"REVDIFF_OUTPUT" no-ini:"true" description:"write annotations to file instead of stdout"`
-	Keys             string   `long:"keys" env:"REVDIFF_KEYS" no-ini:"true" description:"path to keybindings file"`
-	DumpKeys         bool     `long:"dump-keys" no-ini:"true" description:"print effective keybindings to stdout and exit"`
-	Theme            string   `long:"theme" ini-name:"theme" env:"REVDIFF_THEME" description:"load theme from themes directory"`
-	DumpTheme        bool     `long:"dump-theme" no-ini:"true" description:"print currently resolved colors as theme file and exit"`
-	ListThemes       bool     `long:"list-themes" no-ini:"true" description:"print available theme names and exit"`
-	InitThemes       bool     `long:"init-themes" no-ini:"true" description:"write bundled theme files to themes dir and exit"`
-	InitAllThemes    bool     `long:"init-all-themes" no-ini:"true" description:"write all gallery themes (bundled + community) to themes dir and exit"`
-	InstallTheme     []string `long:"install-theme" no-ini:"true" description:"install theme(s) from gallery or local file path and exit"`
-	Config           string   `long:"config" env:"REVDIFF_CONFIG" no-ini:"true" description:"path to config file"`
-	DumpConfig       bool     `long:"dump-config" no-ini:"true" description:"print default config to stdout and exit"`
-	Version          bool     `short:"V" long:"version" no-ini:"true" description:"show version info"`
+	Staged              bool     `long:"staged" ini-name:"staged" env:"REVDIFF_STAGED" description:"show staged changes"`
+	TreeWidth           int      `long:"tree-width" ini-name:"tree-width" env:"REVDIFF_TREE_WIDTH" default:"2" description:"file tree panel width in units (1-10, default 2 of 10)"`
+	TabWidth            int      `long:"tab-width" ini-name:"tab-width" env:"REVDIFF_TAB_WIDTH" default:"4" description:"number of spaces per tab character"`
+	NoColors            bool     `long:"no-colors" ini-name:"no-colors" env:"REVDIFF_NO_COLORS" description:"disable all colors including syntax highlighting"`
+	NoStatusBar         bool     `long:"no-status-bar" ini-name:"no-status-bar" env:"REVDIFF_NO_STATUS_BAR" description:"hide the status bar"`
+	NoConfirmDiscard    bool     `long:"no-confirm-discard" ini-name:"no-confirm-discard" env:"REVDIFF_NO_CONFIRM_DISCARD" description:"skip confirmation prompt when discarding annotations with Q"`
+	Wrap                bool     `long:"wrap" ini-name:"wrap" env:"REVDIFF_WRAP" description:"enable line wrapping in diff view"`
+	Collapsed           bool     `long:"collapsed" ini-name:"collapsed" env:"REVDIFF_COLLAPSED" description:"start in collapsed diff mode"`
+	CrossFileHunks      bool     `long:"cross-file-hunks" ini-name:"cross-file-hunks" env:"REVDIFF_CROSS_FILE_HUNKS" description:"allow [ and ] to jump across file boundaries"`
+	LineNumbers         bool     `long:"line-numbers" ini-name:"line-numbers" env:"REVDIFF_LINE_NUMBERS" description:"show line numbers in diff gutter"`
+	Blame               bool     `long:"blame" ini-name:"blame" env:"REVDIFF_BLAME" description:"show blame gutter on startup"`
+	WordDiff            bool     `long:"word-diff" ini-name:"word-diff" env:"REVDIFF_WORD_DIFF" description:"highlight intra-line word-level changes in paired add/remove lines"`
+	ChromaStyle         string   `long:"chroma-style" ini-name:"chroma-style" env:"REVDIFF_CHROMA_STYLE" default:"catppuccin-macchiato" description:"chroma style for syntax highlighting"`
+	AllFiles            bool     `long:"all-files" short:"A" no-ini:"true" description:"browse all tracked files, not just diffs (git and jj only)"`
+	Stdin               bool     `long:"stdin" no-ini:"true" description:"review stdin as a scratch buffer"`
+	StdinName           string   `long:"stdin-name" no-ini:"true" description:"synthetic file name for stdin content"`
+	Exclude             []string `long:"exclude" short:"X" ini-name:"exclude" env:"REVDIFF_EXCLUDE" env-delim:"," description:"exclude files matching prefix (may be repeated)"`
+	Include             []string `long:"include" short:"I" ini-name:"include" env:"REVDIFF_INCLUDE" env-delim:"," description:"include only files matching prefix (may be repeated)"`
+	Only                []string `long:"only" short:"F" no-ini:"true" description:"show only these files (may be repeated)"`
+	HistoryDir          string   `long:"history-dir" ini-name:"history-dir" env:"REVDIFF_HISTORY_DIR" description:"directory for review history auto-saves"`
+	Output              string   `long:"output" short:"o" env:"REVDIFF_OUTPUT" no-ini:"true" description:"write annotations to file instead of stdout"`
+	Keys                string   `long:"keys" env:"REVDIFF_KEYS" no-ini:"true" description:"path to keybindings file"`
+	DumpKeys            bool     `long:"dump-keys" no-ini:"true" description:"print effective keybindings to stdout and exit"`
+	Theme               string   `long:"theme" ini-name:"theme" env:"REVDIFF_THEME" description:"load theme from themes directory"`
+	DumpTheme           bool     `long:"dump-theme" no-ini:"true" description:"print currently resolved colors as theme file and exit"`
+	ListThemes          bool     `long:"list-themes" no-ini:"true" description:"print available theme names and exit"`
+	InitThemes          bool     `long:"init-themes" no-ini:"true" description:"write bundled theme files to themes dir and exit"`
+	InitAllThemes       bool     `long:"init-all-themes" no-ini:"true" description:"write all gallery themes (bundled + community) to themes dir and exit"`
+	InstallTheme        []string `long:"install-theme" no-ini:"true" description:"install theme(s) from gallery or local file path and exit"`
+	Config              string   `long:"config" env:"REVDIFF_CONFIG" no-ini:"true" description:"path to config file"`
+	DumpConfig          bool     `long:"dump-config" no-ini:"true" description:"print default config to stdout and exit"`
+	Version             bool     `short:"V" long:"version" no-ini:"true" description:"show version info"`
+	Description         string   `long:"description" no-ini:"true" description:"markdown description shown in an overlay (for agent context)"`
+	DescriptionFile     string   `long:"description-file" no-ini:"true" description:"path to markdown file shown in the description overlay"`
+	DescriptionAutoOpen bool     `long:"description-auto-open" no-ini:"true" description:"open the description overlay on startup"`
 
 	Colors struct {
 		Accent       string `long:"color-accent"      ini-name:"color-accent"      env:"REVDIFF_COLOR_ACCENT"      default:"#D5895F" description:"active pane borders and directory names"`
@@ -129,7 +132,23 @@ func parseArgs(args []string) (options, error) {
 		return options{}, err
 	}
 
+	if err := validateDescriptionFlags(opts); err != nil {
+		return options{}, err
+	}
+
 	return opts, nil
+}
+
+// validateDescriptionFlags enforces mutex between --description and --description-file,
+// and requires one of them when --description-auto-open is set.
+func validateDescriptionFlags(opts options) error {
+	if opts.Description != "" && opts.DescriptionFile != "" {
+		return errors.New("--description cannot be used with --description-file")
+	}
+	if opts.DescriptionAutoOpen && opts.Description == "" && opts.DescriptionFile == "" {
+		return errors.New("--description-auto-open requires --description or --description-file")
+	}
+	return nil
 }
 
 // dumpConfig writes the current config with defaults to the given writer.

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -699,3 +699,50 @@ func TestParseArgs_InstallThemeFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"dracula", "nord"}, opts.InstallTheme)
 }
+
+func TestParseArgs_DescriptionFlag(t *testing.T) {
+	opts, err := parseArgs(append(noConfigArgs(t), "--description", "# hello"))
+	require.NoError(t, err)
+	assert.Equal(t, "# hello", opts.Description)
+}
+
+func TestParseArgs_DescriptionEqualsForm(t *testing.T) {
+	opts, err := parseArgs(append(noConfigArgs(t), "--description=# hello"))
+	require.NoError(t, err)
+	assert.Equal(t, "# hello", opts.Description)
+}
+
+func TestParseArgs_DescriptionFileFlag(t *testing.T) {
+	opts, err := parseArgs(append(noConfigArgs(t), "--description-file", "/tmp/desc.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/desc.md", opts.DescriptionFile)
+}
+
+func TestParseArgs_DescriptionAutoOpenFlag(t *testing.T) {
+	opts, err := parseArgs(append(noConfigArgs(t), "--description", "hi", "--description-auto-open"))
+	require.NoError(t, err)
+	assert.True(t, opts.DescriptionAutoOpen)
+}
+
+func TestParseArgs_DescriptionConflictsWithFile(t *testing.T) {
+	_, err := parseArgs(append(noConfigArgs(t), "--description", "inline", "--description-file", "/tmp/desc.md"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--description cannot be used with --description-file")
+}
+
+func TestParseArgs_DescriptionAutoOpenRequiresDescription(t *testing.T) {
+	_, err := parseArgs(append(noConfigArgs(t), "--description-auto-open"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--description-auto-open requires --description or --description-file")
+}
+
+func TestParseArgs_DescriptionNoIni(t *testing.T) {
+	// description flags must not be persisted to config file
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "config")
+	err := os.WriteFile(cfgPath, []byte("[Application Options]\ndescription = should-be-ignored\n"), 0o600)
+	require.NoError(t, err)
+	opts, err := parseArgs([]string{"--config", cfgPath})
+	require.NoError(t, err)
+	assert.Empty(t, opts.Description, "--description should be excluded from ini")
+}

--- a/app/description.go
+++ b/app/description.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// descriptionMaxBytes caps the size of --description-file to prevent loading
+// pathologically large files into the TUI. 1 MiB is far more than any
+// hand-written or agent-generated description will ever need; crossing it is
+// almost certainly a user error (wrong flag, pipe of the whole repo).
+const descriptionMaxBytes = 1 << 20
+
+// resolveDescription returns the final description string from opts, reading
+// --description-file when set. Returns "" when neither flag is present.
+// Surfaces clear errors for missing, oversized, or unreadable files.
+func resolveDescription(opts options) (string, error) {
+	if opts.Description != "" {
+		return opts.Description, nil
+	}
+	if opts.DescriptionFile == "" {
+		return "", nil
+	}
+
+	path, err := filepath.Abs(opts.DescriptionFile)
+	if err != nil {
+		return "", fmt.Errorf("resolve --description-file path: %w", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("read --description-file: %w", err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("--description-file %q is a directory", path)
+	}
+	if info.Size() > descriptionMaxBytes {
+		return "", fmt.Errorf("--description-file %q is %d bytes (max %d)", path, info.Size(), descriptionMaxBytes)
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // path is user-provided via --description-file
+	if err != nil {
+		return "", fmt.Errorf("read --description-file: %w", err)
+	}
+	return string(data), nil
+}

--- a/app/description_test.go
+++ b/app/description_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveDescription_Empty(t *testing.T) {
+	got, err := resolveDescription(options{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestResolveDescription_InlineOverridesFile(t *testing.T) {
+	// --description wins when both are set; validation in parseArgs already
+	// rejects that combination upstream, but the resolver should still be robust.
+	got, err := resolveDescription(options{Description: "inline", DescriptionFile: "/nonexistent"})
+	require.NoError(t, err)
+	assert.Equal(t, "inline", got)
+}
+
+func TestResolveDescription_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "desc.md")
+	content := "# Agent notes\n\n- point one\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	got, err := resolveDescription(options{DescriptionFile: path})
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestResolveDescription_FromFileMissing(t *testing.T) {
+	_, err := resolveDescription(options{DescriptionFile: filepath.Join(t.TempDir(), "missing.md")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read --description-file")
+}
+
+func TestResolveDescription_FromFileDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_, err := resolveDescription(options{DescriptionFile: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is a directory")
+}
+
+func TestResolveDescription_FromFileTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.md")
+	// write a file just over the 1 MiB cap
+	require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte("x"), descriptionMaxBytes+1), 0o600))
+
+	_, err := resolveDescription(options{DescriptionFile: path})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max")
+}
+
+func TestResolveDescription_FromFileRelativePath(t *testing.T) {
+	// create a file in CWD so a relative path resolves
+	dir := t.TempDir()
+	name := "rel-desc.md"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("hello"), 0o600))
+	t.Chdir(dir)
+
+	got, err := resolveDescription(options{DescriptionFile: name})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", got)
+}

--- a/app/highlight/highlight.go
+++ b/app/highlight/highlight.go
@@ -81,6 +81,22 @@ func (h *Highlighter) HighlightLines(filename string, lines []diff.DiffLine) []s
 	return h.mapHighlightedLines(lines, newHL, oldHL)
 }
 
+// HighlightText tokenizes text as-is (no diff reconstruction) and returns a
+// slice of per-line ANSI-formatted strings using the same foreground-only
+// styling as HighlightLines. The filename determines the Chroma lexer.
+// returns nil when highlighting is disabled, text is empty, or no lexer matches.
+func (h *Highlighter) HighlightText(filename, text string) []string {
+	if !h.enabled || text == "" {
+		return nil
+	}
+	lexer := lexers.Match(filename)
+	if lexer == nil {
+		return nil
+	}
+	lexer = chroma.Coalesce(lexer)
+	return h.highlightFile(lexer, styles.Get(h.styleName), text)
+}
+
 // reconstructFiles builds old and new file content from diff lines.
 // new file = context + added lines, old file = context + removed lines.
 func (h *Highlighter) reconstructFiles(lines []diff.DiffLine) (newFile, oldFile string) {

--- a/app/highlight/highlight_test.go
+++ b/app/highlight/highlight_test.go
@@ -206,3 +206,36 @@ func TestSetStyle_unknownStyle(t *testing.T) {
 	assert.False(t, ok)
 	assert.Equal(t, "monokai", h.StyleName(), "style should not change on failure")
 }
+
+func TestHighlighter_HighlightText_markdown(t *testing.T) {
+	h := New("monokai", true)
+
+	const src = "# Heading\n\nSome **bold** text.\n"
+	result := h.HighlightText("note.md", src)
+	require.NotNil(t, result)
+	// input has a trailing newline producing 4 logical segments, but we
+	// return one entry per rendered line of source (3 non-empty + 1 empty).
+	require.Len(t, result, 3)
+	assert.Contains(t, result[0], "Heading")
+	assert.Contains(t, result[0], "\033[", "heading should carry ANSI codes")
+	assert.Contains(t, result[2], "bold")
+}
+
+func TestHighlighter_HighlightText_disabled(t *testing.T) {
+	h := New("monokai", false)
+	result := h.HighlightText("note.md", "# hi")
+	assert.Nil(t, result)
+}
+
+func TestHighlighter_HighlightText_unknownLexer(t *testing.T) {
+	h := New("monokai", true)
+	// an extension chroma has no lexer for — expect nil so caller can fall back
+	result := h.HighlightText("note.zzznoextension", "hello world")
+	assert.Nil(t, result)
+}
+
+func TestHighlighter_HighlightText_empty(t *testing.T) {
+	h := New("monokai", true)
+	result := h.HighlightText("note.md", "")
+	assert.Nil(t, result)
+}

--- a/app/keymap/keymap.go
+++ b/app/keymap/keymap.go
@@ -57,6 +57,7 @@ const (
 	ActionThemeSelect      Action = "theme_select"
 	ActionCommitInfo       Action = "commit_info"
 	ActionReload           Action = "reload"
+	ActionDescription      Action = "description"
 )
 
 // SectionPane is the help section name for pane-related keybindings.
@@ -75,8 +76,9 @@ var validActions = map[Action]bool{
 	ActionToggleLineNums: true, ActionToggleBlame: true, ActionToggleWordDiff: true, ActionToggleHunk: true,
 	ActionMarkReviewed: true, ActionFilter: true, ActionToggleUntracked: true,
 	ActionQuit: true, ActionDiscardQuit: true, ActionHelp: true, ActionDismiss: true, ActionThemeSelect: true,
-	ActionCommitInfo: true,
-	ActionReload:     true,
+	ActionCommitInfo:  true,
+	ActionReload:      true,
+	ActionDescription: true,
 }
 
 // IsValidAction returns true if the action name is recognized.
@@ -160,6 +162,7 @@ func defaultDescriptions() []HelpEntry {
 		{ActionThemeSelect, "theme selector", "View"},
 		{ActionCommitInfo, "show commit info for the current range", "View"},
 		{ActionReload, "reload diff from VCS", "View"},
+		{ActionDescription, "show description overlay", "View"},
 
 		// quit
 		{ActionQuit, "quit", "Quit"},
@@ -214,6 +217,7 @@ func defaultBindings() map[string]Action {
 		"T":      ActionThemeSelect,
 		"i":      ActionCommitInfo,
 		"R":      ActionReload,
+		"D":      ActionDescription,
 		"esc":    ActionDismiss,
 	}
 }

--- a/app/keymap/keymap_test.go
+++ b/app/keymap/keymap_test.go
@@ -42,6 +42,7 @@ func TestDefault_allExpectedBindings(t *testing.T) {
 		{"q", ActionQuit}, {"Q", ActionDiscardQuit}, {"?", ActionHelp}, {"T", ActionThemeSelect}, {"esc", ActionDismiss},
 		{"i", ActionCommitInfo},
 		{"R", ActionReload},
+		{"D", ActionDescription},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.action, km.Resolve(tt.key), "key %q should map to %q", tt.key, tt.action)
@@ -219,6 +220,42 @@ func TestHelpSections_customBindingReflected(t *testing.T) {
 
 func TestActionReload_IsValid(t *testing.T) {
 	assert.True(t, IsValidAction(ActionReload))
+}
+
+func TestActionDescription_IsValid(t *testing.T) {
+	assert.True(t, IsValidAction(ActionDescription))
+}
+
+func TestDescription_roundTrip(t *testing.T) {
+	km := Default()
+	assert.Equal(t, ActionDescription, km.Resolve("D"))
+
+	sections := km.HelpSections()
+	found := false
+	for _, s := range sections {
+		for _, e := range s.Entries {
+			if e.Action == ActionDescription {
+				assert.NotEmpty(t, e.Description, "description action should have description text")
+				assert.Contains(t, e.Keys, "D")
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "description action should appear in help sections")
+
+	var buf strings.Builder
+	require.NoError(t, km.Dump(&buf))
+	assert.Contains(t, buf.String(), "map D description")
+
+	maps, _, err := parse(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+	var matched bool
+	for _, m := range maps {
+		if m.key == "D" && m.action == ActionDescription {
+			matched = true
+		}
+	}
+	assert.True(t, matched, "parsed dump should contain D → description")
 }
 
 func TestIsValidAction(t *testing.T) {

--- a/app/main.go
+++ b/app/main.go
@@ -91,6 +91,11 @@ func run(opts options) error {
 	}
 	km := keymap.LoadOrDefault(keysPath)
 
+	description, err := resolveDescription(opts)
+	if err != nil {
+		return err
+	}
+
 	var (
 		renderer     ui.Renderer
 		workDir      string
@@ -98,7 +103,6 @@ func run(opts options) error {
 		blamer       ui.Blamer
 		untrackedFn  func() ([]string, error)
 		commitLogger diff.CommitLogger
-		err          error
 	)
 
 	programOptions := []tea.ProgramOption{tea.WithAltScreen()}
@@ -141,37 +145,39 @@ func run(opts options) error {
 	}
 
 	model, err := ui.NewModel(ui.ModelConfig{
-		Renderer:          renderer,
-		Store:             store,
-		Highlighter:       hl,
-		StyleResolver:     res,
-		StyleRenderer:     style.NewRenderer(res),
-		SGR:               style.SGR{},
-		WordDiffer:        worddiff.New(),
-		Overlay:           overlay.NewManager(),
-		Themes:            themes,
-		Blamer:            blamer,
-		LoadUntracked:     untrackedFn,
-		Keymap:            km,
-		CommitLog:         commitLogger,
-		CommitsApplicable: commitsApplicable(opts, commitLogger),
-		ReloadApplicable:  reloadApplicable(opts),
-		NoColors:          opts.NoColors,
-		NoStatusBar:       opts.NoStatusBar,
-		NoConfirmDiscard:  opts.NoConfirmDiscard,
-		Wrap:              opts.Wrap,
-		Collapsed:         opts.Collapsed,
-		CrossFileHunks:    opts.CrossFileHunks,
-		LineNumbers:       opts.LineNumbers,
-		ShowBlame:         opts.Blame,
-		WordDiff:          opts.WordDiff,
-		TabWidth:          opts.TabWidth,
-		Ref:               opts.ref(),
-		Staged:            opts.Staged,
-		TreeWidthRatio:    opts.TreeWidth,
-		Only:              opts.Only,
-		WorkDir:           workDir,
-		ActiveThemeName:   themes.catalog.ActiveName(opts.Theme),
+		Renderer:            renderer,
+		Store:               store,
+		Highlighter:         hl,
+		StyleResolver:       res,
+		StyleRenderer:       style.NewRenderer(res),
+		SGR:                 style.SGR{},
+		WordDiffer:          worddiff.New(),
+		Overlay:             overlay.NewManager(),
+		Themes:              themes,
+		Blamer:              blamer,
+		LoadUntracked:       untrackedFn,
+		Keymap:              km,
+		CommitLog:           commitLogger,
+		CommitsApplicable:   commitsApplicable(opts, commitLogger),
+		ReloadApplicable:    reloadApplicable(opts),
+		NoColors:            opts.NoColors,
+		NoStatusBar:         opts.NoStatusBar,
+		NoConfirmDiscard:    opts.NoConfirmDiscard,
+		Wrap:                opts.Wrap,
+		Collapsed:           opts.Collapsed,
+		CrossFileHunks:      opts.CrossFileHunks,
+		LineNumbers:         opts.LineNumbers,
+		ShowBlame:           opts.Blame,
+		WordDiff:            opts.WordDiff,
+		TabWidth:            opts.TabWidth,
+		Ref:                 opts.ref(),
+		Staged:              opts.Staged,
+		TreeWidthRatio:      opts.TreeWidth,
+		Only:                opts.Only,
+		WorkDir:             workDir,
+		ActiveThemeName:     themes.catalog.ActiveName(opts.Theme),
+		Description:         description,
+		DescriptionAutoOpen: opts.DescriptionAutoOpen,
 		NewFileTree: func(entries []diff.FileEntry) ui.FileTreeComponent {
 			return sidepane.NewFileTree(entries)
 		},

--- a/app/ui/handlers_test.go
+++ b/app/ui/handlers_test.go
@@ -454,6 +454,91 @@ func TestModel_HandleCommitInfo_ShowsLoadingHintBeforeLoad(t *testing.T) {
 	assert.Equal(t, "loading commits…", model.commits.hint, "transient hint shown while fetch is in flight")
 }
 
+func TestModel_HandleDescription_OpensOverlayWhenTextSet(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.description.text = "# hello\n\nworld"
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model := result.(Model)
+	assert.Nil(t, cmd, "description open does not issue a tea.Cmd")
+	assert.True(t, model.overlay.Active(), "D should open the overlay when a description is set")
+	assert.Equal(t, overlay.KindDescription, model.overlay.Kind())
+	assert.Empty(t, model.description.hint, "set-text path does not set a hint")
+}
+
+func TestModel_HandleDescription_HintWhenEmpty(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.description.text = ""
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model := result.(Model)
+	assert.False(t, model.overlay.Active(), "overlay must not open when no description provided")
+	assert.Equal(t, "no description provided", model.description.hint)
+}
+
+func TestModel_HandleDescription_HintClearsOnNextKey(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.description.text = ""
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model := result.(Model)
+	require.Equal(t, "no description provided", model.description.hint)
+
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = result.(Model)
+	assert.Empty(t, model.description.hint, "any subsequent key press must clear the transient hint")
+}
+
+func TestModel_HandleDescription_StatusBarShowsHint(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.description.text = ""
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model := result.(Model)
+	assert.Equal(t, "no description provided", model.statusBarText())
+}
+
+func TestModel_Description_AutoOpensOnFirstResize(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.description.text = "# hi"
+	m.description.autoOpen = true
+	require.False(t, m.overlay.Active())
+
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	model := result.(Model)
+	assert.True(t, model.overlay.Active(), "first WindowSizeMsg should auto-open the description overlay")
+	assert.Equal(t, overlay.KindDescription, model.overlay.Kind())
+	assert.True(t, model.description.autoOpened, "autoOpened latch should be set")
+}
+
+func TestModel_Description_AutoOpenSuppressedWhenDisabled(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.description.text = "# hi"
+	m.description.autoOpen = false
+
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	model := result.(Model)
+	assert.False(t, model.overlay.Active(), "auto-open must not fire without the flag")
+}
+
+func TestModel_Description_AutoOpenDoesNotRepeat(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.description.text = "# hi"
+	m.description.autoOpen = true
+
+	// first resize auto-opens
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	model := result.(Model)
+	require.True(t, model.overlay.Active())
+	// user closes the overlay
+	model.overlay.Close()
+	require.False(t, model.overlay.Active())
+	// subsequent resize (e.g. terminal stretched) must not re-open
+	result, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 50})
+	model = result.(Model)
+	assert.False(t, model.overlay.Active(), "second resize must not re-open the description overlay")
+}
+
 func TestModel_ReloadHint_ShownInStatusBar(t *testing.T) {
 	m := testModel([]string{"a.go"}, nil)
 	m.reload.hint = "test reload hint"

--- a/app/ui/mocks/syntax_highlighter.go
+++ b/app/ui/mocks/syntax_highlighter.go
@@ -18,6 +18,9 @@ import (
 //			HighlightLinesFunc: func(filename string, lines []diff.DiffLine) []string {
 //				panic("mock out the HighlightLines method")
 //			},
+//			HighlightTextFunc: func(filename string, text string) []string {
+//				panic("mock out the HighlightText method")
+//			},
 //			SetStyleFunc: func(styleName string) bool {
 //				panic("mock out the SetStyle method")
 //			},
@@ -34,6 +37,9 @@ type SyntaxHighlighterMock struct {
 	// HighlightLinesFunc mocks the HighlightLines method.
 	HighlightLinesFunc func(filename string, lines []diff.DiffLine) []string
 
+	// HighlightTextFunc mocks the HighlightText method.
+	HighlightTextFunc func(filename string, text string) []string
+
 	// SetStyleFunc mocks the SetStyle method.
 	SetStyleFunc func(styleName string) bool
 
@@ -49,6 +55,13 @@ type SyntaxHighlighterMock struct {
 			// Lines is the lines argument value.
 			Lines []diff.DiffLine
 		}
+		// HighlightText holds details about calls to the HighlightText method.
+		HighlightText []struct {
+			// Filename is the filename argument value.
+			Filename string
+			// Text is the text argument value.
+			Text string
+		}
 		// SetStyle holds details about calls to the SetStyle method.
 		SetStyle []struct {
 			// StyleName is the styleName argument value.
@@ -59,6 +72,7 @@ type SyntaxHighlighterMock struct {
 		}
 	}
 	lockHighlightLines sync.RWMutex
+	lockHighlightText  sync.RWMutex
 	lockSetStyle       sync.RWMutex
 	lockStyleName      sync.RWMutex
 }
@@ -96,6 +110,42 @@ func (mock *SyntaxHighlighterMock) HighlightLinesCalls() []struct {
 	mock.lockHighlightLines.RLock()
 	calls = mock.calls.HighlightLines
 	mock.lockHighlightLines.RUnlock()
+	return calls
+}
+
+// HighlightText calls HighlightTextFunc.
+func (mock *SyntaxHighlighterMock) HighlightText(filename string, text string) []string {
+	if mock.HighlightTextFunc == nil {
+		panic("SyntaxHighlighterMock.HighlightTextFunc: method is nil but SyntaxHighlighter.HighlightText was just called")
+	}
+	callInfo := struct {
+		Filename string
+		Text     string
+	}{
+		Filename: filename,
+		Text:     text,
+	}
+	mock.lockHighlightText.Lock()
+	mock.calls.HighlightText = append(mock.calls.HighlightText, callInfo)
+	mock.lockHighlightText.Unlock()
+	return mock.HighlightTextFunc(filename, text)
+}
+
+// HighlightTextCalls gets all the calls that were made to HighlightText.
+// Check the length with:
+//
+//	len(mockedSyntaxHighlighter.HighlightTextCalls())
+func (mock *SyntaxHighlighterMock) HighlightTextCalls() []struct {
+	Filename string
+	Text     string
+} {
+	var calls []struct {
+		Filename string
+		Text     string
+	}
+	mock.lockHighlightText.RLock()
+	calls = mock.calls.HighlightText
+	mock.lockHighlightText.RUnlock()
 	return calls
 }
 

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -41,9 +41,11 @@ type Renderer interface {
 	FileDiff(ref, file string, staged bool) ([]diff.DiffLine, error)
 }
 
-// SyntaxHighlighter provides syntax highlighting for diff lines.
+// SyntaxHighlighter provides syntax highlighting for diff lines and arbitrary
+// text blocks (used by the description overlay to render markdown).
 type SyntaxHighlighter interface {
 	HighlightLines(filename string, lines []diff.DiffLine) []string
+	HighlightText(filename, text string) []string
 	SetStyle(styleName string) bool
 	StyleName() string
 }
@@ -98,6 +100,7 @@ type overlayManager interface {
 	OpenAnnotList(spec overlay.AnnotListSpec)
 	OpenThemeSelect(spec overlay.ThemeSelectSpec)
 	OpenCommitInfo(spec overlay.CommitInfoSpec)
+	OpenDescription(spec overlay.DescriptionSpec)
 	Close()
 	HandleKey(msg tea.KeyMsg, action keymap.Action) overlay.Outcome
 	Compose(base string, ctx overlay.RenderCtx) string
@@ -309,6 +312,20 @@ type commitsState struct {
 	loadSeq    uint64            // bumped before each new commit-log load; stale commitsLoadedMsg (seq mismatch) is dropped
 }
 
+// descriptionState holds the agent-supplied markdown description shown in the
+// description overlay. Populated once at construction from ModelConfig. autoOpen
+// triggers a one-shot open after the first WindowSizeMsg (sizing required by
+// the overlay render path); autoOpened flips to true once that happens so the
+// behavior does not recur after the user closes the overlay. hint is a
+// transient status-bar message used when the user presses D without a
+// description attached — cleared on next key press like other overlay hints.
+type descriptionState struct {
+	text       string
+	autoOpen   bool
+	autoOpened bool
+	hint       string
+}
+
 // reloadState holds the pending-confirmation state for the R reload feature.
 // hint is a transient status-bar message cleared on the next key press.
 // applicable is false in stdin mode (stream consumed; reload impossible).
@@ -361,6 +378,7 @@ type Model struct {
 	annot       annotationState   // annotation input lifecycle state
 	commits     commitsState      // eagerly loaded commit log for the commit-info overlay
 	reload      reloadState       // pending-confirmation state and applicability for R reload
+	description descriptionState  // agent-supplied markdown description for the description overlay
 
 	ready        bool   // true after first WindowSizeMsg
 	filesLoaded  bool   // true after the first filesLoadedMsg is handled (keeps the loading view pinned until real data arrives)
@@ -490,6 +508,16 @@ type ModelConfig struct {
 	// reload is impossible). Computed at composition root in main.go and copied
 	// into Model state. Follows the same pattern as CommitsApplicable.
 	ReloadApplicable bool
+	// Description is the markdown description shown in the description overlay.
+	// Empty means the feature is unavailable — pressing the description hotkey
+	// shows a transient "no description provided" hint instead of the overlay.
+	// Composition root reads --description or --description-file (whichever is
+	// set) into this string.
+	Description string
+	// DescriptionAutoOpen causes the description overlay to open once after the
+	// first WindowSizeMsg when Description is non-empty. Intended for agent
+	// workflows; off by default so interactive users aren't force-fed a popup.
+	DescriptionAutoOpen bool
 }
 
 // NewModel creates a new Model from the given configuration. All dependencies
@@ -600,7 +628,11 @@ func NewModel(cfg ModelConfig) (Model, error) {
 			source:     cls,
 			applicable: cfg.CommitsApplicable && cls != nil,
 		},
-		reload:          reloadState{applicable: cfg.ReloadApplicable},
+		reload: reloadState{applicable: cfg.ReloadApplicable},
+		description: descriptionState{
+			text:     cfg.Description,
+			autoOpen: cfg.DescriptionAutoOpen && cfg.Description != "",
+		},
 		loadUntracked:   cfg.LoadUntracked,
 		activeThemeName: cfg.ActiveThemeName,
 	}, nil
@@ -669,6 +701,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// this point dismisses the last hint before the new action runs.
 	m.commits.hint = ""
 	m.reload.hint = ""
+	m.description.hint = ""
 
 	// pending-reload intercept: y confirms, any other key cancels
 	if m.reload.pending {
@@ -741,6 +774,9 @@ func (m Model) handleOverlayOpen(action keymap.Action) (tea.Model, bool) {
 	case keymap.ActionCommitInfo:
 		m.handleCommitInfo()
 		return m, true
+	case keymap.ActionDescription:
+		m.handleDescription()
+		return m, true
 	default:
 		return m, false
 	}
@@ -767,6 +803,37 @@ func (m *Model) handleCommitInfo() {
 		Truncated:  m.commits.truncated,
 		Err:        m.commits.err,
 	})
+}
+
+// handleDescription opens the description overlay when a description is
+// attached. When no description was supplied, sets a transient status-bar hint
+// so the key press has visible feedback, mirroring handleCommitInfo's no-op
+// branches.
+func (m *Model) handleDescription() {
+	if m.description.text == "" {
+		m.description.hint = "no description provided"
+		return
+	}
+	m.overlay.OpenDescription(overlay.DescriptionSpec{
+		Text:        m.description.text,
+		Highlighter: descriptionHighlighter{base: m.highlighter, enabled: !m.cfg.noColors},
+	})
+}
+
+// descriptionHighlighter adapts the injected SyntaxHighlighter (whose concrete
+// impl owns the chroma plumbing) to the overlay's DescriptionHighlighter shape.
+// When --no-colors is active, returns nil so the overlay falls back to plain
+// text; matches the rest of revdiff's "colors off means colors off" contract.
+type descriptionHighlighter struct {
+	base    SyntaxHighlighter
+	enabled bool
+}
+
+func (h descriptionHighlighter) HighlightText(filename, text string) []string {
+	if !h.enabled || h.base == nil {
+		return nil
+	}
+	return h.base.HighlightText(filename, text)
 }
 
 // applyReloadCleanup clears annotations and turns off the annotated-only
@@ -1029,6 +1096,14 @@ func (m Model) handleResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 
 	if m.file.name != "" {
 		m.syncViewportToCursor()
+	}
+
+	// one-shot description auto-open: fires the first time sizing is known so
+	// overlay.Compose has a valid RenderCtx.Width/Height. autoOpened latches so
+	// the overlay does not reopen on subsequent resizes or after the user closes it.
+	if m.description.autoOpen && !m.description.autoOpened {
+		m.description.autoOpened = true
+		m.handleDescription()
 	}
 
 	return m, nil

--- a/app/ui/overlay/description.go
+++ b/app/ui/overlay/description.go
@@ -1,0 +1,214 @@
+package overlay
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/umputun/revdiff/app/keymap"
+	"github.com/umputun/revdiff/app/ui/style"
+)
+
+const (
+	descriptionPopupMaxWidth    = 90
+	descriptionPopupMinWidth    = 30
+	descriptionPopupWidthRatio  = 0.9
+	descriptionPopupChromeLines = 4 // border (2) + top/bottom padding (2)
+	descriptionPopupBorderPad   = 6 // border (2) + padding-left/right (4)
+	descriptionHeightMargin     = 4
+	descriptionLexerName        = "description.md"
+)
+
+// DescriptionHighlighter renders a markdown source string as per-line ANSI
+// strings. The overlay calls it with the description text and a fake markdown
+// filename so the caller can route to chroma's markdown lexer. Implementations
+// return nil to signal "render plain text instead".
+type DescriptionHighlighter interface {
+	HighlightText(filename, text string) []string
+}
+
+// DescriptionSpec carries the description content and an optional highlighter.
+// Text is the raw markdown source; when Highlighter is non-nil and returns a
+// non-nil slice the overlay renders chroma-highlighted lines, otherwise it
+// falls back to the raw text.
+type DescriptionSpec struct {
+	Text        string
+	Highlighter DescriptionHighlighter
+}
+
+type descriptionOverlay struct {
+	spec   DescriptionSpec
+	offset int
+	height int
+}
+
+func (d *descriptionOverlay) open(spec DescriptionSpec) {
+	d.spec = spec
+	d.offset = 0
+}
+
+func (d *descriptionOverlay) render(ctx RenderCtx, mgr *Manager) string {
+	d.height = ctx.Height
+
+	popupWidth := d.popupWidth(ctx.Width)
+	innerWidth := popupWidth - descriptionPopupBorderPad
+	viewportHeight := d.viewportHeight(ctx.Height)
+
+	content := d.buildContent(innerWidth)
+
+	if maxOffset := max(len(content)-viewportHeight, 0); d.offset > maxOffset {
+		d.offset = maxOffset
+	}
+	if d.offset < 0 {
+		d.offset = 0
+	}
+
+	visible := d.applyScroll(content, viewportHeight)
+
+	boxStyle := ctx.Resolver.Style(style.StyleKeyCommitInfoBox).Width(popupWidth)
+	box := boxStyle.Render(strings.Join(visible, "\n"))
+
+	accentFg := string(ctx.Resolver.Color(style.ColorKeyAccentFg))
+	paneBg := string(ctx.Resolver.Color(style.ColorKeyDiffPaneBg))
+	return mgr.injectBorderTitle(box, " description ", popupWidth, accentFg, paneBg)
+}
+
+func (d *descriptionOverlay) popupWidth(termWidth int) int {
+	target := int(float64(termWidth) * descriptionPopupWidthRatio)
+	w := min(target, descriptionPopupMaxWidth)
+	return max(w, descriptionPopupMinWidth)
+}
+
+func (d *descriptionOverlay) viewportHeight(termHeight int) int {
+	usable := termHeight - descriptionHeightMargin - descriptionPopupChromeLines
+	return max(usable, 1)
+}
+
+// buildContent returns padded, wrapped content lines ready for scroll/render.
+// when Text is empty, renders a centered "no description" hint instead.
+func (d *descriptionOverlay) buildContent(innerWidth int) []string {
+	if strings.TrimSpace(d.spec.Text) == "" {
+		return d.centeredMessage("no description", innerWidth, true)
+	}
+
+	rawLines := d.sourceLines(d.spec.Text)
+
+	var out []string
+	for _, raw := range rawLines {
+		if raw == "" {
+			out = append(out, d.padLine("", innerWidth))
+			continue
+		}
+		for _, wrapped := range d.wrapLine(raw, innerWidth) {
+			out = append(out, d.padLine(wrapped, innerWidth))
+		}
+	}
+	return out
+}
+
+// sourceLines returns chroma-highlighted lines when a highlighter is attached
+// and produces output, otherwise it splits the raw text on newlines.
+func (d *descriptionOverlay) sourceLines(text string) []string {
+	if d.spec.Highlighter != nil {
+		if hl := d.spec.Highlighter.HighlightText(descriptionLexerName, text); hl != nil {
+			return hl
+		}
+	}
+	// preserve trailing blank lines as visible rows inside the popup.
+	return strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+}
+
+// wrapLine wraps s to width using ANSI-aware soft wrap and re-emits active
+// SGR state on each continuation line so chroma tokens that span wraps keep
+// their color.
+func (d *descriptionOverlay) wrapLine(s string, width int) []string {
+	if width <= 0 {
+		return []string{s}
+	}
+	wrapped := ansi.Wrap(s, width, "")
+	lines := strings.Split(wrapped, "\n")
+	return style.SGR{}.Reemit(lines)
+}
+
+// padLine right-pads line with spaces up to width so the overlay's background
+// fills the full line — otherwise the terminal's default bg bleeds through.
+func (d *descriptionOverlay) padLine(line string, width int) string {
+	w := lipgloss.Width(line)
+	if w >= width {
+		return line
+	}
+	return line + strings.Repeat(" ", width-w)
+}
+
+// centeredMessage renders a one-line centered message, optionally italicized.
+func (d *descriptionOverlay) centeredMessage(text string, innerWidth int, italic bool) []string {
+	if italic {
+		text = ansiItalicOn + text + ansiItalicOff
+	}
+	visual := lipgloss.Width(text)
+	pad := max((innerWidth-visual)/2, 0)
+	line := strings.Repeat(" ", pad) + text
+	return []string{d.padLine(line, innerWidth)}
+}
+
+// applyScroll returns the slice of lines currently visible given the viewport
+// height and the overlay's offset.
+func (d *descriptionOverlay) applyScroll(content []string, viewportHeight int) []string {
+	if viewportHeight <= 0 {
+		return nil
+	}
+	if len(content) <= viewportHeight {
+		return content
+	}
+	end := min(d.offset+viewportHeight, len(content))
+	return content[d.offset:end]
+}
+
+func (d *descriptionOverlay) handleKey(msg tea.KeyMsg, action keymap.Action) Outcome {
+	if action == keymap.ActionDescription ||
+		action == keymap.ActionDismiss ||
+		action == keymap.ActionQuit ||
+		msg.Type == tea.KeyEsc {
+		return Outcome{Kind: OutcomeClosed}
+	}
+
+	switch action { //nolint:exhaustive // navigation subset; other actions fall through
+	case keymap.ActionDown:
+		d.offset++
+		return Outcome{Kind: OutcomeNone}
+	case keymap.ActionUp:
+		if d.offset > 0 {
+			d.offset--
+		}
+		return Outcome{Kind: OutcomeNone}
+	case keymap.ActionPageDown, keymap.ActionHalfPageDown:
+		d.offset += d.viewportHeight(d.height)
+		return Outcome{Kind: OutcomeNone}
+	case keymap.ActionPageUp, keymap.ActionHalfPageUp:
+		d.offset -= d.viewportHeight(d.height)
+		if d.offset < 0 {
+			d.offset = 0
+		}
+		return Outcome{Kind: OutcomeNone}
+	case keymap.ActionHome:
+		d.offset = 0
+		return Outcome{Kind: OutcomeNone}
+	case keymap.ActionEnd:
+		d.offset = scrollEndSentinel
+		return Outcome{Kind: OutcomeNone}
+	}
+
+	if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 {
+		switch msg.Runes[0] {
+		case 'g':
+			d.offset = 0
+			return Outcome{Kind: OutcomeNone}
+		case 'G':
+			d.offset = scrollEndSentinel
+			return Outcome{Kind: OutcomeNone}
+		}
+	}
+	return Outcome{Kind: OutcomeNone}
+}

--- a/app/ui/overlay/description_test.go
+++ b/app/ui/overlay/description_test.go
@@ -1,0 +1,131 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/umputun/revdiff/app/keymap"
+	"github.com/umputun/revdiff/app/ui/style"
+)
+
+func descriptionRenderCtx() RenderCtx {
+	return RenderCtx{Width: 100, Height: 30, Resolver: style.PlainResolver()}
+}
+
+func TestDescriptionOverlay_RenderEmpty(t *testing.T) {
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{})
+	out := mgr.description.render(descriptionRenderCtx(), mgr)
+	assert.Contains(t, out, "no description")
+	assert.Contains(t, out, "description")
+}
+
+func TestDescriptionOverlay_RenderPlainText(t *testing.T) {
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: "first line\nsecond line"})
+	out := mgr.description.render(descriptionRenderCtx(), mgr)
+	assert.Contains(t, out, "first line")
+	assert.Contains(t, out, "second line")
+}
+
+func TestDescriptionOverlay_RenderHighlightedMarkdown(t *testing.T) {
+	mgr := NewManager()
+	hl := stubHighlighter{result: []string{"\033[1mhello\033[22m", "world"}}
+	mgr.OpenDescription(DescriptionSpec{Text: "# Hello\n\nworld", Highlighter: hl})
+	out := mgr.description.render(descriptionRenderCtx(), mgr)
+	assert.Contains(t, out, "hello", "highlighted content passed through")
+	assert.Contains(t, out, "world")
+}
+
+func TestDescriptionOverlay_RenderLongContentWraps(t *testing.T) {
+	long := strings.Repeat("word ", 80)
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: long})
+	out := mgr.description.render(descriptionRenderCtx(), mgr)
+	// wraps into multiple visible rows
+	assert.Greater(t, strings.Count(out, "word"), 4)
+}
+
+func TestDescriptionOverlay_ScrollJK(t *testing.T) {
+	body := strings.Repeat("line\n", 200)
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: body})
+	// force a render so height is known
+	_ = mgr.description.render(descriptionRenderCtx(), mgr)
+
+	mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}, keymap.ActionDown)
+	assert.Equal(t, 1, mgr.description.offset)
+
+	mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}}, keymap.ActionUp)
+	assert.Equal(t, 0, mgr.description.offset)
+
+	// k at 0 must stay at 0
+	mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}}, keymap.ActionUp)
+	assert.Equal(t, 0, mgr.description.offset)
+}
+
+func TestDescriptionOverlay_ScrollGG(t *testing.T) {
+	body := strings.Repeat("line\n", 200)
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: body})
+	_ = mgr.description.render(descriptionRenderCtx(), mgr)
+
+	mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}}, "")
+	assert.Equal(t, scrollEndSentinel, mgr.description.offset)
+
+	mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}, "")
+	assert.Equal(t, 0, mgr.description.offset)
+}
+
+func TestDescriptionOverlay_DClosesOverlay(t *testing.T) {
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: "hi"})
+	out := mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}, keymap.ActionDescription)
+	assert.Equal(t, OutcomeClosed, out.Kind)
+}
+
+func TestDescriptionOverlay_QClosesOverlay(t *testing.T) {
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: "hi"})
+	out := mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}, keymap.ActionQuit)
+	assert.Equal(t, OutcomeClosed, out.Kind)
+}
+
+func TestDescriptionOverlay_EscClosesOverlay(t *testing.T) {
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: "hi"})
+	out := mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyEsc}, keymap.ActionDismiss)
+	assert.Equal(t, OutcomeClosed, out.Kind)
+}
+
+func TestDescriptionOverlay_TitleShowsDescription(t *testing.T) {
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{Text: "body"})
+	out := mgr.description.render(descriptionRenderCtx(), mgr)
+	assert.Contains(t, out, "description")
+}
+
+// stubHighlighter is used only by description overlay tests to simulate
+// chroma-formatted markdown without requiring the real highlighter.
+type stubHighlighter struct {
+	result []string
+}
+
+func (s stubHighlighter) HighlightText(_, _ string) []string { return s.result }
+
+// ensure description overlay offsets clamp within bounds when Text is empty.
+func TestDescriptionOverlay_EmptyScrollClamp(t *testing.T) {
+	mgr := NewManager()
+	mgr.OpenDescription(DescriptionSpec{})
+	_ = mgr.description.render(descriptionRenderCtx(), mgr)
+	// scrolling on empty should not panic or move offset below zero
+	mgr.description.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}, keymap.ActionDown)
+	assert.GreaterOrEqual(t, mgr.description.offset, 0)
+	require.NotPanics(t, func() {
+		_ = mgr.description.render(descriptionRenderCtx(), mgr)
+	})
+}

--- a/app/ui/overlay/overlay.go
+++ b/app/ui/overlay/overlay.go
@@ -31,6 +31,7 @@ const (
 	KindAnnotList        // annotation list popup
 	KindThemeSelect      // theme selector popup
 	KindCommitInfo       // commit info popup
+	KindDescription      // description overlay
 )
 
 // OutcomeKind describes what happened after a key press in an overlay.
@@ -138,11 +139,12 @@ type CommitInfoSpec struct {
 // Manager coordinates overlay lifecycle: open/close, key routing, and render composition.
 // Only one overlay can be active at a time.
 type Manager struct {
-	kind       Kind
-	help       helpOverlay
-	annotLst   annotListOverlay
-	themeSel   themeSelectOverlay
-	commitInfo commitInfoOverlay
+	kind        Kind
+	help        helpOverlay
+	annotLst    annotListOverlay
+	themeSel    themeSelectOverlay
+	commitInfo  commitInfoOverlay
+	description descriptionOverlay
 }
 
 // NewManager creates a Manager with no active overlay.
@@ -187,6 +189,13 @@ func (m *Manager) OpenCommitInfo(spec CommitInfoSpec) {
 	m.commitInfo.open(spec)
 }
 
+// OpenDescription activates the description overlay with the given spec.
+func (m *Manager) OpenDescription(spec DescriptionSpec) {
+	m.Close()
+	m.kind = KindDescription
+	m.description.open(spec)
+}
+
 // HandleKey routes a key press to the active overlay and returns the outcome.
 // auto-closes the overlay for outcomes that imply dismissal.
 // returns Outcome{Kind: OutcomeNone} when no overlay is active.
@@ -203,6 +212,8 @@ func (m *Manager) HandleKey(msg tea.KeyMsg, action keymap.Action) Outcome {
 		out = m.themeSel.handleKey(msg, action)
 	case KindCommitInfo:
 		out = m.commitInfo.handleKey(msg, action)
+	case KindDescription:
+		out = m.description.handleKey(msg, action)
 	default:
 		return Outcome{}
 	}
@@ -231,6 +242,8 @@ func (m *Manager) Compose(base string, ctx RenderCtx) string {
 		fg = m.themeSel.render(ctx, m)
 	case KindCommitInfo:
 		fg = m.commitInfo.render(ctx, m)
+	case KindDescription:
+		fg = m.description.render(ctx, m)
 	}
 	return m.overlayCenter(base, fg, ctx.Width)
 }

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -121,6 +121,10 @@ func (m Model) statusBarText() string {
 		return m.reload.hint
 	}
 
+	if m.description.hint != "" {
+		return m.description.hint
+	}
+
 	// build left-side segments
 	var segments []string
 
@@ -343,6 +347,7 @@ func (m Model) statusModeIcons() string {
 		{"±", m.modes.wordDiff},
 		{"✓", m.tree.ReviewedCount() > 0},
 		{"∅", m.modes.showUntracked},
+		{"§", m.description.text != ""},
 	}
 
 	mutedSeq := string(m.resolver.Color(style.ColorKeyMutedFg))

--- a/app/ui/view_test.go
+++ b/app/ui/view_test.go
@@ -71,6 +71,28 @@ func TestModel_StatusModeIcons(t *testing.T) {
 		assert.Contains(t, icons, "◉")
 		assert.Contains(t, icons, "↩")
 		assert.Contains(t, icons, "≋")
+		assert.Contains(t, icons, "§", "description indicator always present (muted when no description)")
+	})
+
+	t.Run("description icon active when text set", func(t *testing.T) {
+		sc := style.Colors{Muted: "#6c6c6c", StatusFg: "#202020"}
+		m := testModel(nil, nil)
+		res := style.NewResolver(sc)
+		m.resolver = res
+		m.renderer = style.NewRenderer(res)
+		m.description.text = "# hi"
+		icons := m.statusModeIcons()
+		assert.Contains(t, icons, "\033[38;2;32;32;32m§", "active description icon should have status fg")
+	})
+
+	t.Run("description icon inactive when no text", func(t *testing.T) {
+		sc := style.Colors{Muted: "#6c6c6c", StatusFg: "#202020"}
+		m := testModel(nil, nil)
+		res := style.NewResolver(sc)
+		m.resolver = res
+		m.renderer = style.NewRenderer(res)
+		icons := m.statusModeIcons()
+		assert.Contains(t, icons, "\033[38;2;108;108;108m§", "inactive description icon should use muted fg")
 	})
 
 	t.Run("with colors active icons use status fg", func(t *testing.T) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,6 +153,7 @@ Layered popup system with mutual exclusivity (one overlay at a time).
 - **`annotListOverlay`** — scrollable annotation list with cross-file jump
 - **`themeSelectOverlay`** — theme picker with fzf-style filter, live swatch preview
 - **`commitInfoOverlay`** (`commitinfo.go`) — scrollable read-only pager showing subject + body of every commit in the current ref range. Populated eagerly at startup via `loadCommits()` in parallel with `loadFiles()` under `tea.Batch`; re-fetched on `R` reload. `handleCommitInfo` only reads cached state — a transient "loading commits…" hint fires if the user presses `i` before the fetch lands. Sized via `clamp(term_w * 0.9, 30, 90)` × `term_h - 4`, wraps body text at word boundaries using `ansi.Wrap` from `charmbracelet/x/ansi` (ANSI-aware, preserves inline escapes). Renders "no commits in range" / error-italic / "no commits in this mode" placeholders for edge cases.
+- **`descriptionOverlay`** (`description.go`) — scrollable read-only pager showing an agent-supplied markdown description (`--description` / `--description-file`). Content is already loaded at startup (read in the composition root with a 1 MiB cap), so there is no async fetch path. Reuses the chroma markdown lexer via `highlight.Highlighter.HighlightText` so styling matches how a `.md` file appears in the diff view. Sized and wrapped the same way as `commitInfoOverlay`. Auto-opens once after the first `tea.WindowSizeMsg` when `--description-auto-open` is set (guarded by a one-shot latch so closing the overlay doesn't trigger it again on terminal resize). Pressing `D` with no description attached sets a transient "no description provided" hint on the status bar.
 
 `Manager.HandleKey()` returns an `Outcome` — Model switches on `OutcomeKind` to perform side effects (file jumps, theme apply/persist). This keeps overlay package free of Model dependencies.
 
@@ -226,7 +227,7 @@ All consumer-side — defined in `app/ui/model.go`, not in implementor packages 
 | `wordDiffer` | `ComputeIntraRanges()`, `PairLines()`, `InsertHighlightMarkers()` | `worddiff.Differ` |
 | `FileTreeComponent` | 15 methods (navigation, query, mutation, render) | `sidepane.FileTree` |
 | `TOCComponent` | 7 methods (navigation, cursor/section query+set, render) | `sidepane.TOC` |
-| `overlayManager` | `Active()`, `Kind()`, `OpenHelp()`, `OpenAnnotList()`, `OpenThemeSelect()`, `OpenCommitInfo()`, `Close()`, `HandleKey()`, `Compose()` | `overlay.Manager` |
+| `overlayManager` | `Active()`, `Kind()`, `OpenHelp()`, `OpenAnnotList()`, `OpenThemeSelect()`, `OpenCommitInfo()`, `OpenDescription()`, `Close()`, `HandleKey()`, `Compose()` | `overlay.Manager` |
 | `ThemeCatalog` | `Entries()`, `Resolve()`, `Persist()` | `themeCatalog` adapter in `app/themes.go` (composes `theme.Catalog` + config persistence) |
 | `ExternalEditor` | `Command(content)` returning `*exec.Cmd`, `complete(error) (string, error)`, `error` | `editor.Editor` (default wiring via `ModelConfig.Editor`; stubbed in tests) |
 

--- a/plugins/codex/skills/revdiff/SKILL.md
+++ b/plugins/codex/skills/revdiff/SKILL.md
@@ -111,6 +111,29 @@ The script outputs structured fields:
 - On main + clean → `HEAD~1` (last commit)
 - On feature branch + clean → main branch name (full branch diff)
 
+### Step 1.5: Compose a Description (when you have context)
+
+If you have meaningful context about the diff — you just implemented the code, you're running revdiff as part of a larger workflow, or the user has been discussing the change — write a short markdown description and pass it to the launcher so the reviewer sees it the moment revdiff pops up.
+
+Write 2–6 lines of markdown that cover: what changed, why, and anything specific you want the user to look at. Save it to a temp file and pass both flags on the launcher command line:
+
+```bash
+DESC_FILE="$(mktemp -t revdiff-desc.XXXXXX.md)"
+cat > "$DESC_FILE" <<'MARKDOWN'
+# Short title
+
+- bullet one
+- bullet two
+
+Please check X.
+MARKDOWN
+# append to the launcher call in Step 2: --description-file="$DESC_FILE" --description-auto-open
+```
+
+Skip this step when the user explicitly invoked `revdiff <ref>` without any backstory (you don't know what's in the diff, so inventing context would mislead the reviewer). Also skip for the explanation loop (Step 3.5) — that markdown already is the content being reviewed.
+
+Clean up the temp file after the review loop exits (Step 7): `rm -f "$DESC_FILE"`.
+
 ### Step 2: Launch Review
 
 Run the launcher script:

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -41,6 +41,9 @@ Then uncomment and edit the values you want to change.
 | `-X`, `--exclude` | `REVDIFF_EXCLUDE` | Exclude files matching prefix (may be repeated; comma-separated in env) | |
 | `-F`, `--only` | | Show only matching files (may be repeated, matches by path or suffix) | |
 | `-o`, `--output` | `REVDIFF_OUTPUT` | Write annotations to file instead of stdout | |
+| `--description` | | Markdown description shown in the description overlay (press `D` to toggle); useful for agents attaching context to a diff | |
+| `--description-file` | | Path to markdown file shown in the description overlay (mutually exclusive with `--description`) | |
+| `--description-auto-open` | | Open the description overlay on startup when a description is set | `false` |
 | `--history-dir` | `REVDIFF_HISTORY_DIR` | Directory for review history auto-saves | `~/.config/revdiff/history/` |
 | `--keys` | `REVDIFF_KEYS` | Path to keybindings file | `~/.config/revdiff/keybindings` |
 | `--dump-keys` | | Print effective keybindings to stdout and exit | |

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -123,6 +123,7 @@ While the annotation input is active, press `Ctrl+E` to hand off the current tex
 | `f` | Toggle filter: all files / annotated only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle commit info popup (subject + body of commits in the current ref range; git/hg/jj only) |
+| `D` | Toggle description overlay (shows `--description` / `--description-file` content) |
 | `R` | Reload diff from VCS (warns if annotations exist) |
 | `q` | Quit, output annotations to stdout |
 | `Q` | Discard all annotations and quit (confirms if annotations exist) |
@@ -143,6 +144,7 @@ The status bar shows a fixed row of mode indicators on the right side. All ten s
 | `±` | `W` | Intra-line word-diff highlighting |
 | `✓` | `Space` | Reviewed count (increments when a file is marked reviewed) |
 | `∅` | `u` | Untracked files visible in tree |
+| `§` | `D` | Description overlay available (a `--description` / `--description-file` was supplied) |
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.
 

--- a/plugins/pi/skills/revdiff/SKILL.md
+++ b/plugins/pi/skills/revdiff/SKILL.md
@@ -17,6 +17,8 @@ Use the revdiff pi extension for interactive review sessions.
 - `/revdiff-clear` — clear the stored review state widget/panel
 - `/revdiff-reminders on|off` — enable or disable post-edit review reminders
 
+Pass `--description="…"` or `--description-file=<path>` (plus `--description-auto-open` to open it on startup) to attach a markdown description shown in the `D` overlay — useful when the agent wants to summarize the diff before the user reviews it.
+
 ## Recommended usage
 
 Examples:
@@ -29,6 +31,7 @@ Examples:
 /revdiff --all-files --include src
 /revdiff --all-files --exclude vendor
 /revdiff --only README.md
+/revdiff HEAD~1 --description-file=/tmp/notes.md --description-auto-open
 ```
 
 Behavior:

--- a/site/docs.html
+++ b/site/docs.html
@@ -344,6 +344,9 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>-A, --all-files</code></td><td>Browse all tracked files (git and jj only)</td><td><code>false</code></td></tr>
                 <tr><td><code>--stdin</code></td><td>Review stdin as a scratch buffer</td><td><code>false</code></td></tr>
                 <tr><td><code>--stdin-name</code></td><td>Synthetic file name for stdin content</td><td><code>scratch-buffer</code></td></tr>
+                <tr><td><code>--description</code></td><td>Markdown description shown in the description overlay (press <code>D</code> to toggle)</td><td></td></tr>
+                <tr><td><code>--description-file</code></td><td>Path to markdown file shown in the description overlay (mutually exclusive with <code>--description</code>)</td><td></td></tr>
+                <tr><td><code>--description-auto-open</code></td><td>Open the description overlay on startup when a description is set</td><td><code>false</code></td></tr>
                 <tr><td><code>-I, --include</code></td><td>Include only files matching prefix (repeatable)</td><td></td></tr>
                 <tr><td><code>-X, --exclude</code></td><td>Exclude files by prefix (repeatable)</td><td></td></tr>
                 <tr><td><code>-F, --only</code></td><td>Show only matching files</td><td></td></tr>
@@ -478,6 +481,7 @@ color-border = #6272a4
                 <tr><td><code>f</code></td><td>Filter: all files / annotated only</td></tr>
                 <tr><td><code>?</code></td><td>Help overlay</td></tr>
                 <tr><td><code>i</code></td><td>Commit info popup (subject + body of commits in the current ref range; git/hg/jj only)</td></tr>
+                <tr><td><code>D</code></td><td>Description overlay (shows <code>--description</code> / <code>--description-file</code> content; hint when neither is set)</td></tr>
                 <tr><td><code>R</code></td><td>Reload diff from VCS (warns if annotations exist)</td></tr>
                 <tr><td><code>q</code></td><td>Quit, output annotations</td></tr>
                 <tr><td><code>Q</code></td><td>Discard annotations and quit</td></tr>
@@ -499,6 +503,7 @@ color-border = #6272a4
                 <tr><td><code>±</code></td><td><code>W</code></td><td>Intra-line word-diff highlighting</td></tr>
                 <tr><td><code>✓</code></td><td><code>Space</code></td><td>Reviewed count (increments when a file is marked reviewed)</td></tr>
                 <tr><td><code>∅</code></td><td><code>u</code></td><td>Untracked files visible in tree</td></tr>
+                <tr><td><code>§</code></td><td><code>D</code></td><td>Description overlay available (a <code>--description</code> / <code>--description-file</code> was supplied)</td></tr>
             </tbody>
         </table>
         <p>On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.</p>
@@ -518,7 +523,7 @@ unmap q</code></div>
         <p><strong>Pane:</strong> <code>toggle_pane</code>, <code>focus_tree</code>, <code>focus_diff</code></p>
         <p><strong>Search:</strong> <code>search</code></p>
         <p><strong>Annotations:</strong> <code>confirm</code>, <code>annotate_file</code>, <code>delete_annotation</code>, <code>annot_list</code></p>
-        <p><strong>View:</strong> <code>toggle_collapsed</code>, <code>toggle_wrap</code>, <code>toggle_tree</code>, <code>toggle_line_numbers</code>, <code>toggle_blame</code>, <code>toggle_word_diff</code>, <code>toggle_hunk</code>, <code>toggle_untracked</code>, <code>mark_reviewed</code>, <code>theme_select</code>, <code>filter</code>, <code>commit_info</code>, <code>reload</code></p>
+        <p><strong>View:</strong> <code>toggle_collapsed</code>, <code>toggle_wrap</code>, <code>toggle_tree</code>, <code>toggle_line_numbers</code>, <code>toggle_blame</code>, <code>toggle_word_diff</code>, <code>toggle_hunk</code>, <code>toggle_untracked</code>, <code>mark_reviewed</code>, <code>theme_select</code>, <code>filter</code>, <code>commit_info</code>, <code>reload</code>, <code>description</code></p>
         <p><strong>Quit:</strong> <code>quit</code>, <code>discard_quit</code>, <code>help</code>, <code>dismiss</code></p>
 
         <!-- claude code plugin -->


### PR DESCRIPTION
## Summary

Adds a `D`-toggled markdown description overlay so agents can attach a short markdown explanation of a diff and have it visible the moment revdiff opens. Closes #130.

## Problem

When revdiff auto-opens from a Claude Code / Codex / Pi popup, the user often loses track of *what* is being shown and *why* — especially after stepping away for a meeting. Agents have this context when they launch revdiff, but there was no way to carry it into the review session.

## Solution

- New CLI flags (all agent-friendly: `no-ini:"true"`, per-invocation):
  - `--description="..."` — inline markdown shown in the overlay.
  - `--description-file=path.md` — read markdown from a file (1 MiB cap; avoids shell-escape pain for multi-line agent output).
  - `--description-auto-open` — pop the overlay on startup (opt-in so interactive users aren't force-fed a popup).
  - `--description` and `--description-file` are mutually exclusive; `--description-auto-open` requires one of them.
- New `D` hotkey (unbound before; `d` is delete-annotation).
- New `descriptionOverlay` built by mirroring the `commitInfoOverlay` pattern the maintainer called out: `overlay.Manager` coordination, ANSI-aware wrap via `ansi.Wrap` + `style.SGR.Reemit`, offset-based scrolling with `j`/`k`/`PageUp`/`PageDown`/`g`/`G`/`Home`/`End`/`q`/`Esc`.
- Markdown rendering reuses chroma via a new `highlight.Highlighter.HighlightText(filename, text)` — same path that highlights `.md` files in the diff, no new dependency.
- Auto-open fires once after the first `tea.WindowSizeMsg` (needed for `RenderCtx.Width/Height`); guarded so closing the overlay doesn't re-open it on terminal resize.
- New `§` status-bar mode icon (active when a description is attached).
- Plugin skills (Claude, Codex, Pi) updated to encourage agents to compose a short description before launching when they have context, and to document the new flags.

## Design notes (matches maintainer's framing in #130)

- **Overlay, not pane** — consistent with `i` commit-info, minimal footprint on narrow terminals, hidden by default.
- **Chroma-highlighted markdown source** — keeps markers visible, matches how `.md` files look in the diff view.
- **File read in composition root** (`app/description.go`), not in `app/ui/` — honors CLAUDE.md's "decouple OS/external concerns from UI".
- **Consumer-side interface extension** — `overlayManager` and `SyntaxHighlighter` grew in `app/ui/model.go`, with the moq mock regenerated.

## Test plan

- [x] `make test` passes (race detector).
- [x] Unit tests: config flag parse/mutex (7), `HighlightText` (4), description overlay render/scroll/close (11), Model handler + auto-open + status icon (7), `resolveDescription` file I/O (7).
- [x] Manual tmux scenarios in a dedicated window:
  - Auto-open with `--description-file=…` → overlay visible on startup.
  - `D` toggles open/close.
  - Long description wraps and scrolls (`j`/`k`/`G`/`g`).
  - No description + `D` → "no description provided" status-bar hint.
  - `--description` + `--description-file` → parse error at startup.
  - `--description-file=/does/not/exist` → clear startup error, no TUI.
  - `--description-auto-open` without description → startup error.
- [x] README, `site/docs.html`, `docs/ARCHITECTURE.md`, and plugin reference docs updated in lockstep.

Split into 10 small commits for easy review.