### PR TITLE
Add mouse support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "revdiff",
       "source": "./",
       "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
   "author": {
     "name": "umputun",

--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -31,6 +31,7 @@ Then uncomment and edit the values you want to change.
 | `--blame` | `REVDIFF_BLAME` | Show blame gutter on startup | `false` |
 | `--word-diff` | `REVDIFF_WORD_DIFF` | Highlight intra-line word-level changes in paired add/remove lines | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
+| `--no-mouse` | `REVDIFF_NO_MOUSE` | Disable mouse support (scroll wheel, click) | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
 | `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/` | |
 | `--dump-theme` | | Print currently resolved colors as theme file and exit | |

--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -148,6 +148,28 @@ The status bar shows a fixed row of mode indicators on the right side. All slots
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.
 
+## Mouse Support
+
+revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.
+
+- **Scroll wheel** — scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.
+- **Shift+scroll** — half-page scroll in whichever pane the cursor is over.
+- **Left-click in the tree** — focuses the tree and selects/loads the clicked entry. Clicking a directory row moves the cursor but does not load a file.
+- **Left-click in the diff** — focuses the diff and moves the cursor to the clicked line. Enables a "click, then `a`" annotation flow.
+- **Left-click in the TOC pane** (single-file markdown) — focuses the TOC and selects the clicked header.
+
+Horizontal wheel, right-click, middle-click, drag selection, and clicks on the status bar or diff header are intentionally ignored. Modal states (annotation input, search input, confirm discard, reload confirm, open overlay) swallow mouse events so they cannot interfere with text entry or popups.
+
+**Text selection trade-off** — once mouse tracking is on, plain drag is captured by revdiff. For terminal-native text selection:
+
+- **kitty**: hold `Ctrl+Shift` while dragging
+- **iTerm2**: hold `Option` while dragging
+- **most other terminals**: hold `Shift` while dragging
+
+Because the tree pane is rendered alongside the diff on the same rows, multi-line Shift+drag will include tree content. For clean copies of diff text, use your terminal's block-select mode (Option+drag in iTerm2, Ctrl+Shift+drag in kitty) or run with `--no-mouse` to disable mouse capture entirely.
+
+Opt out with `--no-mouse`, `REVDIFF_NO_MOUSE=true`, or `no-mouse = true` in the config file.
+
 ## Custom Keybindings
 
 All keybindings can be customized via `~/.config/revdiff/keybindings` (override path with `--keys` or `REVDIFF_KEYS`).

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Positional arguments support several forms:
 | `--blame` | Show blame gutter on startup, env: `REVDIFF_BLAME` | `false` |
 | `--word-diff` | Highlight intra-line word-level changes in paired add/remove lines, env: `REVDIFF_WORD_DIFF` | `false` |
 | `--no-confirm-discard` | Skip confirmation when discarding annotations with Q, env: `REVDIFF_NO_CONFIRM_DISCARD` | `false` |
+| `--no-mouse` | Disable mouse support (scroll wheel, click), env: `REVDIFF_NO_MOUSE` | `false` |
 | `--chroma-style` | Chroma color theme for syntax highlighting, env: `REVDIFF_CHROMA_STYLE` | `catppuccin-macchiato` |
 | `--theme` | Load color theme from `~/.config/revdiff/themes/`, env: `REVDIFF_THEME` | |
 | `--dump-theme` | Print currently resolved colors as theme file to stdout and exit | |
@@ -652,6 +653,28 @@ The status bar shows a fixed row of mode indicators on the right side. All slots
 | `∅` | `u` | Untracked files visible in tree |
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.
+
+### Mouse Support
+
+revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.
+
+- **Scroll wheel**: scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.
+- **Shift+scroll**: half-page scroll in whichever pane the cursor is over.
+- **Left-click in the tree**: focuses the tree and selects/loads the clicked entry (same as pressing `j`/`k` to land there). Clicking a directory row moves the cursor but does not load a file.
+- **Left-click in the diff**: focuses the diff and moves the cursor to the clicked line. Enables a "click, then `a`" annotation flow.
+- **Left-click in the TOC pane** (single-file markdown): focuses the TOC and selects the clicked header.
+
+Horizontal wheel, right-click, middle-click, drag selection, and clicks on the status bar or diff header are intentionally ignored. Modal states (annotation input, search input, confirm discard, reload confirm, open overlay) swallow mouse events so they cannot interfere with text entry or popups.
+
+**Text selection trade-off** — once mouse tracking is on, plain drag is captured by revdiff. For terminal-native text selection:
+
+- **kitty**: hold `Ctrl+Shift` while dragging
+- **iTerm2**: hold `Option` while dragging
+- **most other terminals**: hold `Shift` while dragging
+
+Because the tree pane is rendered alongside the diff on the same rows, multi-line Shift+drag will include tree content. For clean copies of diff text, use your terminal's block-select mode (Option+drag in iTerm2, Ctrl+Shift+drag in kitty) or run with `--no-mouse` to disable mouse capture entirely.
+
+Opt out with `--no-mouse`, `REVDIFF_NO_MOUSE=true`, or `no-mouse = true` in the config file.
 
 ### Custom Keybindings
 

--- a/app/config.go
+++ b/app/config.go
@@ -23,6 +23,7 @@ type options struct {
 	NoColors         bool     `long:"no-colors" ini-name:"no-colors" env:"REVDIFF_NO_COLORS" description:"disable all colors including syntax highlighting"`
 	NoStatusBar      bool     `long:"no-status-bar" ini-name:"no-status-bar" env:"REVDIFF_NO_STATUS_BAR" description:"hide the status bar"`
 	NoConfirmDiscard bool     `long:"no-confirm-discard" ini-name:"no-confirm-discard" env:"REVDIFF_NO_CONFIRM_DISCARD" description:"skip confirmation prompt when discarding annotations with Q"`
+	NoMouse          bool     `long:"no-mouse" ini-name:"no-mouse" env:"REVDIFF_NO_MOUSE" description:"disable mouse support (scroll wheel, click)"`
 	Wrap             bool     `long:"wrap" ini-name:"wrap" env:"REVDIFF_WRAP" description:"enable line wrapping in diff view"`
 	Collapsed        bool     `long:"collapsed" ini-name:"collapsed" env:"REVDIFF_COLLAPSED" description:"start in collapsed diff mode"`
 	Compact          bool     `long:"compact" ini-name:"compact" env:"REVDIFF_COMPACT" description:"start in compact diff mode (small context around changes)"`

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -27,6 +27,7 @@ func TestParseArgs_Defaults(t *testing.T) {
 	assert.False(t, opts.NoColors)
 	assert.False(t, opts.NoStatusBar)
 	assert.False(t, opts.NoConfirmDiscard)
+	assert.False(t, opts.NoMouse)
 	assert.False(t, opts.Wrap)
 	assert.False(t, opts.Collapsed)
 	assert.False(t, opts.Compact)
@@ -63,6 +64,31 @@ func TestParseArgs_NoConfirmDiscard(t *testing.T) {
 		opts, err := parseArgs([]string{"--config", cfgPath})
 		require.NoError(t, err)
 		assert.True(t, opts.NoConfirmDiscard)
+	})
+}
+
+func TestParseArgs_NoMouse(t *testing.T) {
+	t.Run("flag", func(t *testing.T) {
+		opts, err := parseArgs(append(noConfigArgs(t), "--no-mouse"))
+		require.NoError(t, err)
+		assert.True(t, opts.NoMouse)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("REVDIFF_NO_MOUSE", "true")
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.True(t, opts.NoMouse)
+	})
+
+	t.Run("config file", func(t *testing.T) {
+		cfgDir := t.TempDir()
+		cfgPath := filepath.Join(cfgDir, "config")
+		err := os.WriteFile(cfgPath, []byte("[Application Options]\nno-mouse = true\n"), 0o600)
+		require.NoError(t, err)
+		opts, err := parseArgs([]string{"--config", cfgPath})
+		require.NoError(t, err)
+		assert.True(t, opts.NoMouse)
 	})
 }
 
@@ -555,6 +581,7 @@ func TestDumpConfig(t *testing.T) {
 	assert.Contains(t, output, "[Application Options]")
 	assert.Contains(t, output, "chroma-style = catppuccin-macchiato")
 	assert.Contains(t, output, "cross-file-hunks = false")
+	assert.Contains(t, output, "no-mouse = false")
 	assert.Contains(t, output, "[color options]")
 	assert.Contains(t, output, "color-accent = #D5895F")
 	assert.NotContains(t, output, "\ncolors =", "should not have spurious colors= line")

--- a/app/main.go
+++ b/app/main.go
@@ -102,6 +102,9 @@ func run(opts options) error {
 	)
 
 	programOptions := []tea.ProgramOption{tea.WithAltScreen()}
+	if !opts.NoMouse {
+		programOptions = append(programOptions, tea.WithMouseCellMotion())
+	}
 	if opts.Stdin {
 		var tty *os.File
 		renderer, tty, err = prepareStdinMode(opts, os.Stdin)

--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -492,6 +492,28 @@ func (m Model) cursorVisualRange() (top, bottom int) {
 	return top, top + h - 1
 }
 
+// rowOnAnnotationSubLine reports whether relRow (0-based, relative to the first
+// visual row of the diff line at idx) targets the injected annotation sub-line
+// below that diff line. h is the total visual height of the diff line (wrap rows
+// plus any injected annotation rows). delete-only placeholders always return
+// false because renderCollapsedDiff skips annotation rendering for them, even
+// when the underlying removed line has an annotation.
+func (m Model) rowOnAnnotationSubLine(idx, relRow, h int, hunks []int, annSet map[string]bool) bool {
+	if m.isDeleteOnlyPlaceholder(idx, hunks) {
+		return false
+	}
+	dl := m.file.lines[idx]
+	if dl.ChangeType == diff.ChangeDivider {
+		return false
+	}
+	key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
+	if !annSet[key] {
+		return false
+	}
+	annRows := m.wrappedAnnotationLineCount(key)
+	return annRows > 0 && relRow >= h-annRows
+}
+
 // visualRowToDiffLine maps a visual row within the diff viewport content back
 // to a diff-line index. row is 0-based relative to the first visible content
 // row of the viewport (caller must add YOffset and subtract any header rows).
@@ -542,19 +564,7 @@ func (m Model) visualRowToDiffLine(row int) (idx int, onAnnotation bool) {
 			continue
 		}
 		if row < running+h {
-			annRows := 0
-			dl := m.file.lines[i]
-			if dl.ChangeType != diff.ChangeDivider {
-				key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
-				if annSet[key] {
-					annRows = m.wrappedAnnotationLineCount(key)
-				}
-			}
-			diffRows := h - annRows
-			if annRows > 0 && row >= running+diffRows {
-				return i, true
-			}
-			return i, false
+			return i, m.rowOnAnnotationSubLine(i, row-running, h, hunks, annSet)
 		}
 		running += h
 	}

--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -492,6 +492,81 @@ func (m Model) cursorVisualRange() (top, bottom int) {
 	return top, top + h - 1
 }
 
+// visualRowToDiffLine maps a visual row within the diff viewport content back
+// to a diff-line index. row is 0-based relative to the first visible content
+// row of the viewport (caller must add YOffset and subtract any header rows).
+// when the file has a file-level annotation, rows covered by that annotation
+// map to idx=-1. the onAnnotation return value mirrors the semantics of
+// m.annot.cursorOnAnnotation: true when the row falls on an injected
+// annotation sub-line rather than the diff line (or its wrap-continuation)
+// itself. this is the inverse of cursorVisualRange + cursorViewportYUsing.
+//
+// edge cases: empty m.file.lines returns (m.nav.diffCursor, false); row < 0
+// returns (-1, false) when a file-level annotation is present, else
+// (firstVisibleIdx, false); rows past the last line return the last valid
+// index.
+func (m Model) visualRowToDiffLine(row int) (idx int, onAnnotation bool) {
+	if len(m.file.lines) == 0 {
+		if m.hasFileAnnotation() && row >= 0 && row < m.wrappedAnnotationLineCount(annotKeyFile) {
+			return -1, false
+		}
+		return m.nav.diffCursor, false
+	}
+
+	var hunks []int
+	if m.modes.collapsed.enabled {
+		hunks = m.findHunks()
+	}
+	annSet := m.buildAnnotationSet()
+
+	running := 0
+	if m.hasFileAnnotation() {
+		fileRows := m.wrappedAnnotationLineCount(annotKeyFile)
+		if row < fileRows {
+			return -1, false
+		}
+		running = fileRows
+	} else if row < 0 {
+		// no file annotation, row above the top: pick the first visible line
+		for i := range m.file.lines {
+			if m.hunkLineHeight(i, hunks, annSet) > 0 {
+				return i, false
+			}
+		}
+		return 0, false
+	}
+
+	for i := range m.file.lines {
+		h := m.hunkLineHeight(i, hunks, annSet)
+		if h == 0 {
+			continue
+		}
+		if row < running+h {
+			annRows := 0
+			dl := m.file.lines[i]
+			if dl.ChangeType != diff.ChangeDivider {
+				key := m.annotationKey(m.diffLineNum(dl), string(dl.ChangeType))
+				if annSet[key] {
+					annRows = m.wrappedAnnotationLineCount(key)
+				}
+			}
+			diffRows := h - annRows
+			if annRows > 0 && row >= running+diffRows {
+				return i, true
+			}
+			return i, false
+		}
+		running += h
+	}
+	// row past the last visible line: return the last visible line index
+	for i := len(m.file.lines) - 1; i >= 0; i-- {
+		if m.hunkLineHeight(i, hunks, annSet) > 0 {
+			return i, false
+		}
+	}
+	return len(m.file.lines) - 1, false
+}
+
 // cursorVisualHeight returns the number of visual rows occupied by the cursor.
 // branches, in order of evaluation:
 //   - cursor on the file-level annotation line → file annotation's wrapped row count

--- a/app/ui/annotate_test.go
+++ b/app/ui/annotate_test.go
@@ -2390,3 +2390,397 @@ func TestModel_AnnotationPlaceholderMentionsEditor(t *testing.T) {
 	m2.startFileAnnotation()
 	assert.Contains(t, m2.annot.input.Placeholder, "Ctrl+E", "file-level placeholder must mention Ctrl+E")
 }
+
+func TestModel_VisualRowToDiffLine_EmptyFile(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.nav.diffCursor = 5
+
+	idx, onAnn := m.visualRowToDiffLine(0)
+	assert.Equal(t, 5, idx, "empty file returns current diffCursor")
+	assert.False(t, onAnn)
+
+	idx, onAnn = m.visualRowToDiffLine(10)
+	assert.Equal(t, 5, idx)
+	assert.False(t, onAnn)
+}
+
+func TestModel_VisualRowToDiffLine_EmptyFileWithFileAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: "file note"})
+
+	idx, onAnn := m.visualRowToDiffLine(0)
+	assert.Equal(t, -1, idx, "row 0 within empty-file file-annotation returns -1")
+	assert.False(t, onAnn)
+}
+
+func TestModel_VisualRowToDiffLine_SimpleLines(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.file.lines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeContext},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeAdd},
+	}
+
+	tests := []struct {
+		name    string
+		row     int
+		wantIdx int
+		wantAnn bool
+	}{
+		{name: "row 0 maps to line 0", row: 0, wantIdx: 0, wantAnn: false},
+		{name: "row 1 maps to line 1", row: 1, wantIdx: 1, wantAnn: false},
+		{name: "row 2 maps to line 2", row: 2, wantIdx: 2, wantAnn: false},
+		{name: "row beyond end clamps to last", row: 10, wantIdx: 2, wantAnn: false},
+		{name: "negative row falls back to first visible line", row: -1, wantIdx: 0, wantAnn: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, onAnn := m.visualRowToDiffLine(tt.row)
+			assert.Equal(t, tt.wantIdx, idx)
+			assert.Equal(t, tt.wantAnn, onAnn)
+		})
+	}
+}
+
+func TestModel_VisualRowToDiffLine_FileAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.file.lines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeContext},
+	}
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: "file note"})
+
+	idx, onAnn := m.visualRowToDiffLine(0)
+	assert.Equal(t, -1, idx, "row 0 maps to file annotation line")
+	assert.False(t, onAnn)
+
+	idx, onAnn = m.visualRowToDiffLine(1)
+	assert.Equal(t, 0, idx, "row 1 maps to first diff line")
+	assert.False(t, onAnn)
+
+	idx, onAnn = m.visualRowToDiffLine(2)
+	assert.Equal(t, 1, idx, "row 2 maps to second diff line")
+	assert.False(t, onAnn)
+}
+
+func TestModel_VisualRowToDiffLine_WrappedFileAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.layout.width = 60
+	m.layout.treeWidth = 20
+	m.file.lines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeContext},
+	}
+	longComment := strings.Repeat("word ", 20) // ~100 chars, wraps
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: longComment})
+
+	wrapCount := m.wrappedAnnotationLineCount(annotKeyFile)
+	require.Greater(t, wrapCount, 1, "test precondition: file annotation must wrap")
+
+	// every row within the wrapped file annotation maps to idx=-1
+	for r := range wrapCount {
+		idx, onAnn := m.visualRowToDiffLine(r)
+		assert.Equal(t, -1, idx, "row %d inside wrapped file annotation", r)
+		assert.False(t, onAnn, "file annotation does not distinguish sub-rows")
+	}
+	// row right after the wrapped annotation is the first diff line
+	idx, onAnn := m.visualRowToDiffLine(wrapCount)
+	assert.Equal(t, 0, idx)
+	assert.False(t, onAnn)
+	idx, onAnn = m.visualRowToDiffLine(wrapCount + 1)
+	assert.Equal(t, 1, idx)
+	assert.False(t, onAnn)
+}
+
+func TestModel_VisualRowToDiffLine_LineAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.file.lines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeContext},
+	}
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, Type: "+", Comment: "inline note"})
+
+	// line 0 occupies row 0, line 1 occupies rows 1 (diff) + 2 (annotation),
+	// line 2 starts at row 3
+	idx, onAnn := m.visualRowToDiffLine(0)
+	assert.Equal(t, 0, idx)
+	assert.False(t, onAnn)
+
+	idx, onAnn = m.visualRowToDiffLine(1)
+	assert.Equal(t, 1, idx, "row 1 on diff row of annotated line")
+	assert.False(t, onAnn)
+
+	idx, onAnn = m.visualRowToDiffLine(2)
+	assert.Equal(t, 1, idx, "row 2 on annotation sub-row of line 1")
+	assert.True(t, onAnn)
+
+	idx, onAnn = m.visualRowToDiffLine(3)
+	assert.Equal(t, 2, idx, "row 3 on the following diff line")
+	assert.False(t, onAnn)
+}
+
+func TestModel_VisualRowToDiffLine_WrappedLineAnnotation(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.layout.width = 60
+	m.layout.treeWidth = 20
+	m.file.lines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+	}
+	longComment := strings.Repeat("note ", 20)
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, Type: "+", Comment: longComment})
+
+	key := m.annotationKey(2, "+")
+	annCount := m.wrappedAnnotationLineCount(key)
+	require.Greater(t, annCount, 1, "test precondition: annotation must wrap")
+
+	// line 0 at row 0, line 1 starts at row 1 (1 diff row + annCount annotation rows)
+	idx, onAnn := m.visualRowToDiffLine(0)
+	assert.Equal(t, 0, idx)
+	assert.False(t, onAnn)
+
+	idx, onAnn = m.visualRowToDiffLine(1)
+	assert.Equal(t, 1, idx, "row 1 is the diff row of annotated line 1")
+	assert.False(t, onAnn)
+
+	// each subsequent row within annotation maps to line 1 with onAnn=true
+	for r := 2; r < 1+1+annCount; r++ {
+		idx, onAnn = m.visualRowToDiffLine(r)
+		assert.Equal(t, 1, idx, "row %d inside wrapped annotation", r)
+		assert.True(t, onAnn, "row %d must be flagged as annotation sub-row", r)
+	}
+}
+
+func TestModel_VisualRowToDiffLine_Dividers(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.file.lines = []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{Content: "...", ChangeType: diff.ChangeDivider},
+		{NewNum: 10, Content: "line10", ChangeType: diff.ChangeContext},
+	}
+
+	// dividers occupy 1 row each (they are not hidden unless in collapsed mode)
+	idx, _ := m.visualRowToDiffLine(0)
+	assert.Equal(t, 0, idx)
+	idx, _ = m.visualRowToDiffLine(1)
+	assert.Equal(t, 1, idx, "divider row maps to its line index")
+	idx, _ = m.visualRowToDiffLine(2)
+	assert.Equal(t, 2, idx)
+}
+
+func TestModel_VisualRowToDiffLine_CollapsedHidden(t *testing.T) {
+	t.Run("mixed hunk hides all removes", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.file.name = "a.go"
+		// a hunk with context, then remove+add+context — not a delete-only hunk,
+		// so collapsed mode hides every remove line entirely (no placeholder).
+		m.file.lines = []diff.DiffLine{
+			{OldNum: 1, NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},
+			{OldNum: 2, Content: "removed1", ChangeType: diff.ChangeRemove},
+			{OldNum: 3, Content: "removed2", ChangeType: diff.ChangeRemove},
+			{NewNum: 2, Content: "added1", ChangeType: diff.ChangeAdd},
+			{OldNum: 4, NewNum: 3, Content: "ctx2", ChangeType: diff.ChangeContext},
+		}
+		m.modes.collapsed.enabled = true
+		m.modes.collapsed.expandedHunks = map[int]bool{}
+
+		// visible rows: 0->ctx(0), 1->added1(3), 2->ctx2(4)
+		idx, onAnn := m.visualRowToDiffLine(0)
+		assert.Equal(t, 0, idx)
+		assert.False(t, onAnn)
+
+		idx, onAnn = m.visualRowToDiffLine(1)
+		assert.Equal(t, 3, idx, "row 1 skips hidden removed lines and lands on added1")
+		assert.False(t, onAnn)
+
+		idx, onAnn = m.visualRowToDiffLine(2)
+		assert.Equal(t, 4, idx, "row 2 must land on the trailing context line")
+		assert.False(t, onAnn)
+	})
+
+	t.Run("delete-only hunk keeps placeholder visible", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.file.name = "a.go"
+		// delete-only hunk: placeholder at hunkStart stays visible, subsequent
+		// removes hidden
+		m.file.lines = []diff.DiffLine{
+			{OldNum: 1, NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},
+			{OldNum: 2, Content: "removed1", ChangeType: diff.ChangeRemove},
+			{OldNum: 3, Content: "removed2", ChangeType: diff.ChangeRemove},
+			{OldNum: 4, NewNum: 2, Content: "ctx2", ChangeType: diff.ChangeContext},
+		}
+		m.modes.collapsed.enabled = true
+		m.modes.collapsed.expandedHunks = map[int]bool{}
+
+		// visible rows: 0->ctx, 1->placeholder(idx 1), 2->ctx2
+		idx, onAnn := m.visualRowToDiffLine(1)
+		assert.Equal(t, 1, idx, "delete-only hunk placeholder maps to hunkStart")
+		assert.False(t, onAnn)
+	})
+}
+
+func TestModel_VisualRowToDiffLine_LargeRow(t *testing.T) {
+	m := testModel(nil, nil)
+	m.file.name = "a.go"
+	m.file.lines = []diff.DiffLine{
+		{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "b", ChangeType: diff.ChangeContext},
+	}
+	// simulates a scrolled viewport: caller passes (y + YOffset) — arbitrary big row
+	idx, onAnn := m.visualRowToDiffLine(9999)
+	assert.Equal(t, 1, idx, "rows past end clamp to last line")
+	assert.False(t, onAnn)
+}
+
+func TestModel_VisualRowToDiffLine_RoundTrip(t *testing.T) {
+	// for every reachable cursor position, cursorVisualRange top must round-trip
+	// back through visualRowToDiffLine to the same index. this is the core
+	// invariant — inverse mapping bugs would surface here.
+	t.Run("plain diff", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.file.name = "a.go"
+		m.file.lines = []diff.DiffLine{
+			{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+			{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+			{Content: "...", ChangeType: diff.ChangeDivider},
+			{NewNum: 10, Content: "line10", ChangeType: diff.ChangeContext},
+		}
+
+		for i := range m.file.lines {
+			m.nav.diffCursor = i
+			m.annot.cursorOnAnnotation = false
+			top, _ := m.cursorVisualRange()
+			idx, onAnn := m.visualRowToDiffLine(top)
+			assert.Equal(t, i, idx, "round-trip diff index for cursor %d", i)
+			assert.False(t, onAnn, "diff row (not annotation) for cursor %d", i)
+		}
+	})
+
+	t.Run("with file annotation", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.file.name = "a.go"
+		m.file.lines = []diff.DiffLine{
+			{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+			{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+		}
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: "file"})
+
+		// file-annotation cursor (-1)
+		m.nav.diffCursor = -1
+		m.annot.cursorOnAnnotation = false
+		top, _ := m.cursorVisualRange()
+		idx, onAnn := m.visualRowToDiffLine(top)
+		assert.Equal(t, -1, idx, "file annotation cursor round-trips to -1")
+		assert.False(t, onAnn)
+
+		// regular cursor positions still round-trip after the file annotation offset
+		for i := range m.file.lines {
+			m.nav.diffCursor = i
+			m.annot.cursorOnAnnotation = false
+			rowTop, _ := m.cursorVisualRange()
+			gotIdx, gotAnn := m.visualRowToDiffLine(rowTop)
+			assert.Equal(t, i, gotIdx, "round-trip with file annotation, cursor %d", i)
+			assert.False(t, gotAnn)
+		}
+	})
+
+	t.Run("with inline annotation and cursor on annotation sub-row", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.file.name = "a.go"
+		m.file.lines = []diff.DiffLine{
+			{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+			{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+			{NewNum: 3, Content: "line3", ChangeType: diff.ChangeContext},
+		}
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, Type: "+", Comment: "inline"})
+
+		// cursor on the diff row of annotated line
+		m.nav.diffCursor = 1
+		m.annot.cursorOnAnnotation = false
+		top, _ := m.cursorVisualRange()
+		idx, onAnn := m.visualRowToDiffLine(top)
+		assert.Equal(t, 1, idx)
+		assert.False(t, onAnn)
+
+		// cursor on the annotation sub-row — top now points to the annotation row
+		m.nav.diffCursor = 1
+		m.annot.cursorOnAnnotation = true
+		top, _ = m.cursorVisualRange()
+		idx, onAnn = m.visualRowToDiffLine(top)
+		assert.Equal(t, 1, idx, "annotation sub-row round-trips to same diff-line index")
+		assert.True(t, onAnn, "annotation sub-row round-trips with onAnnotation=true")
+	})
+
+	t.Run("with wrapped file and line annotations", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.file.name = "a.go"
+		m.layout.width = 60
+		m.layout.treeWidth = 20
+		m.file.lines = []diff.DiffLine{
+			{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+			{NewNum: 2, Content: "line2", ChangeType: diff.ChangeAdd},
+			{NewNum: 3, Content: "line3", ChangeType: diff.ChangeContext},
+		}
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "", Comment: strings.Repeat("word ", 20)})
+		m.store.Add(annotation.Annotation{File: "a.go", Line: 2, Type: "+", Comment: strings.Repeat("note ", 20)})
+
+		// file-annotation cursor
+		m.nav.diffCursor = -1
+		m.annot.cursorOnAnnotation = false
+		top, _ := m.cursorVisualRange()
+		idx, onAnn := m.visualRowToDiffLine(top)
+		assert.Equal(t, -1, idx)
+		assert.False(t, onAnn)
+
+		for i := range m.file.lines {
+			m.nav.diffCursor = i
+			m.annot.cursorOnAnnotation = false
+			rowTop, _ := m.cursorVisualRange()
+			gotIdx, gotAnn := m.visualRowToDiffLine(rowTop)
+			assert.Equal(t, i, gotIdx, "wrapped diff round-trip cursor %d", i)
+			assert.False(t, gotAnn, "cursor %d should not be on annotation sub-row", i)
+		}
+
+		// cursor on annotation sub-row of the annotated line
+		m.nav.diffCursor = 1
+		m.annot.cursorOnAnnotation = true
+		top, _ = m.cursorVisualRange()
+		idx, onAnn = m.visualRowToDiffLine(top)
+		assert.Equal(t, 1, idx)
+		assert.True(t, onAnn)
+	})
+
+	t.Run("in collapsed mode", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.file.name = "a.go"
+		m.file.lines = []diff.DiffLine{
+			{OldNum: 1, NewNum: 1, Content: "ctx", ChangeType: diff.ChangeContext},
+			{OldNum: 2, Content: "rem1", ChangeType: diff.ChangeRemove},
+			{OldNum: 3, Content: "rem2", ChangeType: diff.ChangeRemove},
+			{NewNum: 2, Content: "add1", ChangeType: diff.ChangeAdd},
+			{OldNum: 4, NewNum: 3, Content: "ctx2", ChangeType: diff.ChangeContext},
+		}
+		m.modes.collapsed.enabled = true
+		m.modes.collapsed.expandedHunks = map[int]bool{}
+
+		// visible indices are 0 (ctx), 3 (add), 4 (ctx2). indices 1 and 2 are
+		// hidden removes (mixed hunk, not delete-only) and can't be cursor targets.
+		for _, i := range []int{0, 3, 4} {
+			m.nav.diffCursor = i
+			m.annot.cursorOnAnnotation = false
+			top, _ := m.cursorVisualRange()
+			idx, onAnn := m.visualRowToDiffLine(top)
+			assert.Equal(t, i, idx, "collapsed-mode round-trip for visible cursor %d", i)
+			assert.False(t, onAnn)
+		}
+	})
+}

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -172,6 +172,10 @@ type FileTreeComponent interface {
 	StepFile(dir sidepane.Direction)
 	// SelectByPath sets the cursor to the file entry matching the given path.
 	SelectByPath(path string) bool
+	// SelectByVisibleRow sets the cursor to the entry at the given visible row
+	// (0-based, relative to the first visible tree line). Returns true when the
+	// row maps to a valid entry; the cursor is unchanged when false.
+	SelectByVisibleRow(row int) bool
 	// EnsureVisible adjusts offset so the cursor is within the visible range.
 	EnsureVisible(height int)
 	// Rebuild rebuilds the file tree from new entries in-place.
@@ -195,6 +199,10 @@ type TOCComponent interface {
 	NumEntries() int
 	// Move navigates the cursor according to the given motion.
 	Move(m sidepane.Motion, count ...int)
+	// SelectByVisibleRow sets the cursor to the entry at the given visible row
+	// (0-based, relative to the first visible TOC line). Returns true when the
+	// row maps to a valid entry; the cursor is unchanged when false.
+	SelectByVisibleRow(row int) bool
 	// EnsureVisible adjusts offset so the cursor is within the visible range.
 	EnsureVisible(height int)
 	// UpdateActiveSection sets the active section based on the diff cursor position.
@@ -666,6 +674,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleConfirmDiscardKey(msg)
 		}
 		return m.handleKey(msg)
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
 	case tea.WindowSizeMsg:
 		return m.handleResize(msg)
 	case filesLoadedMsg:

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -59,6 +59,13 @@ func (m Model) hitTest(x, y int) hitZone {
 	if sbh := m.statusBarHeight(); sbh > 0 && y >= m.layout.height-sbh {
 		return hitStatus
 	}
+	// pane bottom border row sits just above the status bar (or the last
+	// row when the status bar is hidden). clicks on the border must not
+	// map into the viewport — without this guard, clickDiff would compute
+	// a row one past the visible content.
+	if y == m.layout.height-m.statusBarHeight()-1 {
+		return hitNone
+	}
 
 	// tree block spans columns [0, treeWidth+1] when visible: left border +
 	// treeWidth content columns + right border = treeWidth+2 columns total.
@@ -83,21 +90,25 @@ func (m Model) hitTest(x, y int) hitZone {
 // position, not by current focus — this matches terminal conventions where
 // scrolling follows the cursor.
 func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	// transient hints persist for exactly one render cycle; any mouse event
-	// that reaches this point dismisses the last hint, mirroring handleKey.
-	m.commits.hint = ""
-	m.reload.hint = ""
-	m.compact.hint = ""
-
 	// swallow during modal states — input belongs to the modal, not the
 	// viewport beneath. overlay must also swallow so wheel does not scroll
-	// through a popup.
+	// through a popup. hints are preserved here so the modal prompt (e.g.
+	// reload's "press y to confirm") stays visible while the event is
+	// discarded. in the keyboard path the prompt is also replaced by a new
+	// hint from handlePendingReload, but mouse events don't transition the
+	// modal, so dropping the hint would leave an invisible modal.
 	if m.inConfirmDiscard || m.reload.pending || m.annot.annotating || m.search.active {
 		return m, nil
 	}
 	if m.overlay.Active() {
 		return m, nil
 	}
+
+	// transient hints persist for exactly one render cycle; any mouse event
+	// that reaches this point dismisses the last hint, mirroring handleKey.
+	m.commits.hint = ""
+	m.reload.hint = ""
+	m.compact.hint = ""
 
 	zone := m.hitTest(msg.X, msg.Y)
 

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -146,9 +146,10 @@ func (m Model) wheelStepFor(shift bool) int {
 func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 	switch zone {
 	case hitDiff:
-		if delta > 0 {
+		switch {
+		case delta > 0:
 			m.moveDiffCursorDownBy(delta)
-		} else if delta < 0 {
+		case delta < 0:
 			m.moveDiffCursorUpBy(-delta)
 		}
 	case hitTree:
@@ -156,21 +157,17 @@ func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 		if step < 0 {
 			step = -step
 		}
+		motion := sidepane.MotionPageDown
+		if delta < 0 {
+			motion = sidepane.MotionPageUp
+		}
 		if m.file.mdTOC != nil {
-			if delta > 0 {
-				m.file.mdTOC.Move(sidepane.MotionPageDown, step)
-			} else {
-				m.file.mdTOC.Move(sidepane.MotionPageUp, step)
-			}
+			m.file.mdTOC.Move(motion, step)
 			m.file.mdTOC.EnsureVisible(m.treePageSize())
 			m.syncDiffToTOCCursor()
 			return m, nil
 		}
-		if delta > 0 {
-			m.tree.Move(sidepane.MotionPageDown, step)
-		} else {
-			m.tree.Move(sidepane.MotionPageUp, step)
-		}
+		m.tree.Move(motion, step)
 		m.pendingAnnotJump = nil
 		m.nav.pendingHunkJump = nil
 		return m.loadSelectedIfChanged()
@@ -211,6 +208,9 @@ func (m Model) clickTree(_, y int) (tea.Model, tea.Cmd) {
 // sub-row, cursorOnAnnotation is set so subsequent navigation treats the
 // cursor as being on the annotation rather than the diff line above it.
 func (m Model) clickDiff(_, y int) (tea.Model, tea.Cmd) {
+	if m.file.name == "" {
+		return m, nil // no file loaded — nothing to focus or point at
+	}
 	row := (y - m.diffTopRow()) + m.layout.viewport.YOffset
 	idx, onAnnot := m.visualRowToDiffLine(row)
 	m.layout.focus = paneDiff

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -1,0 +1,66 @@
+package ui
+
+// hitZone identifies which interactive area a mouse event targets.
+type hitZone int
+
+const (
+	hitNone   hitZone = iota // outside any interactive area (borders, gaps, out-of-bounds)
+	hitTree                  // tree pane (or TOC pane when mdTOC is active)
+	hitDiff                  // diff pane body (below the diff header)
+	hitStatus                // status bar row(s)
+	hitHeader                // diff header row (file path) — currently a no-op zone
+)
+
+// statusBarHeight returns the number of rows occupied by the status bar.
+// 0 when the status bar is hidden, otherwise 1.
+func (m Model) statusBarHeight() int {
+	if m.cfg.noStatusBar {
+		return 0
+	}
+	return 1
+}
+
+// diffTopRow returns the first screen row (0-based y) of diff viewport content.
+// accounts for the pane top border (row 0) and the diff header row (row 1),
+// so the viewport always starts at row 2 regardless of whether the tree pane
+// is visible.
+func (m Model) diffTopRow() int {
+	return 2
+}
+
+// treeTopRow returns the first screen row (0-based y) of tree pane content.
+// accounts for the pane top border only — unlike diff, the tree pane has no
+// internal header row, so content starts at row 1.
+func (m Model) treeTopRow() int {
+	return 1
+}
+
+// hitTest classifies a screen coordinate into a hitZone for mouse-event routing.
+// the classification is pure arithmetic over m.layout state and does not
+// inspect any dynamic UI content. ordering matters: status bar is checked
+// first (y at bottom), then x is used to split tree vs diff columns, and
+// finally y is used within each column to reject the diff header row or tree
+// top border.
+func (m Model) hitTest(x, y int) hitZone {
+	if x < 0 || y < 0 || x >= m.layout.width || y >= m.layout.height {
+		return hitNone
+	}
+	if sbh := m.statusBarHeight(); sbh > 0 && y >= m.layout.height-sbh {
+		return hitStatus
+	}
+
+	// tree block spans columns [0, treeWidth+1] when visible: left border +
+	// treeWidth content columns + right border = treeWidth+2 columns total.
+	// diff block picks up at column treeWidth+2.
+	if !m.treePaneHidden() && x < m.layout.treeWidth+2 {
+		if y < m.treeTopRow() {
+			return hitNone
+		}
+		return hitTree
+	}
+
+	if y < m.diffTopRow() {
+		return hitHeader
+	}
+	return hitDiff
+}

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -116,9 +116,9 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		switch zone {
 		case hitTree:
-			return m.clickTree(msg.X, msg.Y)
+			return m.clickTree(msg.Y)
 		case hitDiff:
-			return m.clickDiff(msg.X, msg.Y)
+			return m.clickDiff(msg.Y)
 		case hitNone, hitStatus, hitHeader:
 			return m, nil
 		}
@@ -153,13 +153,11 @@ func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 			m.moveDiffCursorUpBy(-delta)
 		}
 	case hitTree:
-		step := delta
-		if step < 0 {
-			step = -step
-		}
 		motion := sidepane.MotionPageDown
+		step := delta
 		if delta < 0 {
 			motion = sidepane.MotionPageUp
+			step = -delta
 		}
 		if m.file.mdTOC != nil {
 			m.file.mdTOC.Move(motion, step)
@@ -183,7 +181,7 @@ func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 // load is triggered via loadSelectedIfChanged; on a directory row or an
 // out-of-range row the click just moves the cursor with no load (mirrors
 // j-landing semantics).
-func (m Model) clickTree(_, y int) (tea.Model, tea.Cmd) {
+func (m Model) clickTree(y int) (tea.Model, tea.Cmd) {
 	row := y - m.treeTopRow()
 	m.layout.focus = paneTree
 	if m.file.mdTOC != nil {
@@ -207,7 +205,7 @@ func (m Model) clickTree(_, y int) (tea.Model, tea.Cmd) {
 // under the pointer. when the click lands on an injected annotation
 // sub-row, cursorOnAnnotation is set so subsequent navigation treats the
 // cursor as being on the annotation rather than the diff line above it.
-func (m Model) clickDiff(_, y int) (tea.Model, tea.Cmd) {
+func (m Model) clickDiff(y int) (tea.Model, tea.Cmd) {
 	if m.file.name == "" {
 		return m, nil // no file loaded — nothing to focus or point at
 	}

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -77,6 +77,9 @@ func (m Model) hitTest(x, y int) hitZone {
 		return hitTree
 	}
 
+	if y == 0 {
+		return hitNone // diff pane top border — mirror of treeTopRow() guard above
+	}
 	if y < m.diffTopRow() {
 		return hitHeader
 	}
@@ -114,9 +117,15 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.Button {
 	case tea.MouseButtonWheelUp:
-		return m.handleWheel(zone, -m.wheelStepFor(msg.Shift))
+		if msg.Action != tea.MouseActionPress {
+			return m, nil // guard against non-press wheel emissions for symmetry with left-click
+		}
+		return m.handleWheel(zone, -m.wheelStepFor(zone, msg.Shift))
 	case tea.MouseButtonWheelDown:
-		return m.handleWheel(zone, m.wheelStepFor(msg.Shift))
+		if msg.Action != tea.MouseActionPress {
+			return m, nil
+		}
+		return m.handleWheel(zone, m.wheelStepFor(zone, msg.Shift))
 	case tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight:
 		// horizontal wheel is intentionally swallowed — horizontal scroll
 		// stays keyboard-driven so users keep a single mental model.
@@ -140,14 +149,18 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
-// wheelStepFor returns the wheel scroll step. Shift+wheel scrolls by half
-// the diff viewport (mirroring the half-page-down keyboard shortcut);
-// a plain wheel notch scrolls by the wheelStep constant.
-func (m Model) wheelStepFor(shift bool) int {
-	if shift {
-		return max(1, m.layout.viewport.Height/2)
+// wheelStepFor returns the wheel scroll step. Plain wheel scrolls by the
+// wheelStep constant in every zone. Shift+wheel scrolls by half the pane
+// under the pointer — viewport half for the diff, treePageSize half for
+// the tree/TOC — to match the keyboard half-page shortcuts for that pane.
+func (m Model) wheelStepFor(zone hitZone, shift bool) int {
+	if !shift {
+		return wheelStep
 	}
-	return wheelStep
+	if zone == hitTree {
+		return max(1, m.treePageSize()/2)
+	}
+	return max(1, m.layout.viewport.Height/2)
 }
 
 // handleWheel routes a vertical wheel event to the pane under the pointer.

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -163,6 +163,7 @@ func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 		case delta < 0:
 			m.moveDiffCursorUpBy(-delta)
 		}
+		m.syncTOCActiveSection()
 	case hitTree:
 		motion := sidepane.MotionPageDown
 		step := delta
@@ -226,5 +227,6 @@ func (m Model) clickDiff(y int) (tea.Model, tea.Cmd) {
 	m.nav.diffCursor = idx
 	m.annot.cursorOnAnnotation = onAnnot
 	m.syncViewportToCursor()
+	m.syncTOCActiveSection()
 	return m, nil
 }

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -1,5 +1,16 @@
 package ui
 
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/umputun/revdiff/app/ui/sidepane"
+)
+
+// wheelStep is the number of lines one wheel notch scrolls by. matches the
+// typical terminal feel (3 lines per notch). Shift+wheel uses half the
+// viewport height instead.
+const wheelStep = 3
+
 // hitZone identifies which interactive area a mouse event targets.
 type hitZone int
 
@@ -63,4 +74,148 @@ func (m Model) hitTest(x, y int) hitZone {
 		return hitHeader
 	}
 	return hitDiff
+}
+
+// handleMouse routes a tea.MouseMsg through the modal-state checks and into
+// per-button dispatch. mouse events are only generated when
+// tea.WithMouseCellMotion is enabled (i.e. --no-mouse is off), so this
+// handler never runs in the opted-out path. wheel routing is by pointer
+// position, not by current focus — this matches terminal conventions where
+// scrolling follows the cursor.
+func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// transient hints persist for exactly one render cycle; any mouse event
+	// that reaches this point dismisses the last hint, mirroring handleKey.
+	m.commits.hint = ""
+	m.reload.hint = ""
+	m.compact.hint = ""
+
+	// swallow during modal states — input belongs to the modal, not the
+	// viewport beneath. overlay must also swallow so wheel does not scroll
+	// through a popup.
+	if m.inConfirmDiscard || m.reload.pending || m.annot.annotating || m.search.active {
+		return m, nil
+	}
+	if m.overlay.Active() {
+		return m, nil
+	}
+
+	zone := m.hitTest(msg.X, msg.Y)
+
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		return m.handleWheel(zone, -m.wheelStepFor(msg.Shift))
+	case tea.MouseButtonWheelDown:
+		return m.handleWheel(zone, m.wheelStepFor(msg.Shift))
+	case tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight:
+		// horizontal wheel is intentionally swallowed — horizontal scroll
+		// stays keyboard-driven so users keep a single mental model.
+		return m, nil
+	case tea.MouseButtonLeft:
+		if msg.Action != tea.MouseActionPress {
+			return m, nil // ignore release and motion while holding
+		}
+		switch zone {
+		case hitTree:
+			return m.clickTree(msg.X, msg.Y)
+		case hitDiff:
+			return m.clickDiff(msg.X, msg.Y)
+		case hitNone, hitStatus, hitHeader:
+			return m, nil
+		}
+		return m, nil
+	default:
+		// right, middle, back, forward, none — no-op for this pass.
+		return m, nil
+	}
+}
+
+// wheelStepFor returns the wheel scroll step. Shift+wheel scrolls by half
+// the diff viewport (mirroring the half-page-down keyboard shortcut);
+// a plain wheel notch scrolls by the wheelStep constant.
+func (m Model) wheelStepFor(shift bool) int {
+	if shift {
+		return max(1, m.layout.viewport.Height/2)
+	}
+	return wheelStep
+}
+
+// handleWheel routes a vertical wheel event to the pane under the pointer.
+// delta is positive for wheel-down, negative for wheel-up. the pane is
+// selected by the hit zone, not the current pane focus: users expect the
+// wheel to act on whichever pane the pointer is over.
+func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
+	switch zone {
+	case hitDiff:
+		if delta > 0 {
+			m.moveDiffCursorDownBy(delta)
+		} else if delta < 0 {
+			m.moveDiffCursorUpBy(-delta)
+		}
+	case hitTree:
+		step := delta
+		if step < 0 {
+			step = -step
+		}
+		if m.file.mdTOC != nil {
+			if delta > 0 {
+				m.file.mdTOC.Move(sidepane.MotionPageDown, step)
+			} else {
+				m.file.mdTOC.Move(sidepane.MotionPageUp, step)
+			}
+			m.file.mdTOC.EnsureVisible(m.treePageSize())
+			m.syncDiffToTOCCursor()
+			return m, nil
+		}
+		if delta > 0 {
+			m.tree.Move(sidepane.MotionPageDown, step)
+		} else {
+			m.tree.Move(sidepane.MotionPageUp, step)
+		}
+		m.pendingAnnotJump = nil
+		m.nav.pendingHunkJump = nil
+		return m.loadSelectedIfChanged()
+	case hitNone, hitStatus, hitHeader:
+		// no-op zones — wheel outside the interactive panes is ignored.
+	}
+	return m, nil
+}
+
+// clickTree handles a left-click press in the tree (or TOC) pane. the click
+// both focuses the pane and selects the entry under the pointer — same as
+// pressing j/k to land on the entry. when the entry is a file, the diff
+// load is triggered via loadSelectedIfChanged; on a directory row or an
+// out-of-range row the click just moves the cursor with no load (mirrors
+// j-landing semantics).
+func (m Model) clickTree(_, y int) (tea.Model, tea.Cmd) {
+	row := y - m.treeTopRow()
+	m.layout.focus = paneTree
+	if m.file.mdTOC != nil {
+		if !m.file.mdTOC.SelectByVisibleRow(row) {
+			return m, nil
+		}
+		m.file.mdTOC.EnsureVisible(m.treePageSize())
+		m.syncDiffToTOCCursor()
+		return m, nil
+	}
+	if !m.tree.SelectByVisibleRow(row) {
+		return m, nil
+	}
+	m.pendingAnnotJump = nil
+	m.nav.pendingHunkJump = nil
+	return m.loadSelectedIfChanged()
+}
+
+// clickDiff handles a left-click press in the diff viewport. the click
+// focuses the diff pane and moves the diff cursor to the logical line
+// under the pointer. when the click lands on an injected annotation
+// sub-row, cursorOnAnnotation is set so subsequent navigation treats the
+// cursor as being on the annotation rather than the diff line above it.
+func (m Model) clickDiff(_, y int) (tea.Model, tea.Cmd) {
+	row := (y - m.diffTopRow()) + m.layout.viewport.YOffset
+	idx, onAnnot := m.visualRowToDiffLine(row)
+	m.layout.focus = paneDiff
+	m.nav.diffCursor = idx
+	m.annot.cursorOnAnnotation = onAnnot
+	m.syncViewportToCursor()
+	return m, nil
 }

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -86,7 +86,7 @@ func TestModel_hitTest(t *testing.T) {
 		{name: "tree pane first content row", setup: func(m *Model) {}, x: 5, y: 1, want: hitTree},
 		{name: "diff pane viewport row", setup: func(m *Model) {}, x: 60, y: 10, want: hitDiff},
 		{name: "diff pane header row", setup: func(m *Model) {}, x: 60, y: 1, want: hitHeader},
-		{name: "diff pane top border", setup: func(m *Model) {}, x: 60, y: 0, want: hitHeader},
+		{name: "diff pane top border", setup: func(m *Model) {}, x: 60, y: 0, want: hitNone},
 		{name: "status bar", setup: func(m *Model) {}, x: 60, y: 39, want: hitStatus},
 		{name: "status bar at x=0", setup: func(m *Model) {}, x: 0, y: 39, want: hitStatus},
 		{name: "tree-diff boundary: last tree column", setup: func(m *Model) {}, x: 37, y: 10, want: hitTree},
@@ -253,6 +253,51 @@ func TestModel_HandleMouse_WheelInTreeMovesTreeCursor(t *testing.T) {
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 5, 3, false))
 	model := result.(Model)
 	assert.NotEqual(t, before, model.tree.SelectedFile(), "wheel in tree should change tree selection even when focus is diff")
+}
+
+func TestModel_HandleMouse_WheelNonPressActionIgnored(t *testing.T) {
+	// bubbletea viewport guards wheel on MouseActionPress to avoid double-firing
+	// if a terminal emits non-press wheel events (motion/release). handleMouse
+	// matches that pattern for symmetry with the left-click guard.
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "hello", ChangeType: diff.ChangeContext}},
+	})
+	m.nav.diffCursor = 0
+
+	for _, action := range []tea.MouseAction{tea.MouseActionRelease, tea.MouseActionMotion} {
+		for _, btn := range []tea.MouseButton{tea.MouseButtonWheelUp, tea.MouseButtonWheelDown} {
+			msg := tea.MouseMsg(tea.MouseEvent{X: 60, Y: 10, Button: btn, Action: action})
+			result, _ := m.Update(msg)
+			model := result.(Model)
+			assert.Equal(t, 0, model.nav.diffCursor, "wheel with Action=%v must be ignored", action)
+		}
+	}
+}
+
+func TestModel_HandleMouse_ShiftWheelInTreeUsesTreePageSize(t *testing.T) {
+	// shift+wheel over the tree must move by treePageSize()/2 entries,
+	// matching the keyboard half-page shortcut for that pane — not by
+	// viewport.Height/2 which is the diff-pane half-page step.
+	// force viewport.Height != treePageSize so the test fails under the old
+	// formula.
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "x", ChangeType: diff.ChangeContext}},
+	})
+	m.layout.viewport.Height = 4 // small diff viewport
+	// treePageSize derives from layout.height - 2 (- 1 if status bar present);
+	// with the default mouseTestModel height it is larger than 4.
+	assert.NotEqual(t, m.layout.viewport.Height/2, m.treePageSize()/2,
+		"test precondition: viewport and tree half-pages must differ")
+
+	// shift+wheel in tree zone (x < treeWidth+2, y >= treeTopRow)
+	got := m.wheelStepFor(hitTree, true)
+	assert.Equal(t, max(1, m.treePageSize()/2), got,
+		"shift+wheel in tree must step by treePageSize/2, not viewport.Height/2")
+
+	// sanity: shift+wheel in diff still uses viewport half-page
+	got = m.wheelStepFor(hitDiff, true)
+	assert.Equal(t, max(1, m.layout.viewport.Height/2), got,
+		"shift+wheel in diff must step by viewport.Height/2")
 }
 
 func TestModel_HandleMouse_HorizontalWheelNoop(t *testing.T) {

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -3,9 +3,15 @@ package ui
 import (
 	"testing"
 
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/umputun/revdiff/app/annotation"
 	"github.com/umputun/revdiff/app/diff"
+	"github.com/umputun/revdiff/app/ui/overlay"
 	"github.com/umputun/revdiff/app/ui/sidepane"
 )
 
@@ -151,4 +157,409 @@ func TestModel_hitTest(t *testing.T) {
 				"hitTest(%d, %d) with setup %q", tc.x, tc.y, tc.name)
 		})
 	}
