### PR TITLE
mute ↪ wrap continuation marker, add --wrap-indent

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -24,6 +24,7 @@ Then uncomment and edit the values you want to change.
 | `--no-colors` | `REVDIFF_NO_COLORS` | Disable all colors including syntax highlighting | `false` |
 | `--no-status-bar` | `REVDIFF_NO_STATUS_BAR` | Hide the status bar | `false` |
 | `--wrap` | `REVDIFF_WRAP` | Enable line wrapping in diff view | `false` |
+| `--wrap-indent` | `REVDIFF_WRAP_INDENT` | Indent wrap continuation rows by N columns so they hang under the first row's content (helps when reviewing markdown lists where unindented continuation can be misread as a new bullet) | `0` |
 | `--collapsed` | `REVDIFF_COLLAPSED` | Start in collapsed diff mode | `false` |
 | `--compact` | `REVDIFF_COMPACT` | Start in compact diff mode (small context around changes) | `false` |
 | `--compact-context` | `REVDIFF_COMPACT_CONTEXT` | Number of context lines around changes when in compact mode | `5` |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - exhaustive
     - fatcontext
     - gochecknoinits
-    - goconst
     - gocritic
     - gocyclo
     - godoclint
@@ -58,9 +57,6 @@ linters:
       require-specific: true
     dupl:
       threshold: 100
-    goconst:
-      min-len: 2
-      min-occurrences: 7
     gocritic:
       disabled-checks:
         - wrapperFunc
@@ -128,7 +124,6 @@ linters:
         text: unused-parameter
       - linters:
           - dupl
-          - goconst
           - noctx
           - usestdlibvars
         path: _test\.go$

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built for a specific use case: reviewing code changes, plans, and documents with
 - Full-file diff view with syntax highlighting
 - Intra-line word-diff: highlights the specific changed words within paired add/remove lines using a brighter background overlay, off by default — enable with `--word-diff` or toggle with `W`
 - Collapsed diff mode: shows final text with change markers, toggle with `v`
-- Word wrap mode: wraps long lines at viewport boundary with `↪` continuation markers, toggle with `w`
+- Word wrap mode: wraps long lines at viewport boundary with `↪` continuation markers, toggle with `w`; optional `--wrap-indent N` for hanging-indent continuations (handy for markdown lists)
 - Horizontal scroll overflow indicators: truncated diff lines show `«` / `»` markers at the edges to signal hidden content off-screen
 - Vertical scrollbar thumb: a thicker `┃` segment on pane right borders indicates the visible portion of long diffs, file trees, and markdown TOCs; thumb size and position track scroll progress automatically
 - Line numbers: side-by-side old/new line number gutter for diffs, single column for full-context files, toggle with `L`
@@ -294,6 +294,7 @@ Positional arguments support several forms:
 | `--no-colors` | Disable all colors including syntax highlighting, env: `REVDIFF_NO_COLORS` | `false` |
 | `--no-status-bar` | Hide the status bar, env: `REVDIFF_NO_STATUS_BAR` | `false` |
 | `--wrap` | Enable line wrapping in diff view, env: `REVDIFF_WRAP` | `false` |
+| `--wrap-indent` | Indent wrap continuation rows by N columns so they hang under the first row's content (helps when reviewing markdown lists where unindented continuation can be misread as a new bullet), env: `REVDIFF_WRAP_INDENT` | `0` |
 | `--collapsed` | Start in collapsed diff mode, env: `REVDIFF_COLLAPSED` | `false` |
 | `--compact` | Start in compact diff mode (small context around changes), env: `REVDIFF_COMPACT` | `false` |
 | `--compact-context` | Number of context lines around changes when in compact mode, env: `REVDIFF_COMPACT_CONTEXT` | `5` |

--- a/app/config.go
+++ b/app/config.go
@@ -25,6 +25,7 @@ type options struct {
 	NoConfirmDiscard bool     `long:"no-confirm-discard" ini-name:"no-confirm-discard" env:"REVDIFF_NO_CONFIRM_DISCARD" description:"skip confirmation prompt when discarding annotations with Q"`
 	NoMouse          bool     `long:"no-mouse" ini-name:"no-mouse" env:"REVDIFF_NO_MOUSE" description:"disable mouse support (scroll wheel, click)"`
 	Wrap             bool     `long:"wrap" ini-name:"wrap" env:"REVDIFF_WRAP" description:"enable line wrapping in diff view"`
+	WrapIndent       int      `long:"wrap-indent" ini-name:"wrap-indent" env:"REVDIFF_WRAP_INDENT" default:"0" description:"indent wrap continuation rows by N columns so they hang under the first row's content (helps when reviewing markdown lists where unindented continuation can be misread as a new bullet)"`
 	Collapsed        bool     `long:"collapsed" ini-name:"collapsed" env:"REVDIFF_COLLAPSED" description:"start in collapsed diff mode"`
 	Compact          bool     `long:"compact" ini-name:"compact" env:"REVDIFF_COMPACT" description:"start in compact diff mode (small context around changes)"`
 	CompactContext   int      `long:"compact-context" ini-name:"compact-context" env:"REVDIFF_COMPACT_CONTEXT" default:"5" description:"number of context lines around changes when in compact mode"`

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -117,6 +117,37 @@ func TestParseArgs_Wrap(t *testing.T) {
 	})
 }
 
