### PR TITLE
fix(themes): persist theme into Application Options section

### DIFF
--- a/app/diff/diff_test.go
+++ b/app/diff/diff_test.go
@@ -210,10 +210,10 @@ func TestParseUnifiedDiff_GapLabels(t *testing.T) {
 // a divider only when the last hunk does not reach EOF.
 func TestParseUnifiedDiff_TrailingDivider(t *testing.T) {
 	tests := []struct {
-		name           string
-		raw            string
-		totalOldLines  int
-		wantDividers   []string
+		name          string
+		raw           string
+		totalOldLines int
+		wantDividers  []string
 	}{
 		{
 			name: "trailing plural — hunk ends at line 10, total 300",

--- a/app/testdata/themes/corrupted.ini
+++ b/app/testdata/themes/corrupted.ini
@@ -1,0 +1,7 @@
+[Application Options]
+wrap = true
+compact = true
+
+[color options]
+;color-word-add-bg = #1a8f00
+theme = dracula

--- a/app/testdata/themes/duplicate.ini
+++ b/app/testdata/themes/duplicate.ini
@@ -1,0 +1,6 @@
+[Application Options]
+wrap = true
+theme = dracula
+
+[color options]
+theme = solarized-dark

--- a/app/testdata/themes/good.ini
+++ b/app/testdata/themes/good.ini
@@ -1,0 +1,7 @@
+[Application Options]
+wrap = true
+compact = true
+theme = dracula
+
+[color options]
+;color-word-add-bg = #1a8f00

--- a/app/testdata/themes/no_theme.ini
+++ b/app/testdata/themes/no_theme.ini
@@ -1,0 +1,6 @@
+[Application Options]
+wrap = true
+compact = true
+
+[color options]
+;color-word-add-bg = #1a8f00

--- a/app/themes.go
+++ b/app/themes.go
@@ -232,12 +232,13 @@ func colorsFromTheme(th theme.Theme) style.Colors {
 }
 
 // patchConfigTheme updates the theme setting in the INI config file at tc.configPath.
-// if a "theme = " line already lives in the [Application Options] / default scope,
-// the value is replaced in place. if the line sits in a wrong section (a config
-// corrupted by the pre-fix persist path that wrote past a trailing named section),
-// the stray line is removed and a fresh "theme = ..." is inserted just before the
-// first non-[Application Options] section header so the INI parser attributes it
-// to the default scope. with no existing line, the insert path runs unconditionally.
+// every "theme = ..." line sitting outside the default scope ([Application Options]
+// or the unnamed top-of-file section) is removed — these are strays from configs
+// corrupted by the pre-fix persist path, and leaving any of them behind keeps
+// go-flags erroring with "unknown option: theme" even after a successful patch.
+// if a default-scope line exists its value is replaced in place; otherwise a
+// fresh "theme = ..." is inserted just before the first non-[Application Options]
+// section header so the INI parser attributes it to the default scope.
 func (tc *themeCatalog) patchConfigTheme(themeName string) error {
 	if strings.ContainsAny(themeName, "\r\n") {
 		return fmt.Errorf("invalid theme name %q: must not contain newlines", themeName)
@@ -258,15 +259,21 @@ func (tc *themeCatalog) patchConfigTheme(themeName string) error {
 	}
 
 	lines := strings.Split(string(data), "\n")
-	idx, inDefault := tc.scanThemeLine(lines)
-	if idx >= 0 && inDefault {
-		lines[idx] = "theme = " + themeName
-	} else {
-		if idx >= 0 {
-			// stray "theme = ..." inside a wrong section (config corrupted by the
-			// pre-fix persist path); delete it and re-insert in the default scope.
-			lines = slices.Delete(lines, idx, idx+1)
+	defaultIdx, strayIdxs := tc.scanThemeLines(lines)
+	// always remove every "theme = ..." that sits outside the default scope so a
+	// config previously poisoned by the old persist path is fully healed (not
+	// just patched in one spot while go-flags keeps erroring on a remaining stray).
+	// deleting in reverse order keeps earlier indices stable.
+	for i := len(strayIdxs) - 1; i >= 0; i-- {
+		stray := strayIdxs[i]
+		lines = slices.Delete(lines, stray, stray+1)
+		if defaultIdx > stray {
+			defaultIdx--
 		}
+	}
+	if defaultIdx >= 0 {
+		lines[defaultIdx] = "theme = " + themeName
+	} else {
 		lines = slices.Insert(lines, tc.defaultSectionInsertIdx(lines), "theme = "+themeName)
 	}
 
@@ -276,11 +283,16 @@ func (tc *themeCatalog) patchConfigTheme(themeName string) error {
 	return nil
 }
 
-// scanThemeLine walks lines tracking the active INI section and reports the index
-// of the first "theme = ..." line along with whether it lives in the default scope
-// ([Application Options] or the unnamed top-of-file section). returns (-1, false)
-// when no theme line is found.
-func (tc *themeCatalog) scanThemeLine(lines []string) (idx int, inDefaultSection bool) {
+// scanThemeLines walks lines tracking the active INI section and reports every
+// "theme = ..." occurrence, splitting them into the first one found in the
+// default scope ([Application Options] or the unnamed top-of-file section) and
+// a list of stray ones sitting inside other sections. defaultIdx is -1 when no
+// default-scope line exists; strayIdxs is nil when nothing is misplaced.
+// reporting every stray (not just the first) lets callers fully heal configs
+// corrupted by the pre-fix persist path — otherwise a leftover stray still
+// makes go-flags error on startup.
+func (tc *themeCatalog) scanThemeLines(lines []string) (defaultIdx int, strayIdxs []int) {
+	defaultIdx = -1
 	currentSection := ""
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -295,9 +307,14 @@ func (tc *themeCatalog) scanThemeLine(lines []string) (idx int, inDefaultSection
 		if !ok || strings.TrimSpace(key) != "theme" {
 			continue
 		}
-		return i, currentSection == "" || strings.EqualFold(currentSection, "Application Options")
+		inDefault := currentSection == "" || strings.EqualFold(currentSection, "Application Options")
+		if inDefault && defaultIdx < 0 {
+			defaultIdx = i
+			continue
+		}
+		strayIdxs = append(strayIdxs, i)
 	}
-	return -1, false
+	return defaultIdx, strayIdxs
 }
 
 // defaultSectionInsertIdx returns the line index where a new default-scope entry

--- a/app/themes.go
+++ b/app/themes.go
@@ -196,7 +196,7 @@ func (tc *themeCatalog) Persist(name string) error {
 	if tc.configPath == "" {
 		return nil
 	}
-	return patchConfigTheme(tc.configPath, name)
+	return tc.patchConfigTheme(name)
 }
 
 // optsToStyleColors converts opts.Colors fields to a style.Colors struct.
@@ -231,20 +231,23 @@ func colorsFromTheme(th theme.Theme) style.Colors {
 	}
 }
 
-// patchConfigTheme updates the theme setting in the INI config file.
-// if a "theme = " line exists, it replaces the value. Otherwise appends it.
-func patchConfigTheme(configPath, themeName string) error {
+// patchConfigTheme updates the theme setting in the INI config file at tc.configPath.
+// if a "theme = " line exists, it replaces the value. otherwise appends it
+// just before the first non-[Application Options] section header so the new
+// entry lands inside the default section (the INI parser would assign it to
+// the most recent [section] header above).
+func (tc *themeCatalog) patchConfigTheme(themeName string) error {
 	if strings.ContainsAny(themeName, "\r\n") {
 		return fmt.Errorf("invalid theme name %q: must not contain newlines", themeName)
 	}
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(tc.configPath), 0o750); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
 
-	data, err := os.ReadFile(configPath) //nolint:gosec // path from user's config
+	data, err := os.ReadFile(tc.configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if writeErr := fsutil.AtomicWriteFile(configPath, []byte("theme = "+themeName+"\n")); writeErr != nil {
+			if writeErr := fsutil.AtomicWriteFile(tc.configPath, []byte("theme = "+themeName+"\n")); writeErr != nil {
 				return fmt.Errorf("writing config: %w", writeErr)
 			}
 			return nil
@@ -272,15 +275,29 @@ func patchConfigTheme(configPath, themeName string) error {
 	}
 
 	if !found {
-		// append before trailing empty lines
+		// find the first [section] header that is not [Application Options]; the
+		// new line must go before it so the INI parser attributes it to the default
+		// section. if no such header exists, append at EOF.
 		insertIdx := len(lines)
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") {
+				continue
+			}
+			name := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			if strings.EqualFold(name, "Application Options") {
+				continue
+			}
+			insertIdx = i
+			break
+		}
 		for insertIdx > 0 && strings.TrimSpace(lines[insertIdx-1]) == "" {
 			insertIdx--
 		}
 		lines = slices.Insert(lines, insertIdx, "theme = "+themeName)
 	}
 
-	if err := fsutil.AtomicWriteFile(configPath, []byte(strings.Join(lines, "\n"))); err != nil {
+	if err := fsutil.AtomicWriteFile(tc.configPath, []byte(strings.Join(lines, "\n"))); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
 	return nil

--- a/app/themes.go
+++ b/app/themes.go
@@ -232,10 +232,12 @@ func colorsFromTheme(th theme.Theme) style.Colors {
 }
 
 // patchConfigTheme updates the theme setting in the INI config file at tc.configPath.
-// if a "theme = " line exists, it replaces the value. otherwise appends it
-// just before the first non-[Application Options] section header so the new
-// entry lands inside the default section (the INI parser would assign it to
-// the most recent [section] header above).
+// if a "theme = " line already lives in the [Application Options] / default scope,
+// the value is replaced in place. if the line sits in a wrong section (a config
+// corrupted by the pre-fix persist path that wrote past a trailing named section),
+// the stray line is removed and a fresh "theme = ..." is inserted just before the
+// first non-[Application Options] section header so the INI parser attributes it
+// to the default scope. with no existing line, the insert path runs unconditionally.
 func (tc *themeCatalog) patchConfigTheme(themeName string) error {
 	if strings.ContainsAny(themeName, "\r\n") {
 		return fmt.Errorf("invalid theme name %q: must not contain newlines", themeName)
@@ -256,49 +258,68 @@ func (tc *themeCatalog) patchConfigTheme(themeName string) error {
 	}
 
 	lines := strings.Split(string(data), "\n")
-	found := false
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		// match "theme = ..." or "theme=..." but not commented-out lines
-		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
-			continue
+	idx, inDefault := tc.scanThemeLine(lines)
+	if idx >= 0 && inDefault {
+		lines[idx] = "theme = " + themeName
+	} else {
+		if idx >= 0 {
+			// stray "theme = ..." inside a wrong section (config corrupted by the
+			// pre-fix persist path); delete it and re-insert in the default scope.
+			lines = slices.Delete(lines, idx, idx+1)
 		}
-		key, _, ok := strings.Cut(trimmed, "=")
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(key) == "theme" {
-			lines[i] = "theme = " + themeName
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		// find the first [section] header that is not [Application Options]; the
-		// new line must go before it so the INI parser attributes it to the default
-		// section. if no such header exists, append at EOF.
-		insertIdx := len(lines)
-		for i, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") {
-				continue
-			}
-			name := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
-			if strings.EqualFold(name, "Application Options") {
-				continue
-			}
-			insertIdx = i
-			break
-		}
-		for insertIdx > 0 && strings.TrimSpace(lines[insertIdx-1]) == "" {
-			insertIdx--
-		}
-		lines = slices.Insert(lines, insertIdx, "theme = "+themeName)
+		lines = slices.Insert(lines, tc.defaultSectionInsertIdx(lines), "theme = "+themeName)
 	}
 
 	if err := fsutil.AtomicWriteFile(tc.configPath, []byte(strings.Join(lines, "\n"))); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
 	return nil
+}
+
+// scanThemeLine walks lines tracking the active INI section and reports the index
+// of the first "theme = ..." line along with whether it lives in the default scope
+// ([Application Options] or the unnamed top-of-file section). returns (-1, false)
+// when no theme line is found.
+func (tc *themeCatalog) scanThemeLine(lines []string) (idx int, inDefaultSection bool) {
+	currentSection := ""
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			currentSection = strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		key, _, ok := strings.Cut(trimmed, "=")
+		if !ok || strings.TrimSpace(key) != "theme" {
+			continue
+		}
+		return i, currentSection == "" || strings.EqualFold(currentSection, "Application Options")
+	}
+	return -1, false
+}
+
+// defaultSectionInsertIdx returns the line index where a new default-scope entry
+// should be placed: immediately before the first [section] header whose name is
+// not [Application Options], backed up over any trailing blank lines. returns
+// len(lines) (EOF) when the file has no such named section.
+func (tc *themeCatalog) defaultSectionInsertIdx(lines []string) int {
+	idx := len(lines)
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") {
+			continue
+		}
+		name := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+		if strings.EqualFold(name, "Application Options") {
+			continue
+		}
+		idx = i
+		break
+	}
+	for idx > 0 && strings.TrimSpace(lines[idx-1]) == "" {
+		idx--
+	}
+	return idx
 }

--- a/app/themes_test.go
+++ b/app/themes_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -761,4 +762,74 @@ func TestPatchConfigTheme_appendsInsideApplicationOptions(t *testing.T) {
 	assert.Contains(t, result, "theme = nord")
 	// theme line must be after the [Application Options] header
 	assert.Less(t, strings.Index(result, "[Application Options]"), strings.Index(result, "theme = nord"))
+	// existing keys must be preserved
+	assert.Contains(t, result, "wrap = true")
+	assert.Contains(t, result, "compact = true")
+}
+
+// reproduces the upgrade path from issue #148: a config already corrupted by
+// the pre-fix persist (theme = X sitting inside a trailing named section) must
+// be healed, not just replaced in place.
+func TestPatchConfigTheme_healsMisplacedThemeLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	content := "[Application Options]\nwrap = true\n\n[color options]\n;color-word-add-bg = #1a8f00\ntheme = dracula\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
+
+	data, err := os.ReadFile(path) //nolint:gosec // test
+	require.NoError(t, err)
+	result := string(data)
+
+	themeIdx := strings.Index(result, "theme = nord")
+	colorIdx := strings.Index(result, "[color options]")
+	require.NotEqual(t, -1, themeIdx, "new theme line must be present: %q", result)
+	require.NotEqual(t, -1, colorIdx, "[color options] header must be preserved: %q", result)
+	assert.Less(t, themeIdx, colorIdx, "theme = nord must precede [color options]: %q", result)
+	assert.NotContains(t, result, "theme = dracula", "stale theme line must be removed: %q", result)
+	assert.Contains(t, result, "wrap = true")
+	assert.Contains(t, result, ";color-word-add-bg = #1a8f00")
+}
+
+// parsePatchedConfig parses a patched INI file through go-flags the same way the
+// production code does (see loadConfigFile in config.go), so tests can assert the
+// patched file not only looks right textually but actually resolves opts.Theme
+// with no "unknown option" warning from go-flags.
+func parsePatchedConfig(t *testing.T, path string) (options, error) {
+	t.Helper()
+	var opts options
+	p := flags.NewParser(&opts, flags.Default)
+	iniParser := flags.NewIniParser(p)
+	if err := iniParser.ParseFile(path); err != nil {
+		return opts, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return opts, nil
+}
+
+// testdata fixtures round-trip through patchConfigTheme + flags.NewIniParser.
+// this is the assertion that would have caught issue #148 in the first place.
+func TestPatchConfigTheme_testdataRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string // path under app/testdata/themes/
+	}{
+		{name: "good config (theme already in [Application Options])", fixture: "good.ini"},
+		{name: "no theme line, trailing [color options]", fixture: "no_theme.ini"},
+		{name: "corrupted config (theme inside [color options])", fixture: "corrupted.ini"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join("testdata", "themes", tc.fixture))
+			require.NoError(t, err)
+
+			path := filepath.Join(t.TempDir(), "config")
+			require.NoError(t, os.WriteFile(path, raw, 0o600)) //nolint:gosec // test fixture roundtrip
+
+			require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
+
+			opts, parseErr := parsePatchedConfig(t, path)
+			require.NoError(t, parseErr, "patched file must parse without go-flags error (this is the #148 invariant)")
+			assert.Equal(t, "nord", opts.Theme, "Theme must be populated from the default section after patch")
+		})
+	}
 }

--- a/app/themes_test.go
+++ b/app/themes_test.go
@@ -791,6 +791,32 @@ func TestPatchConfigTheme_healsMisplacedThemeLine(t *testing.T) {
 	assert.Contains(t, result, ";color-word-add-bg = #1a8f00")
 }
 
+// reproduces the hand-repair duplicate scenario flagged in post-merge review:
+// a user whose config was originally corrupted (theme = X in [color options])
+// adds a correct theme = Y in [Application Options] manually without deleting
+// the stray. the next patch must update the default line AND remove the stray,
+// otherwise go-flags keeps erroring on "unknown option: theme".
+func TestPatchConfigTheme_removesStrayDuplicates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	content := "[Application Options]\nwrap = true\ntheme = dracula\n\n[color options]\ntheme = solarized-dark\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
+
+	opts, parseErr := parsePatchedConfig(t, path)
+	require.NoError(t, parseErr, "patched file must parse without go-flags error even with prior duplicates")
+	assert.Equal(t, "nord", opts.Theme)
+
+	data, err := os.ReadFile(path) //nolint:gosec // test
+	require.NoError(t, err)
+	result := string(data)
+	assert.NotContains(t, result, "theme = dracula", "original default-scope value must be replaced")
+	assert.NotContains(t, result, "theme = solarized-dark", "stray line inside [color options] must be removed")
+	assert.Contains(t, result, "wrap = true")
+	// exactly one theme line must remain
+	assert.Equal(t, 1, strings.Count(result, "\ntheme = "), "exactly one theme entry must remain: %q", result)
+}
+
 // parsePatchedConfig parses a patched INI file through go-flags the same way the
 // production code does (see loadConfigFile in config.go), so tests can assert the
 // patched file not only looks right textually but actually resolves opts.Theme
@@ -816,6 +842,7 @@ func TestPatchConfigTheme_testdataRoundTrip(t *testing.T) {
 		{name: "good config (theme already in [Application Options])", fixture: "good.ini"},
 		{name: "no theme line, trailing [color options]", fixture: "no_theme.ini"},
 		{name: "corrupted config (theme inside [color options])", fixture: "corrupted.ini"},
+		{name: "duplicate (one valid, one stray in [color options])", fixture: "duplicate.ini"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/app/themes_test.go
+++ b/app/themes_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -602,7 +603,7 @@ func TestPatchConfigTheme_existingKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config")
 	require.NoError(t, os.WriteFile(path, []byte("wrap = true\ntheme = dracula\nblame = false\n"), 0o600))
 
-	require.NoError(t, patchConfigTheme(path, "nord"))
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
 
 	data, err := os.ReadFile(path) //nolint:gosec // test
 	require.NoError(t, err)
@@ -616,7 +617,7 @@ func TestPatchConfigTheme_noExistingKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config")
 	require.NoError(t, os.WriteFile(path, []byte("wrap = true\nblame = false\n"), 0o600))
 
-	require.NoError(t, patchConfigTheme(path, "nord"))
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
 
 	data, err := os.ReadFile(path) //nolint:gosec // test
 	require.NoError(t, err)
@@ -627,7 +628,7 @@ func TestPatchConfigTheme_noExistingKey(t *testing.T) {
 func TestPatchConfigTheme_createsFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config")
 
-	require.NoError(t, patchConfigTheme(path, "dracula"))
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("dracula"))
 
 	data, err := os.ReadFile(path) //nolint:gosec // test
 	require.NoError(t, err)
@@ -637,7 +638,7 @@ func TestPatchConfigTheme_createsFile(t *testing.T) {
 func TestPatchConfigTheme_createsParentDir(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing", "config")
 
-	require.NoError(t, patchConfigTheme(path, "dracula"))
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("dracula"))
 
 	data, err := os.ReadFile(path) //nolint:gosec // test
 	require.NoError(t, err)
@@ -648,7 +649,7 @@ func TestPatchConfigTheme_skipsCommentedOut(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config")
 	require.NoError(t, os.WriteFile(path, []byte("# theme = dracula\nwrap = true\n"), 0o600))
 
-	require.NoError(t, patchConfigTheme(path, "nord"))
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
 
 	data, err := os.ReadFile(path) //nolint:gosec // test
 	require.NoError(t, err)
@@ -660,7 +661,7 @@ func TestPatchConfigTheme_semicolonComment(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config")
 	require.NoError(t, os.WriteFile(path, []byte("; theme = dracula\n"), 0o600))
 
-	require.NoError(t, patchConfigTheme(path, "nord"))
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
 
 	data, err := os.ReadFile(path) //nolint:gosec // test
 	require.NoError(t, err)
@@ -679,7 +680,7 @@ func TestPatchConfigTheme_rejectsNewlines(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := patchConfigTheme(path, tc.themeName)
+			err := (&themeCatalog{configPath: path}).patchConfigTheme(tc.themeName)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "must not contain newlines")
 		})
@@ -691,11 +692,73 @@ func TestPatchConfigTheme_preservesFormatting(t *testing.T) {
 	content := "wrap = true\n\n# Colors\ncolor-accent = #ff0000\ntheme = old\n\n"
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-	require.NoError(t, patchConfigTheme(path, "new"))
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("new"))
 
 	data, err := os.ReadFile(path) //nolint:gosec // test
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "theme = new")
 	assert.Contains(t, string(data), "# Colors")
 	assert.Contains(t, string(data), "color-accent = #ff0000")
+}
+
+// reproduces issue #148: appending theme = ... after a trailing [color options] section
+// must land inside [Application Options], not inside [color options].
+func TestPatchConfigTheme_insertsBeforeNamedSection(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "application options then color options",
+			content: "[Application Options]\nwrap = true\ncompact = true\n\n[color options]\n;color-word-add-bg = #1a8f00\n",
+		},
+		{
+			name:    "only color options section",
+			content: "[color options]\n;color-word-add-bg = #1a8f00\n",
+		},
+		{
+			name:    "application options with trailing blank lines before named section",
+			content: "[Application Options]\nwrap = true\n\n\n[color options]\n",
+		},
+		{
+			name:    "case-insensitive application options header",
+			content: "[application options]\nwrap = true\n\n[color options]\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config")
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o600))
+
+			require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
+
+			data, err := os.ReadFile(path) //nolint:gosec // test
+			require.NoError(t, err)
+			result := string(data)
+
+			themeIdx := strings.Index(result, "theme = nord")
+			colorIdx := strings.Index(result, "[color options]")
+			require.NotEqual(t, -1, themeIdx, "theme = nord must be present: %q", result)
+			require.NotEqual(t, -1, colorIdx, "[color options] header must be preserved: %q", result)
+			assert.Less(t, themeIdx, colorIdx, "theme = nord must precede [color options], got: %q", result)
+		})
+	}
+}
+
+// when file already has [Application Options] but no other named sections,
+// appending at EOF is correct (stays inside [Application Options]).
+func TestPatchConfigTheme_appendsInsideApplicationOptions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	content := "[Application Options]\nwrap = true\ncompact = true\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	require.NoError(t, (&themeCatalog{configPath: path}).patchConfigTheme("nord"))
+
+	data, err := os.ReadFile(path) //nolint:gosec // test
+	require.NoError(t, err)
+	result := string(data)
+	assert.Contains(t, result, "[Application Options]")
+	assert.Contains(t, result, "theme = nord")
+	// theme line must be after the [Application Options] header
+	assert.Less(t, strings.Index(result, "[Application Options]"), strings.Index(result, "theme = nord"))
 }