+}
+
+// mouseTestModel builds a Model with known layout dimensions, a diff loaded
+// into the viewport, and a multi-file tree. suitable for exercising
+// handleMouse routing end-to-end. caller may tweak any grouped state after
+// the call, e.g. m.layout.focus, m.file.mdTOC.
+func mouseTestModel(t *testing.T, files []string, diffs map[string][]diff.DiffLine) Model {
+	t.Helper()
+	m := testModel(files, diffs)
+	m.tree = testNewFileTree(files)
+	m.layout.width = 120
+	m.layout.height = 40
+	m.layout.treeWidth = 36
+	m.layout.viewport = viewport.New(80, 30)
+	if len(files) > 0 {
+		m.file.name = files[0]
+		if d, ok := diffs[files[0]]; ok {
+			m.file.lines = d
+		}
+	}
+	return m
+}
+
+// wheelMsg builds a wheel-up or wheel-down MouseMsg at (x, y) with an
+// optional shift modifier.
+func wheelMsg(button tea.MouseButton, x, y int, shift bool) tea.MouseMsg {
+	return tea.MouseMsg(tea.MouseEvent{
+		X: x, Y: y, Shift: shift, Button: button, Action: tea.MouseActionPress,
+	})
+}
+
+// leftPressAt builds a left-click press MouseMsg at (x, y).
+func leftPressAt(x, y int) tea.MouseMsg {
+	return tea.MouseMsg(tea.MouseEvent{
+		X: x, Y: y, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+}
+
+func TestModel_HandleMouse_WheelInDiff(t *testing.T) {
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+
+	// pointer in diff pane (x=60 is past tree columns 0..37)
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.Equal(t, wheelStep, model.nav.diffCursor, "wheel-down should advance cursor by wheelStep")
+
+	// wheel-up returns cursor to top
+	result, _ = model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
+	model = result.(Model)
+	assert.Equal(t, 0, model.nav.diffCursor, "wheel-up should move cursor back up by wheelStep")
+}
+
+func TestModel_HandleMouse_ShiftWheelHalfPage(t *testing.T) {
+	lines := make([]diff.DiffLine, 100)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport = viewport.New(80, 20) // Height=20 so half-page = 10
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, true))
+	model := result.(Model)
+	assert.Equal(t, 10, model.nav.diffCursor, "shift+wheel should move cursor by viewport.Height/2")
+}
+
+func TestModel_HandleMouse_WheelInTreeMovesTreeCursor(t *testing.T) {
+	files := make([]string, 30)
+	diffs := make(map[string][]diff.DiffLine, 30)
+	for i := range files {
+		p := string(rune('a'+(i/10))) + string(rune('a'+(i%10))) + ".go"
+		files[i] = p
+		diffs[p] = []diff.DiffLine{{NewNum: 1, Content: p, ChangeType: diff.ChangeContext}}
+	}
+	m := mouseTestModel(t, files, diffs)
+	m.layout.focus = paneDiff // wheel routing is by hit zone, not focus
+	before := m.tree.SelectedFile()
+
+	// wheel-down inside tree columns (x=5, y=3 → hitTree)
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 5, 3, false))
+	model := result.(Model)
+	assert.NotEqual(t, before, model.tree.SelectedFile(), "wheel in tree should change tree selection even when focus is diff")
+}
+
+func TestModel_HandleMouse_HorizontalWheelNoop(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "hello", ChangeType: diff.ChangeContext}},
+	})
+	m.nav.diffCursor = 0
+
+	for _, btn := range []tea.MouseButton{tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight} {
+		result, cmd := m.Update(wheelMsg(btn, 60, 10, false))
+		model := result.(Model)
+		assert.Nil(t, cmd)
+		assert.Equal(t, 0, model.nav.diffCursor, "horizontal wheel must not move cursor")
+	}
+}
+
+func TestModel_HandleMouse_LeftClickInDiff(t *testing.T) {
+	lines := make([]diff.DiffLine, 40)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.focus = paneTree // click should flip focus to diff
+
+	// click on diff row at y=12, diffTopRow=2, YOffset=0 → row 10
+	result, _ := m.Update(leftPressAt(60, 12))
+	model := result.(Model)
+	assert.Equal(t, paneDiff, model.layout.focus, "click in diff must set focus to paneDiff")
+	assert.Equal(t, 10, model.nav.diffCursor, "click at y=12 with diffTopRow=2 must land on diff line 10")
+	assert.False(t, model.annot.cursorOnAnnotation, "plain diff click must not set cursorOnAnnotation")
+}
+
+func TestModel_HandleMouse_LeftClickSetsCursorOnAnnotation(t *testing.T) {
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeAdd},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeContext},
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	// store an annotation on line 1 so it renders an annotation sub-row
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 1, Type: "+", Comment: "note"})
+	m.layout.focus = paneTree
+
+	// diff line 0 has 1 diff row + 1 annotation row. diffTopRow=2, so y=3 → row 1 (annotation sub-row)
+	result, _ := m.Update(leftPressAt(60, 3))
+	model := result.(Model)
+	assert.Equal(t, paneDiff, model.layout.focus)
+	assert.Equal(t, 0, model.nav.diffCursor, "click on annotation sub-row should keep logical index pointing at the diff line")
+	assert.True(t, model.annot.cursorOnAnnotation, "click on annotation sub-row must set cursorOnAnnotation")
+}
+
+func TestModel_HandleMouse_LeftClickInTreeSelectsAndLoads(t *testing.T) {
+	files := []string{"a.go", "b.go", "c.go"}
+	diffs := map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+		"b.go": {{NewNum: 1, Content: "b", ChangeType: diff.ChangeContext}},
+		"c.go": {{NewNum: 1, Content: "c", ChangeType: diff.ChangeContext}},
+	}
+	m := mouseTestModel(t, files, diffs)
+	m.layout.focus = paneDiff
+
+	// treeTopRow=1; entries render at rows 1,2,3 → click y=3 hits entry at visible row 2 (c.go or b.go depending on layout)
+	result, cmd := m.Update(leftPressAt(5, 3))
+	model := result.(Model)
+	assert.Equal(t, paneTree, model.layout.focus, "click in tree must set focus to paneTree")
+	// whatever file gets selected must not be the same as the starting file and must trigger a load
+	assert.NotEqual(t, "a.go", model.tree.SelectedFile(), "tree click should move cursor off first file")
+	assert.NotNil(t, cmd, "tree click on a file entry should trigger file load")
+}
+
+func TestModel_HandleMouse_LeftClickOnStatusBarNoop(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.nav.diffCursor = 0
+	m.layout.focus = paneTree
+
+	result, cmd := m.Update(leftPressAt(60, 39)) // last row = status
+	model := result.(Model)
+	assert.Nil(t, cmd)
+	assert.Equal(t, paneTree, model.layout.focus, "status-bar click must not change focus")
+	assert.Equal(t, 0, model.nav.diffCursor)
+}
+
+func TestModel_HandleMouse_LeftClickOnHeaderNoop(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.nav.diffCursor = 0
+	m.layout.focus = paneTree
+
+	result, cmd := m.Update(leftPressAt(60, 1)) // diff header row
+	model := result.(Model)
+	assert.Nil(t, cmd)
+	assert.Equal(t, paneTree, model.layout.focus, "diff header click must not change focus")
+	assert.Equal(t, 0, model.nav.diffCursor)
+}
+
+func TestModel_HandleMouse_LeftClickOutOfBoundsNoop(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.nav.diffCursor = 0
+	m.layout.focus = paneTree
+
+	result, cmd := m.Update(leftPressAt(999, 999))
+	model := result.(Model)
+	assert.Nil(t, cmd)
+	assert.Equal(t, paneTree, model.layout.focus)
+	assert.Equal(t, 0, model.nav.diffCursor)
+}
+
+func TestModel_HandleMouse_NonLeftButtonsNoop(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.nav.diffCursor = 0
+	m.layout.focus = paneTree
+
+	buttons := []tea.MouseButton{
+		tea.MouseButtonRight,
+		tea.MouseButtonMiddle,
+		tea.MouseButtonBackward,
+		tea.MouseButtonForward,
+	}
+	for _, btn := range buttons {
+		msg := tea.MouseMsg(tea.MouseEvent{X: 60, Y: 10, Button: btn, Action: tea.MouseActionPress})
+		result, cmd := m.Update(msg)
+		model := result.(Model)
+		assert.Nil(t, cmd, "button %v must be no-op", btn)
+		assert.Equal(t, paneTree, model.layout.focus, "button %v must not change focus", btn)
+	}
+}
+
+func TestModel_HandleMouse_LeftReleaseAndMotionNoop(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.nav.diffCursor = 0
+	m.layout.focus = paneTree
+
+	for _, action := range []tea.MouseAction{tea.MouseActionRelease, tea.MouseActionMotion} {
+		msg := tea.MouseMsg(tea.MouseEvent{X: 60, Y: 12, Button: tea.MouseButtonLeft, Action: action})
+		result, cmd := m.Update(msg)
+		model := result.(Model)
+		assert.Nil(t, cmd, "action %v on left button must be no-op", action)
+		assert.Equal(t, paneTree, model.layout.focus, "action %v must not change focus", action)
+	}
+}
+
+func TestModel_HandleMouse_SwallowedWhileAnnotating(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.annot.annotating = true
+	m.annot.input = textinput.New()
+	m.annot.input.SetValue("draft")
+	m.nav.diffCursor = 0
+
+	// wheel must be swallowed: cursor unchanged, textinput value preserved
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.Equal(t, 0, model.nav.diffCursor, "wheel must not move cursor while annotating")
+	assert.True(t, model.annot.annotating, "annotating state must be preserved")
+
+	// click must be swallowed too
+	result, _ = m.Update(leftPressAt(60, 12))
+	model = result.(Model)
+	assert.Equal(t, 0, model.nav.diffCursor, "click must not move cursor while annotating")
+	assert.Equal(t, "draft", model.annot.input.Value(), "textinput value must be unchanged by mouse event")
+}
+
+func TestModel_HandleMouse_SwallowedWhileSearching(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.search.active = true
+	m.search.input = textinput.New()
+	m.nav.diffCursor = 0
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.Equal(t, 0, model.nav.diffCursor, "wheel must not move cursor while search is active")
+	assert.True(t, model.search.active)
+}
+
+func TestModel_HandleMouse_SwallowedWhileReloadPending(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.reload.pending = true
+	m.nav.diffCursor = 0
+	m.layout.focus = paneTree
+
+	result, _ := m.Update(leftPressAt(60, 12))
+	model := result.(Model)
+	assert.Equal(t, 0, model.nav.diffCursor, "click must be swallowed while reload confirmation is pending")
+	assert.Equal(t, paneTree, model.layout.focus)
+	assert.True(t, model.reload.pending)
+}
+
+func TestModel_HandleMouse_SwallowedWhileConfirmDiscard(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.inConfirmDiscard = true
+	m.nav.diffCursor = 0
+
+	result, _ := m.Update(leftPressAt(60, 12))
+	model := result.(Model)
+	assert.Equal(t, 0, model.nav.diffCursor)
+	assert.True(t, model.inConfirmDiscard)
+}
+
+func TestModel_HandleMouse_SwallowedWhileOverlayOpen(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	mgr, ok := m.overlay.(*overlay.Manager)
+	require.True(t, ok, "test expects the real overlay.Manager")
+	mgr.OpenHelp(overlay.HelpSpec{})
+	require.True(t, m.overlay.Active())
+	m.nav.diffCursor = 0
+
+	// wheel must not close the overlay nor move cursor
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.True(t, model.overlay.Active(), "overlay must stay open after wheel event")
+	assert.Equal(t, 0, model.nav.diffCursor)
+
+	// click must also be swallowed
+	result, _ = m.Update(leftPressAt(60, 12))
+	model = result.(Model)
+	assert.True(t, model.overlay.Active(), "overlay must stay open after click")
+	assert.Equal(t, 0, model.nav.diffCursor)
+}
+
+func TestModel_HandleMouse_ClearsTransientHints(t *testing.T) {
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
+	})
+	m.commits.hint = "loading commits..."
+	m.reload.hint = "press y to reload"
+	m.compact.hint = "not applicable"
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.Empty(t, model.commits.hint)
+	assert.Empty(t, model.reload.hint)
+	assert.Empty(t, model.compact.hint)
+}
+
+func TestModel_HandleMouse_StdinModeTreeHiddenClickLandsOnDiff(t *testing.T) {
+	// stdin mode sets treeHidden = true with singleFile = true; mdTOC = nil
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "line2", ChangeType: diff.ChangeContext},
+		{NewNum: 3, Content: "line3", ChangeType: diff.ChangeContext},
+	}
+	m := mouseTestModel(t, []string{"stdin"}, map[string][]diff.DiffLine{"stdin": lines})
+	m.file.lines = lines
+	m.layout.treeHidden = true
+	m.file.singleFile = true
+	m.layout.treeWidth = 0
+	m.layout.focus = paneDiff
+
+	// click at (x=0, y=4) — tree is hidden, so this should land on diff row 2
+	result, _ := m.Update(leftPressAt(0, 4))
+	model := result.(Model)
+	assert.Equal(t, paneDiff, model.layout.focus)
+	assert.Equal(t, 2, model.nav.diffCursor, "with tree hidden, click at y=4 must land on diff row 2")
+}
+
+func TestModel_HandleMouse_WheelInTOCJumpsViewport(t *testing.T) {
+	// markdown single-file with TOC: tree pane slot shows TOC; wheel must route to TOC.
+	files := []string{"README.md"}
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "# A", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "body", ChangeType: diff.ChangeContext},
+		{NewNum: 3, Content: "# B", ChangeType: diff.ChangeContext},
+		{NewNum: 4, Content: "body", ChangeType: diff.ChangeContext},
+		{NewNum: 5, Content: "# C", ChangeType: diff.ChangeContext},
+	}
+	m := mouseTestModel(t, files, map[string][]diff.DiffLine{"README.md": lines})
+	m.file.lines = lines
+	m.file.singleFile = true
+	m.file.mdTOC = sidepane.ParseTOC(lines, "README.md")
+	require.NotNil(t, m.file.mdTOC)
+
+	before, _ := m.file.mdTOC.CurrentLineIdx()
+
+	// wheel-down at (x=5, y=3) hits the tree slot; with mdTOC active, route to TOC
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 5, 3, false))
+	model := result.(Model)
+	after, _ := model.file.mdTOC.CurrentLineIdx()
+	assert.NotEqual(t, before, after, "TOC cursor must advance when wheel is used in TOC pane")
+}
+
+func TestModel_HandleMouse_LeftClickInTOCJumpsViewport(t *testing.T) {
+	files := []string{"README.md"}
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "# A", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "body", ChangeType: diff.ChangeContext},
+		{NewNum: 3, Content: "# B", ChangeType: diff.ChangeContext},
+		{NewNum: 4, Content: "body", ChangeType: diff.ChangeContext},
+	}
+	m := mouseTestModel(t, files, map[string][]diff.DiffLine{"README.md": lines})
+	m.file.lines = lines
+	m.file.singleFile = true
+	m.file.mdTOC = sidepane.ParseTOC(lines, "README.md")
+	require.NotNil(t, m.file.mdTOC)
+	m.layout.focus = paneDiff
+
+	// click on row 1 of TOC (y=2, treeTopRow=1 → row 1)
+	result, _ := m.Update(leftPressAt(5, 2))
+	model := result.(Model)
+	assert.Equal(t, paneTree, model.layout.focus, "TOC click must focus tree pane slot")
 }

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -286,6 +286,30 @@ func TestModel_HandleMouse_LeftClickInDiff(t *testing.T) {
 	assert.False(t, model.annot.cursorOnAnnotation, "plain diff click must not set cursorOnAnnotation")
 }
 
