### PR TITLE
Add colorblind-friendly gallery themes

### DIFF
--- a/themes/gallery/colorblind-dark
+++ b/themes/gallery/colorblind-dark
@@ -1,0 +1,26 @@
+# name: colorblind-dark
+# description: high-contrast red-green colorblind-friendly dark palette adapted from GNU Modus
+# author: Nikita Krajcik
+
+chroma-style = modus-vivendi
+color-accent = #2fafff
+color-border = #646464
+color-normal = #ffffff
+color-muted = #989898
+color-selected-fg = #f0f0f0
+color-selected-bg = #2a2a6a
+color-annotation = #ffa00f
+color-cursor-fg = #efef00
+color-cursor-bg = #1a1a1a
+color-add-fg = #c4d5ff
+color-add-bg = #003066
+color-remove-fg = #d4d48f
+color-remove-bg = #3d3d00
+color-modify-fg = #e3cfff
+color-modify-bg = #2f123f
+color-tree-bg = #000000
+color-diff-bg = #1a1a1a
+color-status-fg = #f0f0f0
+color-status-bg = #2a2a6a
+color-search-fg = #000000
+color-search-bg = #efef00

--- a/themes/gallery/colorblind-light
+++ b/themes/gallery/colorblind-light
@@ -1,0 +1,26 @@
+# name: colorblind-light
+# description: high-contrast red-green colorblind-friendly light palette adapted from GNU Modus
+# author: Nikita Krajcik
+
+chroma-style = xcode
+color-accent = #0031a9
+color-border = #595959
+color-normal = #000000
+color-muted = #595959
+color-selected-fg = #0f0f0f
+color-selected-bg = #d0d6ff
+color-annotation = #973300
+color-cursor-fg = #0000ff
+color-cursor-bg = #f3f3f3
+color-add-fg = #303099
+color-add-bg = #e8edff
+color-remove-fg = #553d00
+color-remove-bg = #f4f099
+color-modify-fg = #6f1343
+color-modify-bg = #eecfdf
+color-tree-bg = #ffffff
+color-diff-bg = #f3f3f3
+color-status-fg = #0f0f0f
+color-status-bg = #d0d6ff
+color-search-fg = #000000
+color-search-bg = #f3d000

--- a/themes/gallery/colorblind-light
+++ b/themes/gallery/colorblind-light
@@ -2,7 +2,7 @@
 # description: high-contrast red-green colorblind-friendly light palette adapted from GNU Modus
 # author: Nikita Krajcik
 
-chroma-style = xcode
+chroma-style = modus-operandi
 color-accent = #0031a9
 color-border = #595959
 color-normal = #000000


### PR DESCRIPTION
## Problem

revdiff has several bundled and gallery themes, but no theme pair aimed at users who have difficulty relying on red/green distinctions in diffs.

## Solution

Add two gallery-only community themes:

- colorblind-dark
- colorblind-light

Both use high-contrast add/remove colors and existing Chroma styles. They do not change defaults and are not marked as bundled.

## Testing

- GOTOOLCHAIN=auto make validate-themes
- Manually previewed colorblind-dark and colorblind-light in WezTerm using both light and dark terminal color schemes
<img width="2542" height="1383" alt="Снимок экрана 2026-04-29 в 13 57 18" src="https://github.com/user-attachments/assets/eddbb1f1-23cd-4fc2-889a-048b69be7b27" />
<img width="1482" height="905" alt="Снимок экрана 2026-04-29 в 14 00 11" src="https://github.com/user-attachments/assets/1eed65d3-960e-4dd5-80a9-a9ffd5724020" />
