### PR TITLE
docs: fix marketplace install command in plugin install instructions

### DIFF
--- a/.claude-plugin/skills/revdiff/references/install.md
+++ b/.claude-plugin/skills/revdiff/references/install.md
@@ -11,7 +11,7 @@ brew install umputun/apps/revdiff
 
 ```bash
 /plugin marketplace add umputun/revdiff
-/plugin install revdiff@umputun-revdiff
+/plugin install revdiff@revdiff
 ```
 
 Use: `/revdiff [base] [against]` — opens review session in a terminal overlay (tmux, Zellij, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm).
@@ -33,7 +33,7 @@ Terminals using CLI tools (tmux, Zellij, kitty, wezterm, cmux) are not affected.
 Automatically opens revdiff when Claude exits plan mode for interactive annotation:
 
 ```bash
-/plugin install revdiff-planning@umputun-revdiff
+/plugin install revdiff-planning@revdiff
 ```
 
 ### Overrides

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Priority: tmux → Zellij → kitty → wezterm/Kaku → cmux → ghostty → iT
 ```bash
 # add marketplace and install
 /plugin marketplace add umputun/revdiff
-/plugin install revdiff@umputun-revdiff
+/plugin install revdiff@revdiff
 ```
 
 **Use with `/revdiff` command:**
@@ -161,7 +161,7 @@ The plugin supports the full review loop: annotate → plan → fix → re-revie
 A separate `revdiff-planning` plugin automatically opens revdiff when Claude exits plan mode, letting you annotate the plan before approving it. If you add annotations, Claude revises the plan and asks again — looping until you're satisfied.
 
 ```bash
-/plugin install revdiff-planning@umputun-revdiff
+/plugin install revdiff-planning@revdiff
 ```
 
 This plugin is independent from the main `revdiff` plugin and does not conflict with other planning plugins (e.g., `planning` from `cc-thingz`).

--- a/plugins/revdiff-planning/README.md
+++ b/plugins/revdiff-planning/README.md
@@ -6,7 +6,7 @@ Claude Code plugin that intercepts `ExitPlanMode` and opens the proposed plan in
 
 ```bash
 /plugin marketplace add umputun/revdiff
-/plugin install revdiff-planning@umputun-revdiff
+/plugin install revdiff-planning@revdiff
 ```
 
 Requires the `revdiff` binary in `PATH` and one of: tmux, Zellij, kitty, wezterm, cmux, ghostty (macOS), iTerm2 (macOS), or Emacs vterm.

--- a/site/docs.html
+++ b/site/docs.html
@@ -609,7 +609,7 @@ map alt+t&gt;n theme_select</code></div>
         <p>revdiff ships with a Claude Code plugin for interactive code review directly from a Claude session. The plugin launches revdiff as a terminal overlay, captures annotations, and feeds them back to Claude for processing.</p>
         <div class="code-block"><code><span class="code-comment"># add marketplace and install</span>
 /plugin marketplace add umputun/revdiff
-/plugin install revdiff@umputun-revdiff</code></div>
+/plugin install revdiff@revdiff</code></div>
 
         <h2 id="plugin-terminals">Terminal support</h2>
         <p>The plugin requires one of the following terminals since Claude Code itself cannot display interactive TUI applications. The overlay runs revdiff in a separate terminal layer on top of the current session.</p>
@@ -663,7 +663,7 @@ map alt+t&gt;n theme_select</code></div>
 
         <h2 id="plugin-planning">Plan review plugin</h2>
         <p>A separate <code>revdiff-planning</code> plugin automatically opens revdiff when Claude exits plan mode, letting you annotate the plan before approving it. If you add annotations, Claude revises the plan and asks again, looping until you're satisfied.</p>
-        <div class="code-block"><code>/plugin install revdiff-planning@umputun-revdiff</code></div>
+        <div class="code-block"><code>/plugin install revdiff-planning@revdiff</code></div>
         <p>This plugin is independent from the main <code>revdiff</code> plugin and does not conflict with other planning plugins.</p>
 
         <h2 id="plugin-overrides">Custom launchers</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -64,7 +64,7 @@
                 "name": "How do I review diffs in the terminal with Claude Code?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Install the revdiff Claude Code plugin with /plugin marketplace add umputun/revdiff and /plugin install revdiff@umputun-revdiff, then run /revdiff to review uncommitted changes in a terminal overlay. Add inline annotations on lines you want changed, quit, and Claude reads the annotations and applies fixes."
+                    "text": "Install the revdiff Claude Code plugin with /plugin marketplace add umputun/revdiff and /plugin install revdiff@revdiff, then run /revdiff to review uncommitted changes in a terminal overlay. Add inline annotations on lines you want changed, quit, and Claude reads the annotations and applies fixes."
                 }
             },
             {
@@ -389,7 +389,7 @@
                 <div class="flow-num">1</div>
                 <div class="flow-text">
                     <h3>Install</h3>
-                    <div class="code-block"><code>/plugin marketplace add umputun/revdiff<br>/plugin install revdiff@umputun-revdiff</code></div>
+                    <div class="code-block"><code>/plugin marketplace add umputun/revdiff<br>/plugin install revdiff@revdiff</code></div>
                 </div>
             </div>
             <div class="flow-step">


### PR DESCRIPTION
Reported in #158: README's `/plugin install revdiff@umputun-revdiff` fails because Claude Code resolves the marketplace by the `name` field in `.claude-plugin/marketplace.json`, which is `revdiff`, not `umputun-revdiff`. Same issue for `revdiff-planning@umputun-revdiff`.

Updated install commands in:

- README.md (lines 116, 164)
- .claude-plugin/skills/revdiff/references/install.md (lines 14, 36)
- plugins/revdiff-planning/README.md (line 9)
- site/docs.html (lines 612, 666)
- site/index.html (line 67 in JSON-LD answer, line 392 in install code block)

Chose this direction over renaming the marketplace in `marketplace.json` because renaming would force every existing install to remove and re-add the marketplace.

Related to #158