+func TestModel_HandleMouse_LeftClickInDiffWithScrolledViewport(t *testing.T) {
+	// verifies the full clickDiff formula: row = (y - diffTopRow()) + YOffset.
+	// plan requires a YOffset > 0 case to guard against regressions in the
+	// scroll-adjusted click mapping; without this, clicks on a scrolled
+	// viewport could silently drop the YOffset term and land on the wrong
+	// diff line.
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
+	m.layout.viewport.SetYOffset(5)
+	m.layout.focus = paneTree
+
+	// click at y=12 with diffTopRow=2, YOffset=5 → row 15
+	result, _ := m.Update(leftPressAt(60, 12))
+	model := result.(Model)
+	assert.Equal(t, paneDiff, model.layout.focus)
+	assert.Equal(t, 15, model.nav.diffCursor, "click in scrolled viewport must add YOffset to logical row")
+	assert.False(t, model.annot.cursorOnAnnotation)
+}
+
 func TestModel_HandleMouse_LeftClickInDiffNoopWhenNoFileLoaded(t *testing.T) {
 	// mirrors the togglePane invariant: focus must not switch to paneDiff
 	// when no file is loaded (e.g. clicks received before filesLoadedMsg
@@ -626,4 +650,70 @@ func TestModel_HandleMouse_LeftClickInTOCJumpsViewport(t *testing.T) {
 	result, _ := m.Update(leftPressAt(5, 2))
 	model := result.(Model)
 	assert.Equal(t, paneTree, model.layout.focus, "TOC click must focus tree pane slot")
+}
+
+func TestModel_HandleMouse_WheelInDiffSyncsTOCActiveSection(t *testing.T) {
+	// mirrors the keyboard-navigation TOC-sync guarantee (diffnav.go:464):
+	// moving the diff cursor via wheel must keep mdTOC.activeSection aligned
+	// with the new cursor position, otherwise switching focus back to the TOC
+	// highlights the stale section.
+	files := []string{"README.md"}
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "# First", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "body", ChangeType: diff.ChangeContext},
+		{NewNum: 3, Content: "## Second", ChangeType: diff.ChangeContext},
+		{NewNum: 4, Content: "body", ChangeType: diff.ChangeContext},
+		{NewNum: 5, Content: "### Third", ChangeType: diff.ChangeContext},
+		{NewNum: 6, Content: "body", ChangeType: diff.ChangeContext},
+	}
+	m := mouseTestModel(t, files, map[string][]diff.DiffLine{"README.md": lines})
+	m.file.lines = lines
+	m.file.singleFile = true
+	m.file.mdTOC = sidepane.ParseTOC(lines, "README.md")
+	require.NotNil(t, m.file.mdTOC)
+	m.layout.focus = paneDiff
+	m.nav.diffCursor = 0
+
+	// wheel-down in diff pane (x=60 lands past treeWidth, y=5 > diffTopRow)
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 5, false))
+	model := result.(Model)
+
+	// after wheel, diffCursor advanced; TOC active-section must reflect it
+	require.Positive(t, model.nav.diffCursor, "wheel-down must advance diffCursor")
+	model.file.mdTOC.SyncCursorToActiveSection()
+	idx, ok := model.file.mdTOC.CurrentLineIdx()
+	assert.True(t, ok, "TOC active section must be set after wheel in diff")
+	// cursor moved past line 2 (## Second at lineIdx=2); active section must be Second or Third
+	assert.GreaterOrEqual(t, idx, 2, "TOC active section must match diff cursor region after wheel")
+}
+
+func TestModel_HandleMouse_ClickInDiffSyncsTOCActiveSection(t *testing.T) {
+	// same guarantee as the wheel case, for click-to-set-cursor.
+	files := []string{"README.md"}
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "# First", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "body", ChangeType: diff.ChangeContext},
+		{NewNum: 3, Content: "## Second", ChangeType: diff.ChangeContext},
+		{NewNum: 4, Content: "body", ChangeType: diff.ChangeContext},
+		{NewNum: 5, Content: "### Third", ChangeType: diff.ChangeContext},
+		{NewNum: 6, Content: "body", ChangeType: diff.ChangeContext},
+	}
+	m := mouseTestModel(t, files, map[string][]diff.DiffLine{"README.md": lines})
+	m.file.lines = lines
+	m.file.singleFile = true
+	m.file.mdTOC = sidepane.ParseTOC(lines, "README.md")
+	require.NotNil(t, m.file.mdTOC)
+	m.layout.focus = paneTree
+	m.nav.diffCursor = 0
+
+	// click at y=6 with diffTopRow=2, YOffset=0 → row 4 (### Third)
+	result, _ := m.Update(leftPressAt(60, 6))
+	model := result.(Model)
+
+	assert.Equal(t, paneDiff, model.layout.focus)
+	assert.Equal(t, 4, model.nav.diffCursor, "click must land on diff line 4 (### Third)")
+	model.file.mdTOC.SyncCursorToActiveSection()
+	idx, ok := model.file.mdTOC.CurrentLineIdx()
+	assert.True(t, ok, "TOC active section must be set after click in diff")
+	assert.Equal(t, 4, idx, "TOC active section must match clicked diff line (Third section at lineIdx=4)")
 }

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -132,19 +132,28 @@ func TestModel_hitTest(t *testing.T) {
 			x: 5, y: 10, want: hitTree,
 		},
 		{
-			name: "no status bar: last row is diff, not status",
+			name: "no status bar: last row is pane bottom border",
 			setup: func(m *Model) {
 				m.cfg.noStatusBar = true
 			},
-			x: 60, y: 39, want: hitDiff,
+			x: 60, y: 39, want: hitNone,
 		},
 		{
-			name: "no status bar: last row in tree zone is hitTree",
+			name: "no status bar: last row in tree zone is pane bottom border",
 			setup: func(m *Model) {
 				m.cfg.noStatusBar = true
 			},
-			x: 5, y: 39, want: hitTree,
+			x: 5, y: 39, want: hitNone,
 		},