+func TestParseArgs_WrapIndent(t *testing.T) {
+	t.Run("default is zero", func(t *testing.T) {
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.Equal(t, 0, opts.WrapIndent)
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		opts, err := parseArgs(append(noConfigArgs(t), "--wrap-indent=4"))
+		require.NoError(t, err)
+		assert.Equal(t, 4, opts.WrapIndent)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("REVDIFF_WRAP_INDENT", "2")
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.Equal(t, 2, opts.WrapIndent)
+	})
+
+	t.Run("config file", func(t *testing.T) {
+		cfgDir := t.TempDir()
+		cfgPath := filepath.Join(cfgDir, "config")
+		err := os.WriteFile(cfgPath, []byte("[Application Options]\nwrap-indent = 3\n"), 0o600)
+		require.NoError(t, err)
+		opts, err := parseArgs([]string{"--config", cfgPath})
+		require.NoError(t, err)
+		assert.Equal(t, 3, opts.WrapIndent)
+	})
+}
+
 func TestParseArgs_Collapsed(t *testing.T) {
 	t.Run("flag", func(t *testing.T) {
 		opts, err := parseArgs(append(noConfigArgs(t), "--collapsed"))
@@ -613,6 +644,7 @@ func TestDumpConfig(t *testing.T) {
 	assert.Contains(t, output, "chroma-style = catppuccin-macchiato")
 	assert.Contains(t, output, "cross-file-hunks = false")
 	assert.Contains(t, output, "no-mouse = false")
+	assert.Contains(t, output, "wrap-indent = 0")
 	assert.Contains(t, output, "[color options]")
 	assert.Contains(t, output, "color-accent = #D5895F")
 	assert.NotContains(t, output, "\ncolors =", "should not have spurious colors= line")

--- a/app/main.go
+++ b/app/main.go
@@ -190,6 +190,7 @@ func run(opts options) error {
 		NoStatusBar:       opts.NoStatusBar,
 		NoConfirmDiscard:  opts.NoConfirmDiscard,
 		Wrap:              opts.Wrap,
+		WrapIndent:        opts.WrapIndent,
 		Collapsed:         opts.Collapsed,
 		Compact:           opts.Compact,
 		CompactContext:    opts.CompactContext,

--- a/app/ui/collapsed.go
+++ b/app/ui/collapsed.go
@@ -114,8 +114,13 @@ func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffL
 		// match the non-highlighted search-match path which uses the search-match
 		// lipgloss style (fg + bg). when chroma highlighting is on, lineHlStyle
 		// drops the foreground for chroma to own content fg, so the prefix wrap
-		// must inject search-fg explicitly.
+		// must inject search-fg explicitly. bgColor must also flip to SearchBg so
+		// the wrapped continuation marker (rendered outside lipgloss via styledWrapMarker)
+		// and the right-side extendLineBg padding stay on the same bg as the lineStyle
+		// content — otherwise wrap continuation markers and the trailing pad show a
+		// visible bg seam when a row is search-matched.
 		prefixFg = m.resolver.Color(style.ColorKeySearchFg)
+		bgColor = m.resolver.Color(style.ColorKeySearchBg)
 	}
 
 	// wrap mode: break long lines at word boundaries with continuation markers
@@ -123,7 +128,8 @@ func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffL
 		m.renderWrappedCollapsedLine(b, textContent, wrappedLineCtx{
 			gutter: gutter, numGutter: numGutter, blGutter: blGutter,
 			isCursor: isCursor, hasHighlight: hasHighlight,
-			lineStyle: lineStyle, hlStyle: lineHlStyle, bgColor: bgColor,
+			isSearchMatch: isSearchMatch,
+			lineStyle:     lineStyle, hlStyle: lineHlStyle, bgColor: bgColor,
 			prefixFg: prefixFg,
 		})
 		return
@@ -148,6 +154,7 @@ func (m Model) renderCollapsedAddLine(b *strings.Builder, idx int, dl diff.DiffL
 type wrappedLineCtx struct {
 	gutter, numGutter, blGutter string
 	isCursor, hasHighlight      bool
+	isSearchMatch               bool // true when the row is search-matched; drives no-colors marker fallback
 	lineStyle, hlStyle          lipgloss.Style
 	bgColor, prefixFg           style.Color
 }
@@ -157,29 +164,40 @@ func (m Model) renderWrappedCollapsedLine(b *strings.Builder, textContent string
 	numBlank, blBlank := m.gutterBlanks()
 	visualLines := m.wrapContent(textContent, m.wrapWidth())
 	for i, vl := range visualLines {
-		prefix := " ↪ "
+		isFirst := i == 0
 		ng := numBlank
 		bg := blBlank
-		if i == 0 {
-			prefix = ctx.gutter
+		if isFirst {
 			ng = ctx.numGutter
 			bg = ctx.blGutter
 		}
 
-		var styled string
-		if ctx.hasHighlight {
-			styled = ctx.hlStyle.Render(m.wrapPrefixForHighlight(prefix, ctx.prefixFg, true) + vl)
-		} else {
-			styled = ctx.lineStyle.Render(prefix + vl)
-		}
+		styled := m.styleCollapsedWrapVisual(ctx, vl, isFirst)
 		styled = m.extendLineBg(styled, ctx.bgColor)
 
 		cursor := " "
-		if i == 0 && ctx.isCursor {
+		if isFirst && ctx.isCursor {
 			cursor = m.renderer.DiffCursor(m.cfg.noColors)
 		}
 		b.WriteString(cursor + ng + bg + styled + "\n")
 	}
+}
+
+// styleCollapsedWrapVisual styles a single visual row of a wrapped collapsed line.
+// the first row uses ctx.gutter; continuation rows prepend a muted ↪ marker so it
+// reads as gutter chrome rather than inheriting the line foreground.
+func (m Model) styleCollapsedWrapVisual(ctx wrappedLineCtx, vl string, isFirst bool) string {
+	if isFirst {
+		if ctx.hasHighlight {
+			return ctx.hlStyle.Render(m.wrapPrefixForHighlight(ctx.gutter, ctx.prefixFg, true) + vl)
+		}
+		return ctx.lineStyle.Render(ctx.gutter + vl)
+	}
+	marker := m.styledWrapMarker(ctx.bgColor, ctx.isSearchMatch)
+	if ctx.hasHighlight {
+		return marker + ctx.hlStyle.Render(vl)
+	}
+	return marker + ctx.lineStyle.Render(vl)
 }
 
 // deletePlaceholderText returns the text shown for a delete-only hunk placeholder starting at hunkStart.
@@ -218,10 +236,16 @@ func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int) {
 	text := m.deletePlaceholderText(hunkStart)
 
 	lineStyle := m.resolver.Style(style.StyleKeyLineRemove)
-	if m.search.matchSet[idx] {
+	bgColor := m.resolver.Color(style.ColorKeyRemoveLineBg)
+	isSearchMatch := m.search.matchSet[idx]
+	if isSearchMatch {
+		// flip both lineStyle and the bg used by the wrap-continuation marker
+		// and extendLineBg padding so the placeholder renders consistently on
+		// SearchBg (otherwise the marker on the wrapped row carries removeBg
+		// while the content carries SearchBg — visible seam).
 		lineStyle = m.resolver.Style(style.StyleKeySearchMatch)
+		bgColor = m.resolver.Color(style.ColorKeySearchBg)
 	}
-	removeBg := m.resolver.Color(style.ColorKeyRemoveLineBg)
 
 	isCursor := m.isCursorLine(idx)
 
@@ -233,16 +257,17 @@ func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int) {
 		numBlank, blBlank := m.gutterBlanks()
 		visualLines := m.wrapContent(text, m.wrapWidth())
 		for i, vl := range visualLines {
-			prefix := " ↪ "
 			ng := numBlank
 			bg := blBlank
+			var styled string
 			if i == 0 {
-				prefix = " - "
 				ng = numGutter
 				bg = blGutter
+				styled = lineStyle.Render(" - " + vl)
+			} else {
+				styled = m.styledWrapMarker(bgColor, isSearchMatch) + lineStyle.Render(vl)
 			}
-			styled := lineStyle.Render(prefix + vl)
-			styled = m.extendLineBg(styled, removeBg)
+			styled = m.extendLineBg(styled, bgColor)
 
 			cursor := " "
 			if i == 0 && isCursor {
@@ -254,8 +279,8 @@ func (m Model) renderDeletePlaceholder(b *strings.Builder, idx, hunkStart int) {
 	}
 
 	content := lineStyle.Render(" - " + text)
-	content = m.applyHorizontalScroll(content, removeBg)
-	content = m.extendLineBg(content, removeBg)
+	content = m.applyHorizontalScroll(content, bgColor)
+	content = m.extendLineBg(content, bgColor)
 
 	cursor := " "
 	if isCursor {

--- a/app/ui/collapsed_render_test.go
+++ b/app/ui/collapsed_render_test.go
@@ -294,6 +294,63 @@ func TestModel_CollapsedWrapPureAddLine(t *testing.T) {
 	assert.Contains(t, rendered, " ↪ ", "wrapped continuation should have ↪ marker")
 }
 
+func TestModel_CollapsedWrapSearchMatchUsesSearchBg(t *testing.T) {
+	colors := style.Colors{
+		AddBg: "#1a3320", AddFg: "#87d787",
+		RemoveBg: "#331a1a", RemoveFg: "#ff8787",
+		Muted: "#999999", DiffBg: "#112233",
+		SearchBg: "#665522", SearchFg: "#ffffff",
+	}
+	res := style.NewResolver(colors)
+	searchBg := "\033[48;2;102;85;34m" // #665522
+	addBg := "\033[48;2;26;51;32m"     // #1a3320
+
+	t.Run("collapsed add line continuation", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.resolver = res
+		m.renderer = style.NewRenderer(res)
+		m.sgr = style.SGR{}
+		m.modes.collapsed.enabled = true
+		m.modes.collapsed.expandedHunks = make(map[int]bool)
+		m.modes.wrap = true
+		m.layout.width = 40
+		m.layout.treeWidth = 0
+		m.file.lines = []diff.DiffLine{
+			{NewNum: 1, Content: "this line is long enough to wrap a couple of times in a narrow pane", ChangeType: diff.ChangeAdd},
+		}
+		m.search.term = "this"
+		m.search.matches = []int{0}
+
+		rendered := m.renderDiff()
+		assert.Contains(t, rendered, " ↪ ", "expected wrapped continuation marker")
+		assert.Contains(t, rendered, searchBg, "search-matched continuation marker must carry SearchBg")
+		assert.NotContains(t, rendered, addBg, "search-matched continuation must not leak the add-line bg seam")
+	})
+
+	t.Run("delete placeholder continuation", func(t *testing.T) {
+		m := testModel(nil, nil)
+		m.resolver = res
+		m.renderer = style.NewRenderer(res)
+		m.sgr = style.SGR{}
+		m.modes.collapsed.enabled = true
+		m.modes.collapsed.expandedHunks = make(map[int]bool)
+		m.modes.wrap = true
+		m.layout.width = 18
+		m.layout.treeWidth = 0
+		m.file.lines = []diff.DiffLine{
+			{OldNum: 1, Content: "del1", ChangeType: diff.ChangeRemove},
+			{OldNum: 2, Content: "del2", ChangeType: diff.ChangeRemove},
+			{OldNum: 3, Content: "del3", ChangeType: diff.ChangeRemove},
+		}
+		m.search.term = "this"
+		m.search.matches = []int{0}
+
+		rendered := m.renderDiff()
+		assert.Contains(t, rendered, " ↪ ", "expected placeholder continuation marker")
+		assert.Contains(t, rendered, searchBg, "search-matched placeholder continuation must carry SearchBg")
+	})
+}
+
 func TestModel_CollapsedWrapDeletePlaceholder(t *testing.T) {
 	t.Run("wrapping", func(t *testing.T) {
 		m := testModel(nil, nil)

--- a/app/ui/diffview.go
+++ b/app/ui/diffview.go
@@ -377,16 +377,21 @@ func (m Model) renderWrappedDiffLine(b *strings.Builder, dl diff.DiffLine, textC
 
 	visualLines := m.wrapContent(textContent, m.wrapWidth())
 	for i, vl := range visualLines {
-		prefix := " ↪ "
 		ng := numBlank
 		bg := blBlank
+		var styled string
 		if i == 0 {
-			prefix = m.linePrefix(dl.ChangeType)
 			ng = numGutter
 			bg = blGutter
+			styled = m.styleDiffContent(dl.ChangeType, m.linePrefix(dl.ChangeType), vl, hasHighlight, isSearchMatch)
+		} else {
+			// non-collapsed wrap path applies search highlight per-word via
+			// highlightSearchMatches inside styleDiffContent (the surrounding lipgloss
+			// LineStyle stays add/remove/context, never SearchMatch), so the marker
+			// does not need the no-colors reverse-video fallback even on a search-matched
+			// row — pass false.
+			styled = m.styledWrapMarker(m.resolver.LineBg(dl.ChangeType), false) + m.styleDiffContent(dl.ChangeType, "", vl, hasHighlight, isSearchMatch)
 		}
-
-		styled := m.styleDiffContent(dl.ChangeType, prefix, vl, hasHighlight, isSearchMatch)
 		styled = m.extendLineBg(styled, m.resolver.LineBg(dl.ChangeType))
 
 		cursor := " "
@@ -495,12 +500,71 @@ func (m Model) linePrefix(changeType diff.ChangeType) string {
 // chroma highlighting is on. Highlighted line styles intentionally set only
 // background (chroma owns per-token fg for content), so the prefix would
 // otherwise inherit the terminal default fg and may render invisibly on
-// light theme backgrounds.
+// light theme backgrounds. an empty prefix is returned unchanged so callers
+// passing "" (e.g. wrap-mode continuation rows that style the marker themselves)
+// don't pay for an empty fg-set + fg-reset SGR pair on every row.
 func (m Model) wrapPrefixForHighlight(prefix string, fg style.Color, hasHighlight bool) string {
-	if !hasHighlight || fg == "" {
+	if !hasHighlight || fg == "" || prefix == "" {
 		return prefix
 	}
 	return string(fg) + prefix + string(style.ResetFg)
+}
+
+// styledWrapMarker returns the " ↪ " continuation marker styled with MutedFg
+// on the given line background via raw ANSI, optionally followed by N bg-padded
+// spaces (where N is m.effectiveWrapIndent — the configured wrapIndent unless
+// the pane is too narrow to keep enough content width, see wrapWidth) so
+// continuation content visually hangs under the first row's content rather than
+// aligning with new bullets/items at the same column. matches the muted treatment
+// of «/» horizontal scroll indicators (see scrollIndicatorANSI) — both gutter-chrome
+// glyphs use ColorKeyMutedFg via raw ANSI rather than going through lipgloss so
+// they do not inherit chroma syntax color or change-line foreground. the two
+// helpers stay separate because scrollIndicatorANSI also handles split bg semantics
+// (line-bg space + DiffBg glyph) that the wrap marker does not need (the wrap
+// marker is gutter-only chrome, never overlaid on content). an empty bg here
+// falls back to DiffPaneBg so context rows (which have no LineBg) still match
+// the surrounding pane.
+//
+// searchMatch toggles the no-colors behavior: when true and --no-colors is on,
+// the marker emits a reverse-video wrap to match the SearchMatch lipgloss style
+// (which renders as Reverse in plain mode), preventing a plain ↪ marker from
+// sitting on a reverse-video content row. in colored mode the caller already
+// flipped bg to SearchBg, so searchMatch is a no-op on the colored path.
+//
+// in --no-colors mode without search match, all color lookups return empty and
+// the marker degrades to plain " ↪ " plus the indent spaces.
+func (m Model) styledWrapMarker(bg style.Color, searchMatch bool) string {
+	if m.cfg.noColors && searchMatch {
+		indent := m.effectiveWrapIndent()
+		pad := ""
+		if indent > 0 {
+			pad = strings.Repeat(" ", indent)
+		}
+		return "\033[7m ↪ " + pad + "\033[27m"
+	}
+	if bg == "" {
+		bg = m.resolver.Color(style.ColorKeyDiffPaneBg)
+	}
+	muted := m.resolver.Color(style.ColorKeyMutedFg)
+	indent := m.effectiveWrapIndent()
+	var b strings.Builder
+	if bg != "" {
+		b.WriteString(string(bg))
+	}
+	if muted != "" {
+		b.WriteString(string(muted))
+	}
+	b.WriteString(" ↪ ")
+	if muted != "" {
+		b.WriteString("\033[39m")
+	}
+	if indent > 0 {
+		b.WriteString(strings.Repeat(" ", indent))
+	}
+	if bg != "" {
+		b.WriteString("\033[49m")
+	}
+	return b.String()
 }
 
 // highlightSearchMatches wraps each occurrence of the search term in the visible text
@@ -657,11 +721,41 @@ func (m Model) annotationContinuationIndent(firstLogicalLine string) string {
 	}
 }
 
-const wrapGutterWidth = 3 // wrap gutter prefix width: " + ", " - ", "   ", " ↪ "
+const (
+	wrapGutterWidth = 3  // wrap gutter prefix width: " + ", " - ", "   ", " ↪ "
+	wrapMinContent  = 10 // minimum content width per visual row when wrap-indent is active
+)
 
-// wrapWidth returns the available width for wrapped content (diff content minus gutter prefix and extra gutters).
+// wrapWidth returns the available width for wrapped content (diff content minus
+// gutter prefix and extra gutters). when wrapIndent > 0, an additional indent is
+// reserved so continuation rows can prepend that many spaces after the ↪ marker
+// without overflowing the pane. as a side effect, the first visual row also
+// wraps at the indent-reduced width — content that would otherwise fit edge-to-edge
+// can wrap one row earlier than necessary. acceptable trade-off vs. the complexity
+// of asymmetric wrapping (different widths per visual row).
+//
+// guards against pathologically large wrapIndent values (or narrow terminals) that
+// would push content below wrapMinContent: in that case the indent is silently
+// disabled for this render so wrap mode stays usable. wrap mode skips horizontal
+// scroll, so a sub-zero return here would let long lines overflow the pane.
 func (m Model) wrapWidth() int {
-	return m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+	base := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+	if base-m.cfg.wrapIndent < wrapMinContent {
+		return base
+	}
+	return base - m.cfg.wrapIndent
+}
+
+// effectiveWrapIndent returns the wrap-indent that is actually applied for the
+// current pane width. mirrors the clamp in wrapWidth so the styledWrapMarker's
+// indent padding stays in sync — when wrapWidth disables the indent due to a
+// narrow pane, the marker likewise emits no indent padding.
+func (m Model) effectiveWrapIndent() int {
+	base := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+	if base-m.cfg.wrapIndent < wrapMinContent {
+		return 0
+	}
+	return m.cfg.wrapIndent
 }
 
 // diffContentWidth returns the available width for diff line content.

--- a/app/ui/diffview.go
+++ b/app/ui/diffview.go
@@ -500,7 +500,7 @@ func (m Model) linePrefix(changeType diff.ChangeType) string {
 // chroma highlighting is on. Highlighted line styles intentionally set only
 // background (chroma owns per-token fg for content), so the prefix would
 // otherwise inherit the terminal default fg and may render invisibly on
-// light theme backgrounds. an empty prefix is returned unchanged so callers
+// light theme backgrounds. An empty prefix is returned unchanged so callers
 // passing "" (e.g. wrap-mode continuation rows that style the marker themselves)
 // don't pay for an empty fg-set + fg-reset SGR pair on every row.
 func (m Model) wrapPrefixForHighlight(prefix string, fg style.Color, hasHighlight bool) string {
@@ -515,23 +515,23 @@ func (m Model) wrapPrefixForHighlight(prefix string, fg style.Color, hasHighligh
 // spaces (where N is m.effectiveWrapIndent — the configured wrapIndent unless
 // the pane is too narrow to keep enough content width, see wrapWidth) so
 // continuation content visually hangs under the first row's content rather than
-// aligning with new bullets/items at the same column. matches the muted treatment
+// aligning with new bullets/items at the same column. Matches the muted treatment
 // of «/» horizontal scroll indicators (see scrollIndicatorANSI) — both gutter-chrome
 // glyphs use ColorKeyMutedFg via raw ANSI rather than going through lipgloss so
-// they do not inherit chroma syntax color or change-line foreground. the two
+// they do not inherit chroma syntax color or change-line foreground. The two
 // helpers stay separate because scrollIndicatorANSI also handles split bg semantics
 // (line-bg space + DiffBg glyph) that the wrap marker does not need (the wrap
-// marker is gutter-only chrome, never overlaid on content). an empty bg here
+// marker is gutter-only chrome, never overlaid on content). An empty bg here
 // falls back to DiffPaneBg so context rows (which have no LineBg) still match
 // the surrounding pane.
 //
 // searchMatch toggles the no-colors behavior: when true and --no-colors is on,
 // the marker emits a reverse-video wrap to match the SearchMatch lipgloss style
 // (which renders as Reverse in plain mode), preventing a plain ↪ marker from
-// sitting on a reverse-video content row. in colored mode the caller already
+// sitting on a reverse-video content row. In colored mode the caller already
 // flipped bg to SearchBg, so searchMatch is a no-op on the colored path.
 //
-// in --no-colors mode without search match, all color lookups return empty and
+// In --no-colors mode without search match, all color lookups return empty and
 // the marker degrades to plain " ↪ " plus the indent spaces.
 func (m Model) styledWrapMarker(bg style.Color, searchMatch bool) string {
 	if m.cfg.noColors && searchMatch {

--- a/app/ui/diffview_test.go
+++ b/app/ui/diffview_test.go
@@ -639,8 +639,9 @@ func TestModel_StyledWrapMarker(t *testing.T) {
 	t.Run("no-colors mode degrades to plain marker", func(t *testing.T) {
 		plain := testModel(nil, nil)
 		plain.resolver = style.PlainResolver()
+		plain.cfg.noColors = true
 		got := plain.styledWrapMarker("", false)
-		assert.Equal(t, " ↪ ", got, "without colors the marker should be plain ascii")
+		assert.Equal(t, " ↪ ", got, "without colors the marker should carry no ANSI sequences")
 	})
 
 	t.Run("no-colors search-match emits reverse video", func(t *testing.T) {
@@ -753,7 +754,7 @@ func TestModel_WrappedLineCountReactsToIndent(t *testing.T) {
 	m.cfg.wrapIndent = 8
 	withIndentRows := m.wrappedLineCount(0)
 
-	assert.Greater(t, withIndentRows, noIndentRows, "non-zero wrapIndent should not reduce row count for an already-fitting line")
+	assert.Greater(t, withIndentRows, noIndentRows, "non-zero wrapIndent must produce more visual rows when content crosses the new wrap boundary")
 }
 
 func TestModel_PlainStyles(t *testing.T) {

--- a/app/ui/diffview_test.go
+++ b/app/ui/diffview_test.go
@@ -604,6 +604,158 @@ func TestModel_ApplyHorizontalScrollIndicatorInNoColorsMode(t *testing.T) {
 	assert.Contains(t, ansi.Strip(result), "»", "indicator glyph should still be visible in no-colors mode")
 }
 
+func TestModel_StyledWrapMarker(t *testing.T) {
+	colors := style.Colors{DiffBg: "#112233", AddBg: "#1a3320", RemoveBg: "#331a1a", Muted: "#999999"}
+	res := style.NewResolver(colors)
+	m := testModel(nil, nil)
+	m.resolver = res
+
+	mutedFg := "\033[38;2;153;153;153m" // #999999
+	diffBg := "\033[48;2;17;34;51m"     // #112233
+	addBg := "\033[48;2;26;51;32m"      // #1a3320
+	removeBg := "\033[48;2;51;26;26m"   // #331a1a
+
+	tests := []struct {
+		name    string
+		bg      style.Color
+		wantBg  string
+		wantStr string // visible glyph
+	}{
+		{name: "context (empty bg falls back to diff bg)", bg: "", wantBg: diffBg, wantStr: " ↪ "},
+		{name: "add line bg", bg: style.Color(addBg), wantBg: addBg, wantStr: " ↪ "},
+		{name: "remove line bg", bg: style.Color(removeBg), wantBg: removeBg, wantStr: " ↪ "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.styledWrapMarker(tt.bg, false)
+			assert.Equal(t, tt.wantStr, ansi.Strip(got), "visible content must be exactly ' ↪ '")
+			assert.Contains(t, got, mutedFg, "marker must use muted fg, matching « » indicators")
+			assert.Contains(t, got, tt.wantBg, "marker must carry the resolved line bg")
+			assert.Contains(t, got, "\033[39m", "marker must reset fg so following content keeps its own color")
+			assert.Contains(t, got, "\033[49m", "marker must reset bg so following content keeps its own bg")
+		})
+	}
+
+	t.Run("no-colors mode degrades to plain marker", func(t *testing.T) {
+		plain := testModel(nil, nil)
+		plain.resolver = style.PlainResolver()
+		got := plain.styledWrapMarker("", false)
+		assert.Equal(t, " ↪ ", got, "without colors the marker should be plain ascii")
+	})
+
+	t.Run("no-colors search-match emits reverse video", func(t *testing.T) {
+		plain := testModel(nil, nil)
+		plain.resolver = style.PlainResolver()
+		plain.cfg.noColors = true
+		got := plain.styledWrapMarker("", true)
+		assert.Contains(t, got, "\033[7m", "search-matched marker must wrap in reverse video so it matches the SearchMatch lipgloss style in plain mode")
+		assert.Contains(t, got, "\033[27m", "search-matched marker must close the reverse video")
+		assert.Equal(t, " ↪ ", ansi.Strip(got), "visible glyph stays the same")
+	})
+
+	t.Run("colored search-match path is identical to non-search (caller already flipped bg)", func(t *testing.T) {
+		mc := testModel(nil, nil)
+		mc.resolver = res
+		searchBg := style.Color("\033[48;2;102;85;34m")
+		gotSearch := mc.styledWrapMarker(searchBg, true)
+		gotNoSearch := mc.styledWrapMarker(searchBg, false)
+		assert.Equal(t, gotNoSearch, gotSearch, "colored path must not branch on searchMatch — caller controls bg")
+	})
+
+	t.Run("wrap indent appends bg-padded spaces", func(t *testing.T) {
+		indent := testModel(nil, nil)
+		indent.resolver = res
+		indent.cfg.wrapIndent = 4
+		got := indent.styledWrapMarker(style.Color(addBg), false)
+		assert.Equal(t, " ↪     ", ansi.Strip(got), "marker plus 4 indent spaces visible")
+		assert.Contains(t, got, addBg, "indent padding stays on line bg")
+		assert.Equal(t, 1, strings.Count(got, "\033[49m"), "single bg reset at end of marker+indent")
+	})
+
+	t.Run("no-colors search-match honors wrap indent", func(t *testing.T) {
+		plain := testModel(nil, nil)
+		plain.resolver = style.PlainResolver()
+		plain.cfg.noColors = true
+		plain.cfg.wrapIndent = 3
+		got := plain.styledWrapMarker("", true)
+		assert.Equal(t, " ↪    ", ansi.Strip(got), "reverse-video marker must include the configured indent")
+	})
+
+	t.Run("oversized indent on narrow pane clamps to zero", func(t *testing.T) {
+		narrow := testModel(nil, nil)
+		narrow.resolver = res
+		narrow.layout.width = 30
+		narrow.layout.treeWidth = 0
+		narrow.file.singleFile = true
+		narrow.cfg.wrapIndent = 200 // far larger than the available content width
+		got := narrow.styledWrapMarker(style.Color(addBg), false)
+		assert.Equal(t, " ↪ ", ansi.Strip(got), "clamp must drop the indent padding when pane is too narrow")
+		assert.Equal(t, 0, narrow.effectiveWrapIndent(), "effectiveWrapIndent should report 0 when clamped")
+	})
+}
+
+func TestModel_WrapWidthClampsLargeIndent(t *testing.T) {
+	m := testModel(nil, nil)
+	m.layout.width = 120
+	m.layout.treeWidth = 0
+	m.file.singleFile = true
+
+	base := m.diffContentWidth() - wrapGutterWidth - m.gutterExtra()
+
+	tests := []struct {
+		name      string
+		indent    int
+		wantWidth int
+		wantEff   int
+	}{
+		{name: "indent 0 returns full base", indent: 0, wantWidth: base, wantEff: 0},
+		{name: "indent 4 reserves room", indent: 4, wantWidth: base - 4, wantEff: 4},
+		{name: "indent at boundary keeps wrapMinContent", indent: base - wrapMinContent, wantWidth: wrapMinContent, wantEff: base - wrapMinContent},
+		{name: "indent past boundary clamps to base", indent: base - wrapMinContent + 1, wantWidth: base, wantEff: 0},
+		{name: "indent equal to base clamps to base", indent: base, wantWidth: base, wantEff: 0},
+		{name: "indent way past base clamps to base", indent: base * 10, wantWidth: base, wantEff: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m.cfg.wrapIndent = tt.indent
+			assert.Equal(t, tt.wantWidth, m.wrapWidth(), "wrapWidth must guard against narrow panes")
+			assert.Equal(t, tt.wantEff, m.effectiveWrapIndent(), "effectiveWrapIndent stays in sync with wrapWidth's clamp")
+		})
+	}
+}
+
+func TestModel_NewModelClampsNegativeWrapIndent(t *testing.T) {
+	renderer := &mocks.RendererMock{
+		ChangedFilesFunc: func(string, bool) ([]diff.FileEntry, error) { return nil, nil },
+		FileDiffFunc:     func(string, string, bool, int) ([]diff.DiffLine, error) { return nil, nil },
+	}
+	m := testNewModel(t, renderer, annotation.NewStore(), noopHighlighter(), ModelConfig{WrapIndent: -7})
+	assert.Equal(t, 0, m.cfg.wrapIndent, "negative WrapIndent must clamp to 0 at construction")
+}
+
+func TestModel_WrappedLineCountReactsToIndent(t *testing.T) {
+	m := testModel(nil, nil)
+	m.layout.width = 60
+	m.layout.treeWidth = 0
+	m.file.singleFile = true
+	m.modes.wrap = true
+
+	// content sized so it fits in one row at indent=0 but spills to a second row at indent>=8
+	contentLen := m.diffContentWidth() - wrapGutterWidth - 1
+	textContent := strings.Repeat("x", contentLen)
+	m.file.lines = []diff.DiffLine{{ChangeType: diff.ChangeContext, Content: textContent}}
+	m.file.highlighted = []string{textContent}
+	m.file.intraRanges = make([][]worddiff.Range, 1)
+
+	m.cfg.wrapIndent = 0
+	noIndentRows := m.wrappedLineCount(0)
+
+	m.cfg.wrapIndent = 8
+	withIndentRows := m.wrappedLineCount(0)
+
+	assert.Greater(t, withIndentRows, noIndentRows, "non-zero wrapIndent should not reduce row count for an already-fitting line")
+}
+
 func TestModel_PlainStyles(t *testing.T) {
 	renderer := &mocks.RendererMock{
 		ChangedFilesFunc: func(string, bool) ([]diff.FileEntry, error) { return []diff.FileEntry{{Path: "a.go"}}, nil },

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -264,6 +264,7 @@ type modelConfigState struct {
 	crossFileHunks   bool     // allow [ and ] to jump across file boundaries
 	treeWidthRatio   int      // 1-10 units for file tree panel
 	tabSpaces        string   // spaces to replace tabs with
+	wrapIndent       int      // extra indent (in columns) for wrap continuation rows; 0 disables
 }
 
 // layoutState holds viewport and layout concerns that change on resize and pane toggles.
@@ -598,6 +599,7 @@ type ModelConfig struct {
 	NoStatusBar      bool     // hide the status bar
 	NoConfirmDiscard bool     // skip confirmation prompt when discarding annotations
 	Wrap             bool     // enable line wrapping
+	WrapIndent       int      // extra indent (cols) for wrap continuation rows; 0 disables
 	Collapsed        bool     // start in collapsed diff mode
 	CrossFileHunks   bool     // allow [ and ] to jump across file boundaries
 	LineNumbers      bool     // show line numbers in diff gutter
@@ -733,6 +735,7 @@ func NewModel(cfg ModelConfig) (Model, error) {
 			crossFileHunks:   cfg.CrossFileHunks,
 			treeWidthRatio:   cfg.TreeWidthRatio,
 			tabSpaces:        strings.Repeat(" ", cfg.TabWidth),
+			wrapIndent:       max(0, cfg.WrapIndent),
 		},
 		layout: layoutState{
 			focus: paneTree,

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -24,6 +24,7 @@ Then uncomment and edit the values you want to change.
 | `--no-colors` | `REVDIFF_NO_COLORS` | Disable all colors including syntax highlighting | `false` |
 | `--no-status-bar` | `REVDIFF_NO_STATUS_BAR` | Hide the status bar | `false` |
 | `--wrap` | `REVDIFF_WRAP` | Enable line wrapping in diff view | `false` |
+| `--wrap-indent` | `REVDIFF_WRAP_INDENT` | Indent wrap continuation rows by N columns so they hang under the first row's content (helps when reviewing markdown lists where unindented continuation can be misread as a new bullet) | `0` |
 | `--collapsed` | `REVDIFF_COLLAPSED` | Start in collapsed diff mode | `false` |
 | `--compact` | `REVDIFF_COMPACT` | Start in compact diff mode (small context around changes) | `false` |
 | `--compact-context` | `REVDIFF_COMPACT_CONTEXT` | Number of context lines around changes when in compact mode | `5` |

--- a/site/docs.html
+++ b/site/docs.html
@@ -356,6 +356,7 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>--no-colors</code></td><td>Disable all colors</td><td><code>false</code></td></tr>
                 <tr><td><code>--no-status-bar</code></td><td>Hide the status bar</td><td><code>false</code></td></tr>
                 <tr><td><code>--wrap</code></td><td>Enable line wrapping</td><td><code>false</code></td></tr>
+                <tr><td><code>--wrap-indent</code></td><td>Indent wrap continuation rows by N columns so they hang under the first row's content</td><td><code>0</code></td></tr>
                 <tr><td><code>--collapsed</code></td><td>Start in collapsed diff mode</td><td><code>false</code></td></tr>
                 <tr><td><code>--compact</code></td><td>Start in compact diff mode (small context around changes)</td><td><code>false</code></td></tr>
                 <tr><td><code>--compact-context</code></td><td>Number of context lines around changes when in compact mode</td><td><code>5</code></td></tr>


### PR DESCRIPTION
**Wrap continuation marker color**

The `↪` glyph used to inherit chroma syntax color or change-line foreground because the highlighted line styles set only background and let content fg fall through. It now renders with `MutedFg` via raw ANSI outside lipgloss, matching the muted treatment of `«`/`»` horizontal scroll indicators.

Applied at all three wrap callsites (`renderWrappedDiffLine`, `renderWrappedCollapsedLine`, `renderDeletePlaceholder`).

**`--wrap-indent N` option**

Default `0` (current behavior, byte-identical). When `> 0`, the marker is followed by N background-padded spaces so wrapped continuation content visually hangs under the first row's content rather than column-aligning with new bullets/items at the same column. Useful when reviewing markdown lists where unindented continuation can be misread as a new bullet.

`wrapWidth()` reserves the indent so total visual width stays consistent. Clamps so wrap width never drops below `wrapMinContent` (10) - wrap mode skips horizontal scroll, so a sub-zero return would let long lines overflow the pane silently. `effectiveWrapIndent()` mirrors the clamp so the marker padding stays in sync.

Trade-off: the indent reservation also shrinks the first row's wrap width even though the first row doesn't render the indent. Asymmetric per-row wrapping was rejected as too complex for the visual gain.

**Search-match consistency**

Two related search-match issues surfaced during code review and were fixed:

1. *Colored mode bg seam*: in collapsed mode, search-matched rows used `lineStyle = SearchMatch` (with `SearchBg`) but `bgColor` stayed at add/modify/remove bg. The wrap marker (rendered outside lipgloss) and the right-side `extendLineBg` padding therefore showed a visible bg seam against the search-styled content. Fixed by flipping `bgColor` to `SearchBg` in the search-match branch.

2. *No-colors plain marker*: in `--no-colors` mode, the `SearchMatch` lipgloss style renders as `Reverse(true)`, but `styledWrapMarker` returned a plain `" ↪ "`. Search-matched continuation rows showed a plain marker against reverse-video content. Fixed by adding a `searchMatch bool` parameter to `styledWrapMarker`; in no-colors + search-match it emits `\x1b[7m...\x1b[27m` around the marker.

`renderWrappedDiffLine` (non-collapsed) passes `searchMatch=false` because its search highlight is per-word inside the existing change-type lipgloss style, not full-line `Reverse`.

**Linter config**

Drops `goconst` from `.golangci.yml` (config + enabled list + test exception). The 12 pre-existing `goconst` complaints in the codebase were noise more than signal at `min-occurrences: 7`.

**Tests**

- `TestModel_StyledWrapMarker`: 9 subtests covering color modes, bg fallback, no-colors plain, no-colors search-match reverse-video, colored search-match parity, indent emission, oversized indent clamp.
- `TestModel_WrapWidthClampsLargeIndent`: 6-row table at indent boundaries (0, 4, exactly at clamp, past clamp, equal to base, way past base).
- `TestModel_NewModelClampsNegativeWrapIndent`: negative `WrapIndent` clamps to 0 in `NewModel`.
- `TestModel_WrappedLineCountReactsToIndent`: `wrappedLineCount` reacts to `wrapIndent` so cursor/viewport math stays consistent.
- `TestModel_CollapsedWrapSearchMatchUsesSearchBg`: end-to-end render asserts SearchBg on collapsed wrap continuations and on delete-placeholder continuations.
- `TestParseArgs_WrapIndent`: 4 subtests (default, flag, env, config file).
- `TestDumpConfig`: assertion for `wrap-indent = 0` in the dumped config.

**Docs**

`README.md`, `site/docs.html`, `.claude-plugin/skills/revdiff/references/config.md`, and `plugins/codex/skills/revdiff/references/config.md` all updated with the new flag and a description that conveys the markdown-list-review use case rather than vague "bullets/items" wording.