--- a/app/ui/diffnav_test.go
+++ b/app/ui/diffnav_test.go
@@ -2739,12 +2739,12 @@ func TestJumpToLineN_SyncsTOCActiveSection(t *testing.T) {
 	// must refresh the TOC highlight so the rendered active-section indicator
 	// tracks the new cursor location.
 	mdLines := []diff.DiffLine{
-		{NewNum: 1, Content: "# First", ChangeType: diff.ChangeContext},  // idx 0
-		{NewNum: 2, Content: "text", ChangeType: diff.ChangeContext},     // idx 1
+		{NewNum: 1, Content: "# First", ChangeType: diff.ChangeContext},   // idx 0
+		{NewNum: 2, Content: "text", ChangeType: diff.ChangeContext},      // idx 1
 		{NewNum: 3, Content: "## Second", ChangeType: diff.ChangeContext}, // idx 2
-		{NewNum: 4, Content: "text", ChangeType: diff.ChangeContext},     // idx 3
+		{NewNum: 4, Content: "text", ChangeType: diff.ChangeContext},      // idx 3
 		{NewNum: 5, Content: "### Third", ChangeType: diff.ChangeContext}, // idx 4
-		{NewNum: 6, Content: "text", ChangeType: diff.ChangeContext},     // idx 5
+		{NewNum: 6, Content: "text", ChangeType: diff.ChangeContext},      // idx 5
 	}
 	m := testModel([]string{"README.md"}, map[string][]diff.DiffLine{"README.md": mdLines})
 	m.file.singleFile = true


### PR DESCRIPTION
Fixes the #148 bug where the theme selector (Shift+T) was writing `theme = <name>` at EOF of `~/.config/revdiff/config`. If the file ended with a named section such as `[color options]`, the new line landed inside that section and go-flags emitted `unknown option: theme` on next startup, silently dropping the setting.

**What changed**

- `patchConfigTheme` now scans with active-section tracking. When no `theme = ` line exists, or when a stray one sits inside a wrong section (configs already corrupted by the pre-fix persist path), the new line is inserted just before the first non-`[Application Options]` section header so the INI parser attributes it to the default scope.
- Stray misplaced lines are removed and re-written, so users hit by the original bug get auto-healed on the next theme pick instead of having to hand-edit the config.
- Promoted `patchConfigTheme` to a method on `*themeCatalog` (it was called only from `themeCatalog.Persist`). Scan + insert-position logic split into two small helper methods for readability.

**Tests**

- New subtest set covers insertion before trailing named sections, case-insensitive `[application options]` header, and blank-line collapsing.
- New testdata-driven round-trip test parses patched files through `flags.NewIniParser` and asserts `opts.Theme` resolves without error across three fixtures: `good.ini`, `no_theme.ini`, `corrupted.ini`. This is the assertion that would have caught #148 originally.
- New regression test for the "heal misplaced theme line" upgrade path.

Related to #148