+		{
+			name: "no status bar: second-to-last row is diff content",
+			setup: func(m *Model) {
+				m.cfg.noStatusBar = true
+			},
+			x: 60, y: 38, want: hitDiff,
+		},
+		{name: "diff pane bottom border", setup: func(m *Model) {}, x: 60, y: 38, want: hitNone},
+		{name: "tree pane bottom border", setup: func(m *Model) {}, x: 5, y: 38, want: hitNone},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -313,6 +322,35 @@ func TestModel_HandleMouse_LeftClickSetsCursorOnAnnotation(t *testing.T) {
 	assert.True(t, model.annot.cursorOnAnnotation, "click on annotation sub-row must set cursorOnAnnotation")
 }
 
+func TestModel_HandleMouse_LeftClickOnDeleteOnlyPlaceholderDoesNotLandOnAnnotation(t *testing.T) {
+	// in collapsed mode, a delete-only hunk renders a single "⋯ N lines deleted"
+	// placeholder. annotations on the underlying removed lines are NOT rendered
+	// (see renderCollapsedDiff). clicking the placeholder must not set
+	// cursorOnAnnotation, mirroring keyboard navigation guarded by
+	// TestModel_CollapsedCursorDownSkipsPlaceholderAnnotation.
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "ctx1", ChangeType: diff.ChangeContext}, // 0
+		{OldNum: 2, Content: "del1", ChangeType: diff.ChangeRemove},  // 1 - placeholder
+		{OldNum: 3, Content: "del2", ChangeType: diff.ChangeRemove},  // 2 - hidden
+		{NewNum: 2, Content: "ctx2", ChangeType: diff.ChangeContext}, // 3
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.modes.collapsed.enabled = true
+	m.modes.collapsed.expandedHunks = make(map[int]bool)
+	// annotation on the hidden removed line — its sub-row is NOT rendered for a placeholder
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 2, Type: "-", Comment: "hidden note"})
+
+	// collapsed layout: row 0 = ctx1, row 1 = placeholder (idx 1), row 2 = ctx2 (idx 3).
+	// diffTopRow=2 so y=3 targets the placeholder row.
+	result, _ := m.Update(leftPressAt(60, 3))
+	model := result.(Model)
+	assert.Equal(t, paneDiff, model.layout.focus)
+	assert.Equal(t, 1, model.nav.diffCursor, "click on placeholder lands on placeholder line index")
+	assert.False(t, model.annot.cursorOnAnnotation,
+		"click on placeholder must not set cursorOnAnnotation — annotation is not rendered")
+}
+
 func TestModel_HandleMouse_LeftClickInTreeSelectsAndLoads(t *testing.T) {
 	files := []string{"a.go", "b.go", "c.go"}
 	diffs := map[string][]diff.DiffLine{
@@ -453,6 +491,7 @@ func TestModel_HandleMouse_SwallowedWhileReloadPending(t *testing.T) {
 		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeContext}},
 	})
 	m.reload.pending = true
+	m.reload.hint = "Annotations will be dropped — press y to confirm, any other key to cancel"
 	m.nav.diffCursor = 0
 	m.layout.focus = paneTree
 
@@ -461,6 +500,14 @@ func TestModel_HandleMouse_SwallowedWhileReloadPending(t *testing.T) {
 	assert.Equal(t, 0, model.nav.diffCursor, "click must be swallowed while reload confirmation is pending")
 	assert.Equal(t, paneTree, model.layout.focus)
 	assert.True(t, model.reload.pending)
+	assert.Equal(t, "Annotations will be dropped — press y to confirm, any other key to cancel", model.reload.hint,
+		"reload hint must stay visible while pending — otherwise the modal prompt vanishes but the modal remains")
+
+	// wheel must also preserve the hint
+	result, _ = m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model = result.(Model)
+	assert.True(t, model.reload.pending)
+	assert.NotEmpty(t, model.reload.hint, "wheel must not erase the reload prompt while pending")
 }
 
 func TestModel_HandleMouse_SwallowedWhileConfirmDiscard(t *testing.T) {

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -1,0 +1,154 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/umputun/revdiff/app/diff"
+	"github.com/umputun/revdiff/app/ui/sidepane"
+)
+
+func TestModel_statusBarHeight(t *testing.T) {
+	tests := []struct {
+		name        string
+		noStatusBar bool
+		want        int
+	}{
+		{"status bar visible", false, 1},
+		{"status bar hidden", true, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testModel([]string{"a.go"}, nil)
+			m.cfg.noStatusBar = tc.noStatusBar
+			assert.Equal(t, tc.want, m.statusBarHeight())
+		})
+	}
+}
+
+func TestModel_diffTopRow(t *testing.T) {
+	// diffTopRow is constant regardless of layout state — it always accounts
+	// for the pane top border (row 0) and the diff header (row 1).
+	m := testModel([]string{"a.go"}, nil)
+	assert.Equal(t, 2, m.diffTopRow(), "diff viewport starts at row 2 (below border + header)")
+
+	t.Run("single file mode", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, nil)
+		m.file.singleFile = true
+		assert.Equal(t, 2, m.diffTopRow())
+	})
+
+	t.Run("no status bar", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, nil)
+		m.cfg.noStatusBar = true
+		assert.Equal(t, 2, m.diffTopRow())
+	})
+
+	t.Run("tree hidden", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, nil)
+		m.layout.treeHidden = true
+		assert.Equal(t, 2, m.diffTopRow())
+	})
+}
+
+func TestModel_treeTopRow(t *testing.T) {
+	// treeTopRow is constant — tree content begins at row 1 (below the top border).
+	m := testModel([]string{"a.go"}, nil)
+	assert.Equal(t, 1, m.treeTopRow(), "tree content starts at row 1 (below border)")
+
+	t.Run("no status bar", func(t *testing.T) {
+		m := testModel([]string{"a.go"}, nil)
+		m.cfg.noStatusBar = true
+		assert.Equal(t, 1, m.treeTopRow())
+	})
+}
+
+func TestModel_hitTest(t *testing.T) {
+	// baseline layout: width=120, height=40, treeWidth=36, status bar visible.
+	// tree block occupies x=[0, 37] (treeWidth+2 cols with borders),
+	// diff block x=[38, 119].
+	// rows: 0=top border, 1=diff header / tree row 0, 2..=content, 38=bottom border, 39=status.
+	tests := []struct {
+		name  string
+		setup func(m *Model)
+		x, y  int
+		want  hitZone
+	}{
+		{name: "tree pane entry row", setup: func(m *Model) {}, x: 5, y: 3, want: hitTree},
+		{name: "tree pane top border", setup: func(m *Model) {}, x: 5, y: 0, want: hitNone},
+		{name: "tree pane first content row", setup: func(m *Model) {}, x: 5, y: 1, want: hitTree},
+		{name: "diff pane viewport row", setup: func(m *Model) {}, x: 60, y: 10, want: hitDiff},
+		{name: "diff pane header row", setup: func(m *Model) {}, x: 60, y: 1, want: hitHeader},
+		{name: "diff pane top border", setup: func(m *Model) {}, x: 60, y: 0, want: hitHeader},
+		{name: "status bar", setup: func(m *Model) {}, x: 60, y: 39, want: hitStatus},
+		{name: "status bar at x=0", setup: func(m *Model) {}, x: 0, y: 39, want: hitStatus},
+		{name: "tree-diff boundary: last tree column", setup: func(m *Model) {}, x: 37, y: 10, want: hitTree},
+		{name: "tree-diff boundary: first diff column", setup: func(m *Model) {}, x: 38, y: 10, want: hitDiff},
+		{name: "x negative", setup: func(m *Model) {}, x: -1, y: 10, want: hitNone},
+		{name: "y negative", setup: func(m *Model) {}, x: 60, y: -1, want: hitNone},
+		{name: "x out of bounds (= width)", setup: func(m *Model) {}, x: 120, y: 10, want: hitNone},
+		{name: "y out of bounds (= height)", setup: func(m *Model) {}, x: 60, y: 40, want: hitNone},
+		{
+			name: "tree hidden: click in former tree area goes to diff",
+			setup: func(m *Model) {
+				m.layout.treeHidden = true
+				m.layout.treeWidth = 0
+			},
+			x: 5, y: 10, want: hitDiff,
+		},
+		{
+			name: "tree hidden: y=1 is diff header even at x=0",
+			setup: func(m *Model) {
+				m.layout.treeHidden = true
+				m.layout.treeWidth = 0
+			},
+			x: 5, y: 1, want: hitHeader,
+		},
+		{
+			name: "single file without TOC: no tree zone",
+			setup: func(m *Model) {
+				m.file.singleFile = true
+				m.file.mdTOC = nil
+				m.layout.treeWidth = 0
+			},
+			x: 5, y: 10, want: hitDiff,
+		},
+		{
+			name: "single file with TOC: tree zone active",
+			setup: func(m *Model) {
+				m.file.singleFile = true
+				m.file.mdTOC = sidepane.ParseTOC(
+					[]diff.DiffLine{{NewNum: 1, Content: "# Title", ChangeType: diff.ChangeContext}},
+					"README.md",
+				)
+			},
+			x: 5, y: 10, want: hitTree,
+		},
+		{
+			name: "no status bar: last row is diff, not status",
+			setup: func(m *Model) {
+				m.cfg.noStatusBar = true
+			},
+			x: 60, y: 39, want: hitDiff,
+		},
+		{
+			name: "no status bar: last row in tree zone is hitTree",
+			setup: func(m *Model) {
+				m.cfg.noStatusBar = true
+			},
+			x: 5, y: 39, want: hitTree,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testModel([]string{"a.go"}, nil)
+			m.layout.width = 120
+			m.layout.height = 40
+			m.layout.treeWidth = 36
+			tc.setup(&m)
+			assert.Equal(t, tc.want, m.hitTest(tc.x, tc.y),
+				"hitTest(%d, %d) with setup %q", tc.x, tc.y, tc.name)
+		})
+	}
+}

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -277,6 +277,23 @@ func TestModel_HandleMouse_LeftClickInDiff(t *testing.T) {
 	assert.False(t, model.annot.cursorOnAnnotation, "plain diff click must not set cursorOnAnnotation")
 }
 
+func TestModel_HandleMouse_LeftClickInDiffNoopWhenNoFileLoaded(t *testing.T) {
+	// mirrors the togglePane invariant: focus must not switch to paneDiff
+	// when no file is loaded (e.g. clicks received before filesLoadedMsg
+	// arrives or in an empty --only result).
+	m := mouseTestModel(t, []string{"a.go"}, nil)
+	m.file.name = ""
+	m.file.lines = nil
+	m.layout.focus = paneTree
+
+	result, cmd := m.Update(leftPressAt(60, 12))
+	model := result.(Model)
+	assert.Nil(t, cmd)
+	assert.Equal(t, paneTree, model.layout.focus, "click in diff with no file loaded must not flip focus")
+	assert.Equal(t, 0, model.nav.diffCursor, "click with no file loaded must not move the diff cursor")
+	assert.False(t, model.annot.cursorOnAnnotation)
+}
+
 func TestModel_HandleMouse_LeftClickSetsCursorOnAnnotation(t *testing.T) {
 	lines := []diff.DiffLine{
 		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeAdd},

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -163,6 +163,22 @@ func (ft *FileTree) SelectByPath(path string) bool {
 	return false
 }
 
+// SelectByVisibleRow sets the cursor to the entry at the given visible row.
+// row is 0-based relative to the first visible tree line (ft.offset).
+// returns true if the row maps to a valid entry, false otherwise.
+// does not modify the cursor when returning false.
+func (ft *FileTree) SelectByVisibleRow(row int) bool {
+	if row < 0 {
+		return false
+	}
+	idx := ft.offset + row
+	if idx >= len(ft.entries) {
+		return false
+	}
+	ft.cursor = idx
+	return true
+}
+
 // EnsureVisible adjusts offset so the cursor is within the visible range of given height.
 func (ft *FileTree) EnsureVisible(height int) {
 	ensureVisible(&ft.cursor, &ft.offset, len(ft.entries), height)

--- a/app/ui/sidepane/filetree_test.go
+++ b/app/ui/sidepane/filetree_test.go
@@ -460,6 +460,79 @@ func TestFileTree_SelectByPath(t *testing.T) {
 	})
 }
 
+func TestFileTree_SelectByVisibleRow(t *testing.T) {
+	t.Run("first row at offset zero selects first entry", func(t *testing.T) {
+		ft := NewFileTree(fileEntries("a.go", "b.go"))
+		// entries: ["./", "a.go", "b.go"]
+		ok := ft.SelectByVisibleRow(0)
+		assert.True(t, ok)
+		assert.Equal(t, 0, ft.cursor)
+	})
+
+	t.Run("row within visible range selects matching entry", func(t *testing.T) {
+		ft := NewFileTree(fileEntries("a.go", "b.go", "c.go"))
+		// entries: ["./", "a.go", "b.go", "c.go"], offset=0
+		ok := ft.SelectByVisibleRow(2)
+		assert.True(t, ok)
+		assert.Equal(t, 2, ft.cursor) // "b.go"
+		assert.Equal(t, "b.go", ft.SelectedFile())
+	})
+
+	t.Run("row with non-zero offset adds offset", func(t *testing.T) {
+		ft := NewFileTree(fileEntries("a.go", "b.go", "c.go", "d.go", "e.go"))
+		// entries: ["./", "a.go", "b.go", "c.go", "d.go", "e.go"]
+		ft.offset = 3
+		ok := ft.SelectByVisibleRow(1)
+		assert.True(t, ok)
+		assert.Equal(t, 4, ft.cursor) // offset(3) + row(1) = "d.go"
+		assert.Equal(t, "d.go", ft.SelectedFile())
+	})
+
+	t.Run("click past end returns false and does not modify cursor", func(t *testing.T) {
+		ft := NewFileTree(fileEntries("a.go", "b.go"))
+		// entries: ["./", "a.go", "b.go"] — only 3 entries
+		prev := ft.cursor
+		ok := ft.SelectByVisibleRow(10)
+		assert.False(t, ok)
+		assert.Equal(t, prev, ft.cursor)
+	})
+
+	t.Run("click on directory row succeeds", func(t *testing.T) {
+		ft := NewFileTree(fileEntries("internal/a.go"))
+		// entries: ["internal/", "a.go"] — first is directory
+		ok := ft.SelectByVisibleRow(0)
+		assert.True(t, ok)
+		assert.Equal(t, 0, ft.cursor)
+		assert.True(t, ft.entries[ft.cursor].isDir)
+		// SelectedFile returns empty for dir entries, mirroring j-landing behavior
+		assert.Empty(t, ft.SelectedFile())
+	})
+
+	t.Run("negative row returns false and does not modify cursor", func(t *testing.T) {
+		ft := NewFileTree(fileEntries("a.go", "b.go"))
+		prev := ft.cursor
+		ok := ft.SelectByVisibleRow(-1)
+		assert.False(t, ok)
+		assert.Equal(t, prev, ft.cursor)
+	})
+
+	t.Run("empty tree returns false for any row", func(t *testing.T) {
+		ft := NewFileTree(nil)
+		ok := ft.SelectByVisibleRow(0)
+		assert.False(t, ok)
+	})
+
+	t.Run("row past end with offset returns false", func(t *testing.T) {
+		ft := NewFileTree(fileEntries("a.go", "b.go", "c.go"))
+		ft.offset = 2
+		prev := ft.cursor
+		// entries has 4 items (./, a.go, b.go, c.go); offset=2, row=5 -> idx=7, out of range
+		ok := ft.SelectByVisibleRow(5)
+		assert.False(t, ok)
+		assert.Equal(t, prev, ft.cursor)
+	})
+}
+
 func TestFileTree_RenderTruncatesLongDirNames(t *testing.T) {
 	ft := NewFileTree(fileEntries(".claude-plugin/skills/revdiff/references/config.md"))
 	res := style.NewResolver(style.Colors{Accent: "#5f87ff", Border: "#585858", Normal: "#d0d0d0", Muted: "#6c6c6c", SelectedFg: "#ffffaf", SelectedBg: "#303030", Annotation: "#ffd700", AddFg: "#87d787", AddBg: "#022800", RemoveFg: "#ff8787", RemoveBg: "#3D0100"})

--- a/app/ui/sidepane/toc.go
+++ b/app/ui/sidepane/toc.go
@@ -155,6 +155,22 @@ func (t *TOC) EnsureVisible(height int) {
 	ensureVisible(&t.cursor, &t.offset, len(t.entries), height)
 }
 
+// SelectByVisibleRow sets the cursor to the entry at the given visible row.
+// row is 0-based relative to the first visible TOC line (t.offset).
+// returns true if the row maps to a valid entry, false otherwise.
+// does not modify the cursor when returning false.
+func (t *TOC) SelectByVisibleRow(row int) bool {
+	if row < 0 {
+		return false
+	}
+	idx := t.offset + row
+	if idx >= len(t.entries) {
+		return false
+	}
+	t.cursor = idx
+	return true
+}
+
 // UpdateActiveSection finds the nearest entry with lineIdx <= diffCursor and sets activeSection.
 // sets activeSection back to -1 when no entry matches, preserving the sentinel contract.
 func (t *TOC) UpdateActiveSection(diffCursor int) {

--- a/app/ui/sidepane/toc_test.go
+++ b/app/ui/sidepane/toc_test.go
@@ -633,6 +633,78 @@ func TestTOC_NumEntries(t *testing.T) {
 	})
 }
 
+func TestTOC_SelectByVisibleRow(t *testing.T) {
+	t.Run("first row at offset zero selects first entry", func(t *testing.T) {
+		toc := &TOC{entries: []tocEntry{
+			{title: "A", level: 1, lineIdx: 0},
+			{title: "B", level: 1, lineIdx: 5},
+		}, cursor: 1}
+		ok := toc.SelectByVisibleRow(0)
+		assert.True(t, ok)
+		assert.Equal(t, 0, toc.cursor)
+	})
+
+	t.Run("row within visible range selects matching entry", func(t *testing.T) {
+		toc := &TOC{entries: []tocEntry{
+			{title: "A", level: 1, lineIdx: 0},
+			{title: "B", level: 1, lineIdx: 5},
+			{title: "C", level: 1, lineIdx: 10},
+		}, cursor: 0}
+		ok := toc.SelectByVisibleRow(2)
+		assert.True(t, ok)
+		assert.Equal(t, 2, toc.cursor)
+	})
+
+	t.Run("row with non-zero offset adds offset", func(t *testing.T) {
+		toc := &TOC{entries: []tocEntry{
+			{title: "A", level: 1, lineIdx: 0},
+			{title: "B", level: 1, lineIdx: 5},
+			{title: "C", level: 1, lineIdx: 10},
+			{title: "D", level: 1, lineIdx: 15},
+			{title: "E", level: 1, lineIdx: 20},
+		}, cursor: 0, offset: 2}
+		ok := toc.SelectByVisibleRow(1)
+		assert.True(t, ok)
+		assert.Equal(t, 3, toc.cursor) // offset(2) + row(1)
+	})
+
+	t.Run("click past end returns false and does not modify cursor", func(t *testing.T) {
+		toc := &TOC{entries: []tocEntry{
+			{title: "A", level: 1, lineIdx: 0},
+			{title: "B", level: 1, lineIdx: 5},
+		}, cursor: 1}
+		ok := toc.SelectByVisibleRow(10)
+		assert.False(t, ok)
+		assert.Equal(t, 1, toc.cursor)
+	})
+
+	t.Run("negative row returns false and does not modify cursor", func(t *testing.T) {
+		toc := &TOC{entries: []tocEntry{
+			{title: "A", level: 1, lineIdx: 0},
+		}, cursor: 0}
+		ok := toc.SelectByVisibleRow(-1)
+		assert.False(t, ok)
+		assert.Equal(t, 0, toc.cursor)
+	})
+
+	t.Run("empty TOC returns false for any row", func(t *testing.T) {
+		toc := &TOC{}
+		ok := toc.SelectByVisibleRow(0)
+		assert.False(t, ok)
+	})
+
+	t.Run("row past end with offset returns false", func(t *testing.T) {
+		toc := &TOC{entries: []tocEntry{
+			{title: "A", level: 1, lineIdx: 0},
+			{title: "B", level: 1, lineIdx: 5},
+			{title: "C", level: 1, lineIdx: 10},
+		}, cursor: 0, offset: 1}
+		ok := toc.SelectByVisibleRow(5)
+		assert.False(t, ok)
+		assert.Equal(t, 0, toc.cursor)
+	})
+}
+
 func TestFencePrefix(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,7 @@ Central package. Single `Model` struct implements bubbletea's `Model` interface.
 | `editor.go` | `$EDITOR` handoff for multi-line annotations: `openEditor()` wraps `app/editor.Editor` in `tea.ExecProcess`, `editorFinishedMsg` dispatch, `handleEditorFinished` routing (save / cancel / error-preserve) |
 | `themeselect.go` | Theme selector operations: open, preview, confirm, apply (via injected `ThemeCatalog`) |
 | `search.go` | Search input handling, match computation, navigation |
+| `mouse.go` | Mouse event routing: `handleMouse` dispatch, `hitTest` pane classification (`hitZone`), wheel/left-click helpers (`clickTree`, `clickDiff`), layout helpers (`statusBarHeight`, `diffTopRow`, `treeTopRow`). Mouse tracking is enabled program-wide via `tea.WithMouseCellMotion()` in `app/main.go` unless `--no-mouse` / `REVDIFF_NO_MOUSE` is set |
 
 Each source file has a matching `_test.go`.
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -379,9 +379,9 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 **Files:**
 - Potentially modify: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `package.json`
 
-- [ ] per project memory "plugin-version-bump": ask user whether to bump Claude plugin version (both `plugin.json` and `marketplace.json`) after modifying `.claude-plugin/skills/revdiff/references/*.md`
-- [ ] ask user whether to bump pi plugin version in `package.json` after modifying `plugins/pi/` (only if any pi files changed — this task does not modify pi by default, so likely no-op)
-- [ ] no test changes needed
+- [x] per project memory "plugin-version-bump": ask user whether to bump Claude plugin version (both `plugin.json` and `marketplace.json`) after modifying `.claude-plugin/skills/revdiff/references/*.md`
+- [x] ask user whether to bump pi plugin version in `package.json` after modifying `plugins/pi/` (only if any pi files changed — this task does not modify pi by default, so likely no-op)
+- [x] no test changes needed
 
 ### Task 8: Verify acceptance criteria
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -313,15 +313,15 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 - Create: `app/ui/mouse_test.go`
 - Potentially Modify: `app/ui/model.go` or `app/ui/view.go` (for layout helpers, if they don't already exist)
 
-- [ ] check existing code for `statusBarHeight`, `diffTopRow`, `treeTopRow` helpers — reuse if present, otherwise add as methods on `Model` near other layout methods
-- [ ] `statusBarHeight() int` returns 0 when `m.NoStatusBar`, otherwise the actual number of rows (typically 1)
-- [ ] `diffTopRow() int` returns the first row of diff viewport content (after diff header). Derive from the same math that `view.go` uses to render
-- [ ] `treeTopRow() int` returns the first row of tree content (after any pane border). Derive from the same math that `renderTwoPaneLayout` uses
-- [ ] declare `hitZone` type and constants (`hitNone`, `hitTree`, `hitDiff`, `hitStatus`, `hitHeader`) in `app/ui/mouse.go`
-- [ ] implement `func (m Model) hitTest(x, y int) hitZone` using the three helpers above — pure arithmetic, no I/O
-- [ ] unit test table for `hitTest`: tree visible/hidden, single-file without TOC, single-file with TOC, no-status-bar, stdin-mode (tree hidden by default), `(x=treeWidth-1, y)` → `hitTree`, `(x=treeWidth, y)` → `hitDiff`, `y=0` → `hitHeader`, `y=last` → `hitStatus`, `x=width` → `hitNone` (out of bounds)
-- [ ] unit tests for `statusBarHeight`, `diffTopRow`, `treeTopRow` covering status bar on/off and single-file vs two-pane layout
-- [ ] run `go test ./app/ui/...` — must pass before task 5
+- [x] check existing code for `statusBarHeight`, `diffTopRow`, `treeTopRow` helpers — reuse if present, otherwise add as methods on `Model` near other layout methods
+- [x] `statusBarHeight() int` returns 0 when `m.NoStatusBar`, otherwise the actual number of rows (typically 1)
+- [x] `diffTopRow() int` returns the first row of diff viewport content (after diff header). Derive from the same math that `view.go` uses to render
+- [x] `treeTopRow() int` returns the first row of tree content (after any pane border). Derive from the same math that `renderTwoPaneLayout` uses
+- [x] declare `hitZone` type and constants (`hitNone`, `hitTree`, `hitDiff`, `hitStatus`, `hitHeader`) in `app/ui/mouse.go`
+- [x] implement `func (m Model) hitTest(x, y int) hitZone` using the three helpers above — pure arithmetic, no I/O
+- [x] unit test table for `hitTest`: tree visible/hidden, single-file without TOC, single-file with TOC, no-status-bar, stdin-mode (tree hidden by default), `(x=treeWidth-1, y)` → `hitTree`, `(x=treeWidth, y)` → `hitDiff`, `y=0` → `hitHeader`, `y=last` → `hitStatus`, `x=width` → `hitNone` (out of bounds)
+- [x] unit tests for `statusBarHeight`, `diffTopRow`, `treeTopRow` covering status bar on/off and single-file vs two-pane layout
+- [x] run `go test ./app/ui/...` — must pass before task 5
 
 ### Task 5: Implement `handleMouse` routing with wheel + left-click
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -330,24 +330,24 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 - Modify: `app/ui/model.go` (add `tea.MouseMsg` case in `Update`)
 - Modify: `app/ui/mouse_test.go`
 
-- [ ] add `tea.MouseMsg` case in `Model.Update` at `app/ui/model.go:662` → delegates to `m.handleMouse(msg)`
-- [ ] at top of `handleMouse`, clear transient hints mirroring `handleKey` at `model.go:704-706`: `m.commits.hint = ""`, `m.reload.hint = ""`, `m.compact.hint = ""`
-- [ ] implement swallow checks in the order specified in Solution Overview (`inConfirmDiscard`, `reload.pending`, `annot.annotating`, `search.active`, overlay-open via `m.overlay` check) — all return `m, nil`
-- [ ] dispatch by `msg.Button`:
+- [x] add `tea.MouseMsg` case in `Model.Update` at `app/ui/model.go:662` → delegates to `m.handleMouse(msg)`
+- [x] at top of `handleMouse`, clear transient hints mirroring `handleKey` at `model.go:704-706`: `m.commits.hint = ""`, `m.reload.hint = ""`, `m.compact.hint = ""`
+- [x] implement swallow checks in the order specified in Solution Overview (`inConfirmDiscard`, `reload.pending`, `annot.annotating`, `search.active`, overlay-open via `m.overlay` check) — all return `m, nil`
+- [x] dispatch by `msg.Button`:
   - wheel up/down: compute `step := wheelStep` (const 3); when `msg.Shift`, use `m.layout.viewport.Height/2`; hit-test `(msg.X, msg.Y)`; route to `m.moveDiffCursorDownBy(step)`/`UpBy(step)` for `hitDiff`, `m.tree.Move(sidepane.MotionPageDown, step)` / `MotionPageUp` for `hitTree`, analogous `m.file.mdTOC.Move(MotionPageDown/Up, step)` when TOC active, no-op for `hitStatus`/`hitHeader`/`hitNone`
   - wheel left/right: return `m, nil` (intentionally swallowed)
   - left press (only `msg.Action == tea.MouseActionPress` — skip release/motion): invoke `clickTree` or `clickDiff` based on hit-zone (helpers set focus themselves)
   - any other button or action: return `m, nil`
-- [ ] implement `clickDiff(x, y int)` helper as shown in Technical Details: uses `visualRowToDiffLine` two-return, sets `m.annot.cursorOnAnnotation` to the `onAnnotation` flag, calls `syncViewportToCursor`, sets `m.layout.focus = paneDiff`
-- [ ] implement `clickTree(x, y int)` helper as shown in Technical Details: routes to `m.file.mdTOC.SelectByVisibleRow` when mdTOC active, else `m.tree.SelectByVisibleRow`; clears pending jumps; calls `loadSelectedIfChanged`; sets focus
-- [ ] wheel tests: wheel in diff pane → cursor moves 3 lines; shift+wheel in diff → cursor moves `viewport.Height/2`; wheel in tree pane → tree cursor moves 3; wheel in tree with focus on diff → tree cursor still moves (routing is by cursor-position, not by current focus); wheel in TOC pane (markdown file, full-context) → TOC cursor moves; wheel-left / wheel-right → no-op
-- [ ] click tests: click in diff at row N → `diffCursor` lands on matching diff-line, `cursorOnAnnotation` set correctly; click on annotation sub-row sets `cursorOnAnnotation=true`; click in tree → tree selection changes + file load triggered; click on directory entry in tree → cursor moves but no file load; click in TOC pane (mdTOC active) → TOC selection changes; click in status zone → no-op; click in diff header → no-op; click in out-of-bounds zone → no-op
-- [ ] button filter tests: right-click → no-op; middle-click → no-op; left release (no press) → no-op; mouse motion → no-op; back/forward buttons → no-op
-- [ ] modal swallow tests: wheel while annotating → no-op; click while annotating → no-op, annotation input unchanged; wheel while overlay open → no-op, overlay stays open; click while overlay open → no-op; wheel while search active → no-op; click while `reload.pending` → no-op; click while `inConfirmDiscard` → no-op
-- [ ] hint-clearing test: wheel event with `m.commits.hint="loading commits..."` — after handler, hint is empty
-- [ ] focus side-effect tests: click in tree while focused on diff → `layout.focus == paneTree`; click in diff while focused on tree → `layout.focus == paneDiff`
-- [ ] stdin-mode test: tree is hidden in stdin mode; click at `(x=0, y=1)` → `hitDiff`, not `hitTree`; wheel and click behave as diff-only
-- [ ] run `go test ./app/ui/...` — must pass before task 6
+- [x] implement `clickDiff(x, y int)` helper as shown in Technical Details: uses `visualRowToDiffLine` two-return, sets `m.annot.cursorOnAnnotation` to the `onAnnotation` flag, calls `syncViewportToCursor`, sets `m.layout.focus = paneDiff`
+- [x] implement `clickTree(x, y int)` helper as shown in Technical Details: routes to `m.file.mdTOC.SelectByVisibleRow` when mdTOC active, else `m.tree.SelectByVisibleRow`; clears pending jumps; calls `loadSelectedIfChanged`; sets focus
+- [x] wheel tests: wheel in diff pane → cursor moves 3 lines; shift+wheel in diff → cursor moves `viewport.Height/2`; wheel in tree pane → tree cursor moves 3; wheel in tree with focus on diff → tree cursor still moves (routing is by cursor-position, not by current focus); wheel in TOC pane (markdown file, full-context) → TOC cursor moves; wheel-left / wheel-right → no-op
+- [x] click tests: click in diff at row N → `diffCursor` lands on matching diff-line, `cursorOnAnnotation` set correctly; click on annotation sub-row sets `cursorOnAnnotation=true`; click in tree → tree selection changes + file load triggered; click on directory entry in tree → cursor moves but no file load; click in TOC pane (mdTOC active) → TOC selection changes; click in status zone → no-op; click in diff header → no-op; click in out-of-bounds zone → no-op
+- [x] button filter tests: right-click → no-op; middle-click → no-op; left release (no press) → no-op; mouse motion → no-op; back/forward buttons → no-op
+- [x] modal swallow tests: wheel while annotating → no-op; click while annotating → no-op, annotation input unchanged; wheel while overlay open → no-op, overlay stays open; click while overlay open → no-op; wheel while search active → no-op; click while `reload.pending` → no-op; click while `inConfirmDiscard` → no-op
+- [x] hint-clearing test: wheel event with `m.commits.hint="loading commits..."` — after handler, hint is empty
+- [x] focus side-effect tests: click in tree while focused on diff → `layout.focus == paneTree`; click in diff while focused on tree → `layout.focus == paneDiff`
+- [x] stdin-mode test: tree is hidden in stdin mode; click at `(x=0, y=1)` → `hitDiff`, not `hitTree`; wheel and click behave as diff-only
+- [x] run `go test ./app/ui/...` — must pass before task 6
 
 ### Task 6: Documentation sync (README + site + ARCHITECTURE + plugin references)
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -385,16 +385,16 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 
 ### Task 8: Verify acceptance criteria
 
-- [ ] verify scroll wheel works in both panes (automated test via `tea.MouseMsg` in Task 5 — re-run here)
-- [ ] verify click in tree selects + loads file
-- [ ] verify click in diff sets cursor, enabling "click then `a`" annotation flow
-- [ ] verify modal-state swallow: no mouse interference during annotation, search, pending-reload, confirm-discard, or any open overlay
-- [ ] verify `--no-mouse` compiles, runs, and disables all mouse behavior (unit test from Task 1)
-- [ ] run full test suite: `go test ./...`
-- [ ] run `go test -race ./...`
-- [ ] run `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0`
-- [ ] run `~/.claude/format.sh`
-- [ ] verify test coverage did not regress (`make test`)
+- [x] verify scroll wheel works in both panes (automated test via `tea.MouseMsg` in Task 5 — re-run here)
+- [x] verify click in tree selects + loads file
+- [x] verify click in diff sets cursor, enabling "click then `a`" annotation flow
+- [x] verify modal-state swallow: no mouse interference during annotation, search, pending-reload, confirm-discard, or any open overlay
+- [x] verify `--no-mouse` compiles, runs, and disables all mouse behavior (unit test from Task 1)
+- [x] run full test suite: `go test ./...`
+- [x] run `go test -race ./...`
+- [x] run `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0`
+- [x] run `~/.claude/format.sh`
+- [x] verify test coverage did not regress (`make test`)
 
 ### Task 9: Final documentation wrap-up
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -300,11 +300,11 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 - Modify: `app/ui/sidepane/toc.go`
 - Modify: `app/ui/sidepane/toc_test.go`
 
-- [ ] add `func (ft *FileTree) SelectByVisibleRow(row int) bool` — returns true if row maps to a valid entry, updates `ft.cursor` to `ft.offset + row`
-- [ ] add equivalent `SelectByVisibleRow` on `*TOC` (same signature)
-- [ ] tests for `FileTree`: click on first visible row when `offset=0` selects entry 0; click when scrolled (`offset=5`) selects `offset+row`; click past end returns false and does not modify cursor; click on directory row succeeds (cursor moves to dir entry); click on negative row returns false
-- [ ] tests for `TOC`: mirror the above
-- [ ] run `go test ./app/ui/sidepane/...` — must pass before task 4
+- [x] add `func (ft *FileTree) SelectByVisibleRow(row int) bool` — returns true if row maps to a valid entry, updates `ft.cursor` to `ft.offset + row`
+- [x] add equivalent `SelectByVisibleRow` on `*TOC` (same signature)
+- [x] tests for `FileTree`: click on first visible row when `offset=0` selects entry 0; click when scrolled (`offset=5`) selects `offset+row`; click past end returns false and does not modify cursor; click on directory row succeeds (cursor moves to dir entry); click on negative row returns false
+- [x] tests for `TOC`: mirror the above
+- [x] run `go test ./app/ui/sidepane/...` — must pass before task 4
 
 ### Task 4: Add `hitTest` and `hitZone` classification + layout helpers
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -269,11 +269,11 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 - Modify: `app/main.go`
 - Modify: `app/config_test.go` (add flag-parsing assertion)
 
-- [ ] add `NoMouse bool` field to `Options` in `app/config.go` following `NoColors`/`NoStatusBar` convention (CLI flag, ini-name, env var, description)
-- [ ] in `app/main.go` conditionally append `tea.WithMouseCellMotion()` to `programOptions` when `!opts.NoMouse`
-- [ ] add flag-parsing test: `--no-mouse` sets `Options.NoMouse=true`; env var `REVDIFF_NO_MOUSE=true` sets it; default is false
-- [ ] verify `--dump-config` output includes `no-mouse = false` by default (spot-check via existing dump-config test pattern)
-- [ ] run `go test ./...` — must pass before task 2
+- [x] add `NoMouse bool` field to `Options` in `app/config.go` following `NoColors`/`NoStatusBar` convention (CLI flag, ini-name, env var, description)
+- [x] in `app/main.go` conditionally append `tea.WithMouseCellMotion()` to `programOptions` when `!opts.NoMouse`
+- [x] add flag-parsing test: `--no-mouse` sets `Options.NoMouse=true`; env var `REVDIFF_NO_MOUSE=true` sets it; default is false
+- [x] verify `--dump-config` output includes `no-mouse = false` by default (spot-check via existing dump-config test pattern)
+- [x] run `go test ./...` — must pass before task 2
 
 *Note: bubbletea `ProgramOption` is an opaque function value — testing its presence in a `[]tea.ProgramOption` slice is impractical. Program wiring is covered by the manual terminal verification in Post-Completion.*
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -283,14 +283,14 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 - Modify: `app/ui/diffnav.go` (or `app/ui/annotate.go` — put it next to `cursorVisualRange` wherever that lives; currently `annotate.go:477`)
 - Modify: `app/ui/diffnav_test.go` or corresponding test file (match location of implementation)
 
-- [ ] add `func (m Model) visualRowToDiffLine(row int) (idx int, onAnnotation bool)` next to `cursorVisualRange` — walks `m.file.lines` summing `hunkLineHeight` (using `m.findHunks()` and `m.buildAnnotationSet()`) until the running sum crosses `row`; distinguishes annotation sub-rows from diff rows within each line
-- [ ] handle file-level annotation: when `m.hasFileAnnotation()` is true, visual row 0 maps to `idx=-1, onAnnotation=false`
-- [ ] handle edge cases: empty `m.file.lines` → return `(m.nav.diffCursor, false)`; row < 0 → return `(0, false)` (or `(-1, false)` if file-level annotation present); row exceeds total → return last valid index
-- [ ] add round-trip table test: for each cursor index `i` in a synthetic set, set `m.nav.diffCursor = i`, call `top, _ := m.cursorVisualRange()`, assert `visualRowToDiffLine(top) == (i, false)`
-- [ ] add round-trip test for annotation sub-rows: set cursor on a line with annotation, set `cursorOnAnnotation=true`, round-trip must return `(i, true)`
-- [ ] add table cases covering: file-level annotation row `i=-1`, `i=0` baseline, wrapped long lines, lines with injected annotations, collapsed-mode dividers, viewport with `YOffset > 0`
-- [ ] add direct-input tests: specific `row` values → expected `(idx, onAnnotation)` pairs in a known fixture
-- [ ] run `go test ./app/ui/...` — must pass before task 3
+- [x] add `func (m Model) visualRowToDiffLine(row int) (idx int, onAnnotation bool)` next to `cursorVisualRange` — walks `m.file.lines` summing `hunkLineHeight` (using `m.findHunks()` and `m.buildAnnotationSet()`) until the running sum crosses `row`; distinguishes annotation sub-rows from diff rows within each line
+- [x] handle file-level annotation: when `m.hasFileAnnotation()` is true, visual row 0 maps to `idx=-1, onAnnotation=false`
+- [x] handle edge cases: empty `m.file.lines` → return `(m.nav.diffCursor, false)`; row < 0 → return `(0, false)` (or `(-1, false)` if file-level annotation present); row exceeds total → return last valid index
+- [x] add round-trip table test: for each cursor index `i` in a synthetic set, set `m.nav.diffCursor = i`, call `top, _ := m.cursorVisualRange()`, assert `visualRowToDiffLine(top) == (i, false)`
+- [x] add round-trip test for annotation sub-rows: set cursor on a line with annotation, set `cursorOnAnnotation=true`, round-trip must return `(i, true)`
+- [x] add table cases covering: file-level annotation row `i=-1`, `i=0` baseline, wrapped long lines, lines with injected annotations, collapsed-mode dividers, viewport with `YOffset > 0`
+- [x] add direct-input tests: specific `row` values → expected `(idx, onAnnotation)` pairs in a known fixture
+- [x] run `go test ./app/ui/...` — must pass before task 3
 
 ### Task 3: Add `SelectByVisibleRow` on FileTree and TOC
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -360,17 +360,17 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 - Modify: `plugins/codex/skills/revdiff/references/config.md`
 - Modify: `plugins/codex/skills/revdiff/references/usage.md`
 
-- [ ] README: add a "Mouse support" subsection covering wheel, click-to-select in tree, click-to-set-cursor in diff, Shift+wheel half-page, `--no-mouse` opt-out
-- [ ] README: add explicit text-selection note in that subsection — something like: "Text selection requires Shift+drag (most terminals) or Option+drag (iTerm2). Because the tree pane is rendered alongside the diff on the same rows, multi-line Shift+drag will include tree content. For clean copies of diff text, use your terminal's block-select mode: Option+drag in iTerm2, Ctrl+Shift+drag in kitty, or run with `--no-mouse` to disable mouse capture entirely."
-- [ ] README: add `--no-mouse` to the flags table (placement consistent with `--no-colors`, `--no-status-bar`)
-- [ ] `site/docs.html`: mirror README Mouse section and flag entry (including the text-selection note)
-- [ ] `docs/ARCHITECTURE.md`: add one paragraph under the `app/ui/` description noting the new `mouse.go` file and its role (hit-testing + event routing), matching the file-by-file breakdown style
-- [ ] `.claude-plugin/skills/revdiff/references/config.md`: add `--no-mouse` / `REVDIFF_NO_MOUSE` to config options
-- [ ] `.claude-plugin/skills/revdiff/references/usage.md`: add mouse interactions (wheel, click) to the interactions list, plus the Shift+drag / block-select note
-- [ ] `plugins/codex/skills/revdiff/references/config.md`: byte-identical copy of the claude-plugin version
-- [ ] `plugins/codex/skills/revdiff/references/usage.md`: byte-identical copy of the claude-plugin version
-- [ ] verify byte-identity: `diff -q .claude-plugin/skills/revdiff/references/config.md plugins/codex/skills/revdiff/references/config.md` and same for usage.md — both must produce no output
-- [ ] no test changes needed (documentation task)
+- [x] README: add a "Mouse support" subsection covering wheel, click-to-select in tree, click-to-set-cursor in diff, Shift+wheel half-page, `--no-mouse` opt-out
+- [x] README: add explicit text-selection note in that subsection — something like: "Text selection requires Shift+drag (most terminals) or Option+drag (iTerm2). Because the tree pane is rendered alongside the diff on the same rows, multi-line Shift+drag will include tree content. For clean copies of diff text, use your terminal's block-select mode: Option+drag in iTerm2, Ctrl+Shift+drag in kitty, or run with `--no-mouse` to disable mouse capture entirely."
+- [x] README: add `--no-mouse` to the flags table (placement consistent with `--no-colors`, `--no-status-bar`)
+- [x] `site/docs.html`: mirror README Mouse section and flag entry (including the text-selection note)
+- [x] `docs/ARCHITECTURE.md`: add one paragraph under the `app/ui/` description noting the new `mouse.go` file and its role (hit-testing + event routing), matching the file-by-file breakdown style
+- [x] `.claude-plugin/skills/revdiff/references/config.md`: add `--no-mouse` / `REVDIFF_NO_MOUSE` to config options
+- [x] `.claude-plugin/skills/revdiff/references/usage.md`: add mouse interactions (wheel, click) to the interactions list, plus the Shift+drag / block-select note
+- [x] `plugins/codex/skills/revdiff/references/config.md`: byte-identical copy of the claude-plugin version
+- [x] `plugins/codex/skills/revdiff/references/usage.md`: byte-identical copy of the claude-plugin version
+- [x] verify byte-identity: `diff -q .claude-plugin/skills/revdiff/references/config.md plugins/codex/skills/revdiff/references/config.md` and same for usage.md — both must produce no output
+- [x] no test changes needed (documentation task)
 
 *Note: CHANGELOG.md is updated at release-tag time (see commit pattern `c564016 docs: update changelog, site, and plugin versions for v0.22.0` — changelog updates land with version bumps, not with feature PRs). Do not modify CHANGELOG.md in this task.*
 

--- a/docs/plans/20260422-mouse-support.md
+++ b/docs/plans/20260422-mouse-support.md
@@ -1,0 +1,424 @@
+# Mouse Support (Option B)
+
+## Overview
+
+Add mouse support to revdiff covering scroll-wheel in both panes and left-click on the file tree and diff lines. Today revdiff does not enable mouse tracking at all — what "works" in kitty is the terminal translating wheel events into cursor keys while alt-screen mouse reporting is off. iTerm2 and several other terminals do not translate, so users see inconsistent behavior.
+
+This plan enables `tea.WithMouseCellMotion()` and routes `tea.MouseMsg` events through a new `handleMouse` handler. After this work:
+
+- Scroll wheel scrolls whichever pane the cursor is over (diff or tree).
+- Left-click on a tree entry focuses the tree and selects/loads that entry — same as pressing j/k to land there.
+- Left-click on a diff line focuses the diff pane and moves the cursor to that line — enabling "click, then `a` to annotate".
+- Shift+wheel scrolls by half-page.
+- `--no-mouse` / `REVDIFF_NO_MOUSE` opts out entirely, for users who lean heavily on terminal-native text-selection.
+
+Out of scope: clickable status-bar segments, overlay item clicks, right-click menus, drag selection, middle-click paste, click on horizontal scroll indicators, per-column semantics (blame/line-number).
+
+## Context (from discovery)
+
+- **Bubble Tea setup**: `app/main.go:104` currently uses `tea.WithAltScreen()` only. Mouse is opt-in via `tea.WithMouseCellMotion()` (button events + motion while pressed, no hover flood).
+- **Update loop**: `app/ui/model.go:662` — `Update()` switches on `tea.KeyMsg`, `tea.WindowSizeMsg`, and the project's own `*Msg` types. No `tea.MouseMsg` case today; any mouse event is silently dropped.
+- **Pane focus model already exists**: `pane` iota with `paneTree` and `paneDiff` at `app/ui/model.go:212`. `Model.layout.focus` tracks current pane. `togglePane()` (model.go:898) flips focus — re-usable by the mouse path.
+- **Layout math**: `app/ui/view.go` — tree width is `m.layout.treeWidth`, diff width is `m.layout.width - m.layout.treeWidth - 4`. Tree is hidden when `m.layout.treeHidden` or `m.file.singleFile && m.file.mdTOC == nil`.
+- **Tree navigation reuse**: `app/ui/diffnav.go:468` `handleTreeNav` calls `m.tree.Move(...)` then `m.loadSelectedIfChanged()` — any mouse-driven tree selection reuses the same load path.
+- **FileTree API**: `app/ui/sidepane/filetree.go` exposes `Move`, `SelectByPath`, `SelectedFile`, with internal `cursor int` and `offset int`. No `SelectByVisibleRow` yet — needs adding.
+- **Cursor-line math**: `app/ui/diffnav.go` has `cursorVisualRange(idx)` (forward: diff-line → visual-row range) and `hunkLineHeight(i, hunks, annSet)` (height of one diff line including wrap + annotations). Inverse mapping (visual-row → diff-line) does not exist and must be added.
+- **Modal states that must swallow mouse**: `m.annot.annotating`, `m.search.active`, `m.reload.pending`, `m.inConfirmDiscard`, and any open overlay via `m.overlay.Manager`.
+- **Existing no-* flags pattern**: `app/config.go:23-25` — `NoColors`, `NoStatusBar`, `NoConfirmDiscard` all use `long:"no-foo" ini-name:"no-foo" env:"REVDIFF_NO_FOO"` — `NoMouse` follows the same shape.
+- **Docs sync locations** (per project memory): `README.md`, `site/docs.html`, `.claude-plugin/skills/revdiff/references/{config,usage}.md`, `plugins/codex/skills/revdiff/references/{config,usage}.md` (byte-identical copy of the claude-plugin versions).
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests). The design was already validated in brainstorm; TDD is lower-value here because the routing skeleton is nearly mechanical and the interesting invariant (visual-row ↔ diff-line round-trip) benefits from property-style tests written against the finished implementation.
+- Complete each task fully before moving to the next.
+- **CRITICAL: every task MUST include new/updated tests** — tests for routing, hit-testing, round-trip mapping, and modal-state swallowing are non-negotiable.
+- **CRITICAL: all tests must pass before starting the next task**.
+- Maintain backward compatibility — default behavior when `--no-mouse` is not set is unchanged from the user's perspective *except* that wheel now works consistently and tree/diff are clickable.
+- After each change, run: `go test ./...`, `golangci-lint run`, and `~/.claude/format.sh`.
+
+## Testing Strategy
+
+- **Unit tests**: required for every task. Tests for `hitTest`, `visualRowToDiffLine`, `handleMouse` routing (all pane × button combinations), modal-state swallowing, and `--no-mouse` config wiring.
+- **No e2e tests**: revdiff has no Playwright/headless-TUI harness. Mouse events are constructed as `tea.MouseMsg` values in-process, which is the existing test idiom for `tea.KeyMsg` cases. Manual verification against kitty, iTerm2, Ghostty, and tmux is part of Post-Completion.
+- **Round-trip property test**: for a set of synthetic `diffLines` (with wraps, annotations, collapsed-mode dividers), assert `visualRowToDiffLine(cursorVisualRange(i).top) == i` for every valid `i`. This is the highest-value test — inverse mapping bugs would be the most common failure mode.
+
+## Solution Overview
+
+**Architecture:**
+
+1. Program-level: `app/main.go` appends `tea.WithMouseCellMotion()` to `programOptions` unless `opts.NoMouse` is true.
+2. Model-level: `Model.Update()` gains a `tea.MouseMsg` case that calls `m.handleMouse(msg)`.
+3. New package-local file `app/ui/mouse.go` owns: `handleMouse`, `hitTest`, `hitZone` type, and routing helpers. Keeps `model.go` from growing (file-by-concern convention).
+4. New method `m.visualRowToDiffLine(row int) int` lives in `app/ui/diffnav.go` next to `cursorVisualRange` — keeps forward and inverse mapping side-by-side so any future layout change touches both.
+5. New method `ft.SelectByVisibleRow(row, topOffset int) bool` on `*sidepane.FileTree` maps a screen row to an entry index using its internal `offset`.
+
+**Event dispatch flow inside `handleMouse`:**
+
+```
+# clear transient hints first, mirroring handleKey at model.go:704-706
+m.commits.hint = ""; m.reload.hint = ""; m.compact.hint = ""
+
+if m.inConfirmDiscard || m.reload.pending || m.annot.annotating || m.search.active:
+    return m, nil                             # swallow, do nothing
+if m.overlay.HasOpen():
+    return m, nil                             # swallow, do not forward wheel to diff
+switch msg.Button:
+case wheelUp/wheelDown:
+    step := wheelStep; if msg.Shift { step = viewport.Height/2 }
+    route to pane under (msg.X, msg.Y)
+case wheelLeft/wheelRight:
+    return m, nil                             # intentionally swallowed — horizontal scroll stays keyboard-driven
+case left press (msg.Action == MouseActionPress only — skip release/motion):
+    route to pane under (msg.X, msg.Y)
+default:                                      # right, middle, back, forward, release, motion
+    swallow
+```
+
+**Wheel step constant**: `const wheelStep = 3` (unexported) in `mouse.go`. Matches standard terminal feel (3 lines per notch). Shift+wheel uses `viewport.Height/2` to mirror half-page keyboard shortcut.
+
+**Single-click on tree loads file immediately**: confirmed by reading `diffnav.go:468-502` — `handleTreeNav` always calls `loadSelectedIfChanged()` after every cursor move. Click reuses the same path, so single-click == j-to-land behavior. No double-click state machine needed.
+
+**Click on directory row in tree**: cursor moves there (matches j landing on a directory); `SelectedFile()` returns empty for dirs, so `loadSelectedIfChanged` becomes a no-op. Same outcome as j.
+
+**Text-selection trade-off**: once mouse tracking is on, plain drag is captured by revdiff. Users must hold Shift (most terminals) or Option (iTerm2) for terminal-native text selection. Documented in README; `--no-mouse` is the escape hatch.
+
+## Technical Details
+
+### `tea.MouseMsg` shape (Bubble Tea v1)
+
+```go
+type MouseMsg MouseEvent
+type MouseEvent struct {
+    X, Y   int
+    Shift  bool
+    Alt    bool
+    Ctrl   bool
+    Action MouseAction   // Press / Release / Motion
+    Button MouseButton   // None / Left / Middle / Right / WheelUp / WheelDown / WheelLeft / WheelRight / Back / Forward
+    Type   MouseEventType // legacy
+}
+```
+
+Use `msg.Button` and `msg.Action` for dispatch; use `msg.Shift` for half-page wheel; use `msg.X/Y` for hit-testing. Ignore `Alt`/`Ctrl` for this pass.
+
+### Hit-zone classification
+
+```go
+type hitZone int
+const (
+    hitNone   hitZone = iota   // outside any interactive area
+    hitTree                    // in tree pane (or TOC pane when mdTOC active)
+    hitDiff                    // in diff pane (body, not header)
+    hitStatus                  // in status bar rows
+    hitHeader                  // in diff header (file path row) — currently no-op
+)
+
+func (m Model) hitTest(x, y int) hitZone {
+    if y >= m.layout.height - m.statusBarHeight() { return hitStatus }
+    if y < m.diffTopRow() { return hitHeader }
+
+    treeVisible := !m.layout.treeHidden && (!m.file.singleFile || m.file.mdTOC != nil)
+    if treeVisible && x < m.layout.treeWidth { return hitTree }
+    if x < m.layout.width { return hitDiff }
+    return hitNone
+}
+```
+
+Three layout helpers on `Model` (all unexported, pure reads of `m.layout.*`):
+
+- `statusBarHeight() int` — 0 when `m.NoStatusBar`, 1 otherwise. Check if a similar helper already exists — reuse if present.
+- `diffTopRow() int` — first row of diff viewport content (accounts for diff header row).
+- `treeTopRow() int` — first row of tree content (accounts for any pane border from `renderTwoPaneLayout`). Derived from the same layout math that produces the rendered output, not hardcoded — verified against `view.go` rendering.
+
+Unit-testable in isolation — pure arithmetic, no I/O.
+
+### Inverse mapping `visualRowToDiffLine`
+
+Returns both the diff-line index and whether the target row is an annotation sub-row (so the caller can set `m.annot.cursorOnAnnotation` consistently with keyboard navigation at `diffnav.go:28-46`).
+
+```go
+// visualRowToDiffLine returns the diff-line index whose rendered rows contain
+// the given visual row (0 = first visible row of viewport content), and whether
+// the row falls on an annotation sub-line rather than the diff line itself.
+// Returns the current cursor if row is out of bounds.
+func (m Model) visualRowToDiffLine(row int) (idx int, onAnnotation bool) {
+    if len(m.file.lines) == 0 { return m.nav.diffCursor, false }
+
+    hunks := m.findHunks()
+    annSet := m.buildAnnotationSet()
+    running := 0
+
+    // file-level annotation occupies visual row 0 at logical index -1
+    // (see moveDiffCursorToStart at diffnav.go:172 and hasFileAnnotation at annotate.go:331)
+    if m.hasFileAnnotation() {
+        if row < 1 { return -1, false }
+        running = 1
+    }
+
+    for i := 0; i < len(m.file.lines); i++ {
+        h := m.hunkLineHeight(i, hunks, annSet)   // total visual rows (diff line + injected annotation rows)
+        if row < running + h {
+            // if row falls on an annotation sub-row (row >= running + diffLineHeight)
+            // we need to distinguish. hunkLineHeight = diffLineRows + annotationRows.
+            diffRows := h - m.annotationRowsFor(i, annSet)  // helper: 0 if no annotation, else N rows
+            if row >= running + diffRows {
+                return i, true
+            }
+            return i, false
+        }
+        running += h
+    }
+    return len(m.file.lines) - 1, false
+}
+```
+
+Called with `row = (y - m.diffTopRow()) + m.layout.viewport.YOffset` where `diffTopRow()` is a new helper returning the first row of the diff viewport content (header offset).
+
+**Round-trip invariant** (tested in Task 2):
+
+```go
+// for each valid cursor position i, cursorVisualRange must round-trip through
+// the inverse mapping. cursorVisualRange takes no args; it reads m.nav.diffCursor.
+m.nav.diffCursor = i
+top, _ := m.cursorVisualRange()
+idx, _ := m.visualRowToDiffLine(top)
+assert.Equal(t, i, idx)
+```
+
+Test cases must cover: `i=-1` (file-level annotation), `i=0`, wrapped long lines, lines with injected annotations (annotation sub-row round-trip), collapsed-mode dividers, viewport with `YOffset > 0`.
+
+### Tree row → entry index
+
+```go
+// SelectByVisibleRow sets the cursor to the entry at the given visible row.
+// row is 0-based relative to the first visible tree line. Returns true if the
+// row maps to a valid entry.
+func (ft *FileTree) SelectByVisibleRow(row int) bool {
+    idx := ft.offset + row
+    if idx < 0 || idx >= len(ft.entries) { return false }
+    ft.cursor = idx
+    return true
+}
+```
+
+Click wrapper on `Model`:
+
+```go
+func (m Model) clickTree(x, y int) (tea.Model, tea.Cmd) {
+    row := y - m.treeTopRow()
+    m.layout.focus = paneTree
+    if m.file.mdTOC != nil {
+        if !m.file.mdTOC.SelectByVisibleRow(row) { return m, nil }
+    } else if !m.tree.SelectByVisibleRow(row) {
+        return m, nil
+    }
+    m.pendingAnnotJump = nil
+    m.nav.pendingHunkJump = nil
+    return m.loadSelectedIfChanged()
+}
+
+func (m Model) clickDiff(x, y int) (tea.Model, tea.Cmd) {
+    row := (y - m.diffTopRow()) + m.layout.viewport.YOffset
+    idx, onAnnot := m.visualRowToDiffLine(row)
+    m.layout.focus = paneDiff
+    m.nav.diffCursor = idx
+    m.annot.cursorOnAnnotation = onAnnot
+    m.syncViewportToCursor()
+    return m, nil
+}
+```
+
+**Wheel-by-N in tree**: use the existing page-motion mechanism — `m.tree.Move(sidepane.MotionPageDown, wheelStep)` / `MotionPageUp` already move the cursor by N entries (see `pageDown(n)` at `filetree.go:488`). No new motion needed, no loop required. Shift+wheel passes `m.treePageSize()/2` for half-page feel consistent with half-page-down keybinding.
+
+### `--no-mouse` flag
+
+```go
+// app/config.go
+NoMouse bool `long:"no-mouse" ini-name:"no-mouse" env:"REVDIFF_NO_MOUSE" description:"disable mouse support (scroll wheel, click)"`
+```
+
+```go
+// app/main.go
+programOptions := []tea.ProgramOption{tea.WithAltScreen()}
+if !opts.NoMouse {
+    programOptions = append(programOptions, tea.WithMouseCellMotion())
+}
+```
+
+`--dump-config` will include the field automatically via the existing INI serialization.
+
+### `--no-mouse` is honored at the program-option layer
+
+Rationale: if mouse tracking is never enabled, the terminal never emits mouse escape sequences, so `handleMouse` is never called. No runtime branch needed inside `handleMouse`. Simpler and makes text-selection-for-copy work without Shift.
+
+### TOC pane handling
+
+When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in that slot should route to the TOC (analogous `mdTOC.SelectByVisibleRow` — add to `app/ui/sidepane/toc.go`). Otherwise routes to the file tree. This is a direct mirror of `handleTreeNav`'s `if m.file.mdTOC != nil { return m.handleTOCNav(msg) }` branch.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): code, tests, docs sync. Everything that can be verified locally.
+- **Post-Completion** (no checkboxes): manual terminal verification (kitty, iTerm2, Ghostty, tmux, Zellij), since we cannot test mouse behavior in CI.
+
+## Implementation Steps
+
+### Task 1: Add `NoMouse` config flag + wire program option
+
+**Files:**
+- Modify: `app/config.go`
+- Modify: `app/main.go`
+- Modify: `app/config_test.go` (add flag-parsing assertion)
+
+- [ ] add `NoMouse bool` field to `Options` in `app/config.go` following `NoColors`/`NoStatusBar` convention (CLI flag, ini-name, env var, description)
+- [ ] in `app/main.go` conditionally append `tea.WithMouseCellMotion()` to `programOptions` when `!opts.NoMouse`
+- [ ] add flag-parsing test: `--no-mouse` sets `Options.NoMouse=true`; env var `REVDIFF_NO_MOUSE=true` sets it; default is false
+- [ ] verify `--dump-config` output includes `no-mouse = false` by default (spot-check via existing dump-config test pattern)
+- [ ] run `go test ./...` — must pass before task 2
+
+*Note: bubbletea `ProgramOption` is an opaque function value — testing its presence in a `[]tea.ProgramOption` slice is impractical. Program wiring is covered by the manual terminal verification in Post-Completion.*
+
+### Task 2: Add `visualRowToDiffLine` inverse mapping
+
+**Files:**
+- Modify: `app/ui/diffnav.go` (or `app/ui/annotate.go` — put it next to `cursorVisualRange` wherever that lives; currently `annotate.go:477`)
+- Modify: `app/ui/diffnav_test.go` or corresponding test file (match location of implementation)
+
+- [ ] add `func (m Model) visualRowToDiffLine(row int) (idx int, onAnnotation bool)` next to `cursorVisualRange` — walks `m.file.lines` summing `hunkLineHeight` (using `m.findHunks()` and `m.buildAnnotationSet()`) until the running sum crosses `row`; distinguishes annotation sub-rows from diff rows within each line
+- [ ] handle file-level annotation: when `m.hasFileAnnotation()` is true, visual row 0 maps to `idx=-1, onAnnotation=false`
+- [ ] handle edge cases: empty `m.file.lines` → return `(m.nav.diffCursor, false)`; row < 0 → return `(0, false)` (or `(-1, false)` if file-level annotation present); row exceeds total → return last valid index
+- [ ] add round-trip table test: for each cursor index `i` in a synthetic set, set `m.nav.diffCursor = i`, call `top, _ := m.cursorVisualRange()`, assert `visualRowToDiffLine(top) == (i, false)`
+- [ ] add round-trip test for annotation sub-rows: set cursor on a line with annotation, set `cursorOnAnnotation=true`, round-trip must return `(i, true)`
+- [ ] add table cases covering: file-level annotation row `i=-1`, `i=0` baseline, wrapped long lines, lines with injected annotations, collapsed-mode dividers, viewport with `YOffset > 0`
+- [ ] add direct-input tests: specific `row` values → expected `(idx, onAnnotation)` pairs in a known fixture
+- [ ] run `go test ./app/ui/...` — must pass before task 3
+
+### Task 3: Add `SelectByVisibleRow` on FileTree and TOC
+
+**Files:**
+- Modify: `app/ui/sidepane/filetree.go`
+- Modify: `app/ui/sidepane/filetree_test.go`
+- Modify: `app/ui/sidepane/toc.go`
+- Modify: `app/ui/sidepane/toc_test.go`
+
+- [ ] add `func (ft *FileTree) SelectByVisibleRow(row int) bool` — returns true if row maps to a valid entry, updates `ft.cursor` to `ft.offset + row`
+- [ ] add equivalent `SelectByVisibleRow` on `*TOC` (same signature)
+- [ ] tests for `FileTree`: click on first visible row when `offset=0` selects entry 0; click when scrolled (`offset=5`) selects `offset+row`; click past end returns false and does not modify cursor; click on directory row succeeds (cursor moves to dir entry); click on negative row returns false
+- [ ] tests for `TOC`: mirror the above
+- [ ] run `go test ./app/ui/sidepane/...` — must pass before task 4
+
+### Task 4: Add `hitTest` and `hitZone` classification + layout helpers
+
+**Files:**
+- Create: `app/ui/mouse.go`
+- Create: `app/ui/mouse_test.go`
+- Potentially Modify: `app/ui/model.go` or `app/ui/view.go` (for layout helpers, if they don't already exist)
+
+- [ ] check existing code for `statusBarHeight`, `diffTopRow`, `treeTopRow` helpers — reuse if present, otherwise add as methods on `Model` near other layout methods
+- [ ] `statusBarHeight() int` returns 0 when `m.NoStatusBar`, otherwise the actual number of rows (typically 1)
+- [ ] `diffTopRow() int` returns the first row of diff viewport content (after diff header). Derive from the same math that `view.go` uses to render
+- [ ] `treeTopRow() int` returns the first row of tree content (after any pane border). Derive from the same math that `renderTwoPaneLayout` uses
+- [ ] declare `hitZone` type and constants (`hitNone`, `hitTree`, `hitDiff`, `hitStatus`, `hitHeader`) in `app/ui/mouse.go`
+- [ ] implement `func (m Model) hitTest(x, y int) hitZone` using the three helpers above — pure arithmetic, no I/O
+- [ ] unit test table for `hitTest`: tree visible/hidden, single-file without TOC, single-file with TOC, no-status-bar, stdin-mode (tree hidden by default), `(x=treeWidth-1, y)` → `hitTree`, `(x=treeWidth, y)` → `hitDiff`, `y=0` → `hitHeader`, `y=last` → `hitStatus`, `x=width` → `hitNone` (out of bounds)
+- [ ] unit tests for `statusBarHeight`, `diffTopRow`, `treeTopRow` covering status bar on/off and single-file vs two-pane layout
+- [ ] run `go test ./app/ui/...` — must pass before task 5
+
+### Task 5: Implement `handleMouse` routing with wheel + left-click
+
+**Files:**
+- Modify: `app/ui/mouse.go`
+- Modify: `app/ui/model.go` (add `tea.MouseMsg` case in `Update`)
+- Modify: `app/ui/mouse_test.go`
+
+- [ ] add `tea.MouseMsg` case in `Model.Update` at `app/ui/model.go:662` → delegates to `m.handleMouse(msg)`
+- [ ] at top of `handleMouse`, clear transient hints mirroring `handleKey` at `model.go:704-706`: `m.commits.hint = ""`, `m.reload.hint = ""`, `m.compact.hint = ""`
+- [ ] implement swallow checks in the order specified in Solution Overview (`inConfirmDiscard`, `reload.pending`, `annot.annotating`, `search.active`, overlay-open via `m.overlay` check) — all return `m, nil`
+- [ ] dispatch by `msg.Button`:
+  - wheel up/down: compute `step := wheelStep` (const 3); when `msg.Shift`, use `m.layout.viewport.Height/2`; hit-test `(msg.X, msg.Y)`; route to `m.moveDiffCursorDownBy(step)`/`UpBy(step)` for `hitDiff`, `m.tree.Move(sidepane.MotionPageDown, step)` / `MotionPageUp` for `hitTree`, analogous `m.file.mdTOC.Move(MotionPageDown/Up, step)` when TOC active, no-op for `hitStatus`/`hitHeader`/`hitNone`
+  - wheel left/right: return `m, nil` (intentionally swallowed)
+  - left press (only `msg.Action == tea.MouseActionPress` — skip release/motion): invoke `clickTree` or `clickDiff` based on hit-zone (helpers set focus themselves)
+  - any other button or action: return `m, nil`
+- [ ] implement `clickDiff(x, y int)` helper as shown in Technical Details: uses `visualRowToDiffLine` two-return, sets `m.annot.cursorOnAnnotation` to the `onAnnotation` flag, calls `syncViewportToCursor`, sets `m.layout.focus = paneDiff`
+- [ ] implement `clickTree(x, y int)` helper as shown in Technical Details: routes to `m.file.mdTOC.SelectByVisibleRow` when mdTOC active, else `m.tree.SelectByVisibleRow`; clears pending jumps; calls `loadSelectedIfChanged`; sets focus
+- [ ] wheel tests: wheel in diff pane → cursor moves 3 lines; shift+wheel in diff → cursor moves `viewport.Height/2`; wheel in tree pane → tree cursor moves 3; wheel in tree with focus on diff → tree cursor still moves (routing is by cursor-position, not by current focus); wheel in TOC pane (markdown file, full-context) → TOC cursor moves; wheel-left / wheel-right → no-op
+- [ ] click tests: click in diff at row N → `diffCursor` lands on matching diff-line, `cursorOnAnnotation` set correctly; click on annotation sub-row sets `cursorOnAnnotation=true`; click in tree → tree selection changes + file load triggered; click on directory entry in tree → cursor moves but no file load; click in TOC pane (mdTOC active) → TOC selection changes; click in status zone → no-op; click in diff header → no-op; click in out-of-bounds zone → no-op
+- [ ] button filter tests: right-click → no-op; middle-click → no-op; left release (no press) → no-op; mouse motion → no-op; back/forward buttons → no-op
+- [ ] modal swallow tests: wheel while annotating → no-op; click while annotating → no-op, annotation input unchanged; wheel while overlay open → no-op, overlay stays open; click while overlay open → no-op; wheel while search active → no-op; click while `reload.pending` → no-op; click while `inConfirmDiscard` → no-op
+- [ ] hint-clearing test: wheel event with `m.commits.hint="loading commits..."` — after handler, hint is empty
+- [ ] focus side-effect tests: click in tree while focused on diff → `layout.focus == paneTree`; click in diff while focused on tree → `layout.focus == paneDiff`
+- [ ] stdin-mode test: tree is hidden in stdin mode; click at `(x=0, y=1)` → `hitDiff`, not `hitTree`; wheel and click behave as diff-only
+- [ ] run `go test ./app/ui/...` — must pass before task 6
+
+### Task 6: Documentation sync (README + site + ARCHITECTURE + plugin references)
+
+**Files:**
+- Modify: `README.md`
+- Modify: `site/docs.html`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `.claude-plugin/skills/revdiff/references/config.md`
+- Modify: `.claude-plugin/skills/revdiff/references/usage.md`
+- Modify: `plugins/codex/skills/revdiff/references/config.md`
+- Modify: `plugins/codex/skills/revdiff/references/usage.md`
+
+- [ ] README: add a "Mouse support" subsection covering wheel, click-to-select in tree, click-to-set-cursor in diff, Shift+wheel half-page, `--no-mouse` opt-out
+- [ ] README: add explicit text-selection note in that subsection — something like: "Text selection requires Shift+drag (most terminals) or Option+drag (iTerm2). Because the tree pane is rendered alongside the diff on the same rows, multi-line Shift+drag will include tree content. For clean copies of diff text, use your terminal's block-select mode: Option+drag in iTerm2, Ctrl+Shift+drag in kitty, or run with `--no-mouse` to disable mouse capture entirely."
+- [ ] README: add `--no-mouse` to the flags table (placement consistent with `--no-colors`, `--no-status-bar`)
+- [ ] `site/docs.html`: mirror README Mouse section and flag entry (including the text-selection note)
+- [ ] `docs/ARCHITECTURE.md`: add one paragraph under the `app/ui/` description noting the new `mouse.go` file and its role (hit-testing + event routing), matching the file-by-file breakdown style
+- [ ] `.claude-plugin/skills/revdiff/references/config.md`: add `--no-mouse` / `REVDIFF_NO_MOUSE` to config options
+- [ ] `.claude-plugin/skills/revdiff/references/usage.md`: add mouse interactions (wheel, click) to the interactions list, plus the Shift+drag / block-select note
+- [ ] `plugins/codex/skills/revdiff/references/config.md`: byte-identical copy of the claude-plugin version
+- [ ] `plugins/codex/skills/revdiff/references/usage.md`: byte-identical copy of the claude-plugin version
+- [ ] verify byte-identity: `diff -q .claude-plugin/skills/revdiff/references/config.md plugins/codex/skills/revdiff/references/config.md` and same for usage.md — both must produce no output
+- [ ] no test changes needed (documentation task)
+
+*Note: CHANGELOG.md is updated at release-tag time (see commit pattern `c564016 docs: update changelog, site, and plugin versions for v0.22.0` — changelog updates land with version bumps, not with feature PRs). Do not modify CHANGELOG.md in this task.*
+
+### Task 7: Plugin version bumps (ask user first)
+
+**Files:**
+- Potentially modify: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `package.json`
+
+- [ ] per project memory "plugin-version-bump": ask user whether to bump Claude plugin version (both `plugin.json` and `marketplace.json`) after modifying `.claude-plugin/skills/revdiff/references/*.md`
+- [ ] ask user whether to bump pi plugin version in `package.json` after modifying `plugins/pi/` (only if any pi files changed — this task does not modify pi by default, so likely no-op)
+- [ ] no test changes needed
+
+### Task 8: Verify acceptance criteria
+
+- [ ] verify scroll wheel works in both panes (automated test via `tea.MouseMsg` in Task 5 — re-run here)
+- [ ] verify click in tree selects + loads file
+- [ ] verify click in diff sets cursor, enabling "click then `a`" annotation flow
+- [ ] verify modal-state swallow: no mouse interference during annotation, search, pending-reload, confirm-discard, or any open overlay
+- [ ] verify `--no-mouse` compiles, runs, and disables all mouse behavior (unit test from Task 1)
+- [ ] run full test suite: `go test ./...`
+- [ ] run `go test -race ./...`
+- [ ] run `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0`
+- [ ] run `~/.claude/format.sh`
+- [ ] verify test coverage did not regress (`make test`)
+
+### Task 9: Final documentation wrap-up
+
+**Files:**
+- Potentially modify: `CLAUDE.md`
+
+- [ ] update `CLAUDE.md` Gotchas section ONLY if implementation revealed a non-obvious nesting or coordinate issue (e.g., mouse X/Y vs wrapped-ANSI rendering quirk). Otherwise skip — the code is discoverable and a gotcha note would be noise.
+- [ ] move this plan to `docs/plans/completed/`
+- [ ] no test changes needed
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems — no checkboxes, informational only.*
+
+**Manual terminal verification** (CI cannot test mouse escape sequences):
+
+- **kitty**: wheel in both panes, click in tree, click in diff, Shift+wheel half-page, `--no-mouse` text-selection
+- **iTerm2**: same scenarios (this is the terminal the bug report mentioned — verify scroll now works consistently)
+- **Ghostty**: same scenarios
+- **Alacritty**: same scenarios
+- **tmux with `mouse on`** and with `mouse off`: verify behavior in both, confirm the README note about `set -g mouse on`
+- **Zellij floating pane**: same scenarios
+- **SSH into a remote box** (iTerm2 → ssh → revdiff): verify mouse tracking still works — some SSH + tmux combos drop the escape sequences. If broken, recommend `--no-mouse` via env var.
+
+**Text-selection trade-off communication**: the README change documents the Shift-select requirement. If user reports friction, consider whether the default should flip to `mouse off` — but the memory of "text selection captured by default" across other TUIs (vim, htop, lazygit) argues against that.
+
+**Release notes**: when cutting the next revdiff release, mention mouse support as a headline feature plus the `--no-mouse` opt-out in CHANGELOG.md and the site hero badge.

--- a/docs/plans/completed/20260422-mouse-support.md
+++ b/docs/plans/completed/20260422-mouse-support.md
@@ -401,9 +401,9 @@ When `m.file.mdTOC != nil`, the tree pane slot renders the TOC instead. Click in
 **Files:**
 - Potentially modify: `CLAUDE.md`
 
-- [ ] update `CLAUDE.md` Gotchas section ONLY if implementation revealed a non-obvious nesting or coordinate issue (e.g., mouse X/Y vs wrapped-ANSI rendering quirk). Otherwise skip — the code is discoverable and a gotcha note would be noise.
-- [ ] move this plan to `docs/plans/completed/`
-- [ ] no test changes needed
+- [x] update `CLAUDE.md` Gotchas section ONLY if implementation revealed a non-obvious nesting or coordinate issue (e.g., mouse X/Y vs wrapped-ANSI rendering quirk). Otherwise skip — the code is discoverable and a gotcha note would be noise. *(skipped: coordinate math is encapsulated in `diffTopRow`/`treeTopRow`/`hitTest` with comments explaining the magic numbers; no quirk worth a gotcha)*
+- [x] move this plan to `docs/plans/completed/`
+- [x] no test changes needed
 
 ## Post-Completion
 

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -31,6 +31,7 @@ Then uncomment and edit the values you want to change.
 | `--blame` | `REVDIFF_BLAME` | Show blame gutter on startup | `false` |
 | `--word-diff` | `REVDIFF_WORD_DIFF` | Highlight intra-line word-level changes in paired add/remove lines | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
+| `--no-mouse` | `REVDIFF_NO_MOUSE` | Disable mouse support (scroll wheel, click) | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
 | `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/` | |
 | `--dump-theme` | | Print currently resolved colors as theme file and exit | |

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -148,6 +148,28 @@ The status bar shows a fixed row of mode indicators on the right side. All slots
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.
 
+## Mouse Support
+
+revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.
+
+- **Scroll wheel** — scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.
+- **Shift+scroll** — half-page scroll in whichever pane the cursor is over.
+- **Left-click in the tree** — focuses the tree and selects/loads the clicked entry. Clicking a directory row moves the cursor but does not load a file.
+- **Left-click in the diff** — focuses the diff and moves the cursor to the clicked line. Enables a "click, then `a`" annotation flow.
+- **Left-click in the TOC pane** (single-file markdown) — focuses the TOC and selects the clicked header.
+
+Horizontal wheel, right-click, middle-click, drag selection, and clicks on the status bar or diff header are intentionally ignored. Modal states (annotation input, search input, confirm discard, reload confirm, open overlay) swallow mouse events so they cannot interfere with text entry or popups.
+
+**Text selection trade-off** — once mouse tracking is on, plain drag is captured by revdiff. For terminal-native text selection:
+
+- **kitty**: hold `Ctrl+Shift` while dragging
+- **iTerm2**: hold `Option` while dragging
+- **most other terminals**: hold `Shift` while dragging
+
+Because the tree pane is rendered alongside the diff on the same rows, multi-line Shift+drag will include tree content. For clean copies of diff text, use your terminal's block-select mode (Option+drag in iTerm2, Ctrl+Shift+drag in kitty) or run with `--no-mouse` to disable mouse capture entirely.
+
+Opt out with `--no-mouse`, `REVDIFF_NO_MOUSE=true`, or `no-mouse = true` in the config file.
+
 ## Custom Keybindings
 
 All keybindings can be customized via `~/.config/revdiff/keybindings` (override path with `--keys` or `REVDIFF_KEYS`).

--- a/site/docs.html
+++ b/site/docs.html
@@ -80,6 +80,7 @@
         <a href="#annotations">Annotations</a>
         <a href="#view">View toggles</a>
         <a href="#status-bar-icons">Status bar icons</a>
+        <a href="#mouse-support">Mouse support</a>
         <a href="#custom-keys">Custom keybindings</a>
 
         <h4>Claude Code plugin</h4>
@@ -336,6 +337,7 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>--line-numbers</code></td><td>Show line numbers in diff gutter</td><td><code>false</code></td></tr>
                 <tr><td><code>--word-diff</code></td><td>Highlight intra-line word-level changes in paired add/remove lines</td><td><code>false</code></td></tr>
                 <tr><td><code>--no-confirm-discard</code></td><td>Skip discard confirmation</td><td><code>false</code></td></tr>
+                <tr><td><code>--no-mouse</code></td><td>Disable mouse support (scroll wheel, click)</td><td><code>false</code></td></tr>
                 <tr><td><code>--chroma-style</code></td><td>Syntax highlighting theme</td><td><code>catppuccin-macchiato</code></td></tr>
                 <tr><td><code>--theme</code></td><td>Load color theme from <code>~/.config/revdiff/themes/</code></td><td></td></tr>
                 <tr><td><code>--dump-theme</code></td><td>Print resolved colors as theme file and exit</td><td></td></tr>
@@ -506,6 +508,25 @@ color-border = #6272a4
             </tbody>
         </table>
         <p>On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.</p>
+
+        <h2 id="mouse-support">Mouse support</h2>
+        <p>revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.</p>
+        <ul>
+            <li><strong>Scroll wheel</strong> &mdash; scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.</li>
+            <li><strong>Shift+scroll</strong> &mdash; half-page scroll in whichever pane the cursor is over.</li>
+            <li><strong>Left-click in the tree</strong> &mdash; focuses the tree and selects/loads the clicked entry (same as pressing <code>j</code>/<code>k</code> to land there). Clicking a directory row moves the cursor but does not load a file.</li>
+            <li><strong>Left-click in the diff</strong> &mdash; focuses the diff and moves the cursor to the clicked line. Enables a &ldquo;click, then <code>a</code>&rdquo; annotation flow.</li>
+            <li><strong>Left-click in the TOC pane</strong> (single-file markdown) &mdash; focuses the TOC and selects the clicked header.</li>
+        </ul>
+        <p>Horizontal wheel, right-click, middle-click, drag selection, and clicks on the status bar or diff header are intentionally ignored. Modal states (annotation input, search input, confirm discard, reload confirm, open overlay) swallow mouse events so they cannot interfere with text entry or popups.</p>
+        <p><strong>Text selection trade-off</strong> &mdash; once mouse tracking is on, plain drag is captured by revdiff. For terminal-native text selection:</p>
+        <ul>
+            <li><strong>kitty</strong>: hold <code>Ctrl+Shift</code> while dragging</li>
+            <li><strong>iTerm2</strong>: hold <code>Option</code> while dragging</li>
+            <li><strong>most other terminals</strong>: hold <code>Shift</code> while dragging</li>
+        </ul>
+        <p>Because the tree pane is rendered alongside the diff on the same rows, multi-line Shift+drag will include tree content. For clean copies of diff text, use your terminal's block-select mode (Option+drag in iTerm2, Ctrl+Shift+drag in kitty) or run with <code>--no-mouse</code> to disable mouse capture entirely.</p>
+        <p>Opt out with <code>--no-mouse</code>, <code>REVDIFF_NO_MOUSE=true</code>, or <code>no-mouse = true</code> in the config file.</p>
 
         <h2 id="custom-keys">Custom keybindings</h2>
         <p>All keybindings can be customized via <code>~/.config/revdiff/keybindings</code>. Override path with <code>--keys</code> or <code>REVDIFF_KEYS</code>.</p>


### PR DESCRIPTION
Adds mouse support with scroll-wheel in both panes and left-click for tree/diff navigation.

**Added**

- scroll-wheel in diff and tree (routed by pane under the pointer, not current focus)
- shift+wheel scrolls half-page
- left-click on tree entry selects and loads that file
- left-click on diff line sets cursor (click then `a` to annotate that line)
- `--no-mouse` / `REVDIFF_NO_MOUSE` opt-out for users who prefer terminal-native text selection

**Text selection**

Once mouse tracking is on, plain drag is captured. Users hold Shift (most terminals) or Option (iTerm2) to select. The tree pane sits on the same rows as the diff, so multi-line drags will pick up tree content. For clean diff copies, use terminal block-select (iTerm2 Option+drag, kitty Ctrl+Shift+drag) or run with `--no-mouse`.

**Out of scope**

Clickable status-bar segments, overlay item clicks, right-click menus, drag-selection, middle-click paste. Kept for a future follow-up if the need shows up.

**Docs**

README, `site/docs.html`, `docs/ARCHITECTURE.md`, and both Claude and Codex plugin references updated.