### PR TITLE
feat: in-session search history recall

### DIFF
--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -128,6 +128,8 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `/` | Start search in diff pane |
 | `n` | Next search match (overrides next file when search active) |
 | `N` | Previous search match |
+| `↑` / `Ctrl+P` | Recall previous search query (in search prompt) |
+| `↓` / `Ctrl+N` | Recall next search query / clear (in search prompt) |
 | `Esc` | Cancel search input / clear search results |
 
 **Annotations:**

--- a/README.md
+++ b/README.md
@@ -644,6 +644,8 @@ In the Claude Code and Codex plugins, you can also tell the agent to use a past 
 | `/` | Start search in diff pane |
 | `n` | Next search match (overrides next file when search active) |
 | `N` | Previous file (previous search match when searching) |
+| `↑` / `Ctrl+P` | Recall previous search query (in search prompt) |
+| `↓` / `Ctrl+N` | Recall next search query / clear (in search prompt) |
 | `Esc` | Cancel search input / clear search results |
 
 **Annotations:**

--- a/app/themes.go
+++ b/app/themes.go
@@ -264,8 +264,7 @@ func (tc *themeCatalog) patchConfigTheme(themeName string) error {
 	// config previously poisoned by the old persist path is fully healed (not
 	// just patched in one spot while go-flags keeps erroring on a remaining stray).
 	// deleting in reverse order keeps earlier indices stable.
-	for i := len(strayIdxs) - 1; i >= 0; i-- {
-		stray := strayIdxs[i]
+	for _, stray := range slices.Backward(strayIdxs) {
 		lines = slices.Delete(lines, stray, stray+1)
 		if defaultIdx > stray {
 			defaultIdx--

--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -571,7 +572,7 @@ func (m Model) visualRowToDiffLine(row int) (idx int, onAnnotation bool) {
 		running += h
 	}
 	// row past the last visible line: return the last visible line index
-	for i := len(m.file.lines) - 1; i >= 0; i-- {
+	for i := range slices.Backward(m.file.lines) {
 		if m.hunkLineHeight(i, hunks, annSet) > 0 {
 			return i, false
 		}

--- a/app/ui/diffnav.go
+++ b/app/ui/diffnav.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"slices"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/umputun/revdiff/app/diff"
@@ -196,8 +198,8 @@ func (m *Model) moveDiffCursorToStart() {
 func (m *Model) moveDiffCursorToEnd() {
 	m.annot.cursorOnAnnotation = false
 	hunks := m.findHunks()
-	for i := len(m.file.lines) - 1; i >= 0; i-- {
-		if m.file.lines[i].ChangeType != diff.ChangeDivider && !m.isCollapsedHidden(i, hunks) {
+	for i, dl := range slices.Backward(m.file.lines) {
+		if dl.ChangeType != diff.ChangeDivider && !m.isCollapsedHidden(i, hunks) {
 			m.nav.diffCursor = i
 			break
 		}
@@ -417,8 +419,8 @@ func (m *Model) moveToNextHunk() {
 func (m *Model) moveToPrevHunk() {
 	m.annot.cursorOnAnnotation = false
 	hunks := m.findHunks()
-	for i := len(hunks) - 1; i >= 0; i-- {
-		target := m.firstVisibleInHunk(hunks[i], hunks)
+	for _, h := range slices.Backward(hunks) {
+		target := m.firstVisibleInHunk(h, hunks)
 		if target < 0 {
 			continue // skip delete-only hunks in collapsed mode
 		}

--- a/app/ui/handlers.go
+++ b/app/ui/handlers.go
@@ -63,6 +63,12 @@ func (m Model) buildHelpSpec() overlay.HelpSpec {
 				Description: e.Description,
 			})
 		}
+		if sec.Name == "Search" {
+			entries = append(entries,
+				overlay.HelpEntry{Keys: "↑ / Ctrl+P", Description: "recall previous search query (in search prompt)"},
+				overlay.HelpEntry{Keys: "↓ / Ctrl+N", Description: "recall next search query / clear (in search prompt)"},
+			)
+		}
 		result = append(result, overlay.HelpSection{Title: sec.Name, Entries: entries})
 
 		if sec.Name == keymap.SectionPane {

--- a/app/ui/handlers_test.go
+++ b/app/ui/handlers_test.go
@@ -738,6 +738,34 @@ func TestModel_ToggleCompactMode_CursorResetsAfterReload(t *testing.T) {
 	assert.Equal(t, 1, model.nav.diffCursor, "cursor must reset to first non-divider line after compact re-fetch")
 }
 
+func TestBuildHelpSpec_SearchPromptHistoryEntries(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+
+	spec := m.buildHelpSpec()
+	var searchSection *overlay.HelpSection
+	for i := range spec.Sections {
+		if spec.Sections[i].Title == "Search" {
+			searchSection = &spec.Sections[i]
+			break
+		}
+	}
+	require.NotNil(t, searchSection, "help overlay must include a Search section")
+
+	var upEntry, downEntry *overlay.HelpEntry
+	for i := range searchSection.Entries {
+		switch searchSection.Entries[i].Keys {
+		case "↑ / Ctrl+P":
+			upEntry = &searchSection.Entries[i]
+		case "↓ / Ctrl+N":
+			downEntry = &searchSection.Entries[i]
+		}
+	}
+	require.NotNil(t, upEntry, "Search section must list the Up / Ctrl+P recall binding")
+	require.NotNil(t, downEntry, "Search section must list the Down / Ctrl+N recall binding")
+	assert.Contains(t, upEntry.Description, "previous", "Up entry description must mention previous query")
+	assert.Contains(t, downEntry.Description, "next", "Down entry description must mention next query")
+}
+
 func TestBuildHelpSpec_VimMotionSectionOff(t *testing.T) {
 	m := testModel([]string{"a.go"}, nil)
 	m.modes.vimMotion = false

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -657,7 +657,7 @@ type ModelConfig struct {
 func isNilValue(v any) bool {
 	rv := reflect.ValueOf(v)
 	k := rv.Kind()
-	if k == reflect.Ptr || k == reflect.Interface || k == reflect.Chan ||
+	if k == reflect.Pointer || k == reflect.Interface || k == reflect.Chan ||
 		k == reflect.Func || k == reflect.Map || k == reflect.Slice {
 		return rv.IsNil()
 	}

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -300,12 +300,14 @@ type navigationState struct {
 
 // searchState holds all search lifecycle state.
 type searchState struct {
-	active   bool            // true when search textinput is active (typing)
-	term     string          // last submitted search query
-	matches  []int           // indices into file.lines that match
-	cursor   int             // current position in matches (0-based)
-	input    textinput.Model // dedicated textinput for search
-	matchSet map[int]bool    // set of file.lines indices that match, computed per render
+	active     bool            // true when search textinput is active (typing)
+	term       string          // last submitted search query
+	matches    []int           // indices into file.lines that match
+	cursor     int             // current position in matches (0-based)
+	input      textinput.Model // dedicated textinput for search
+	matchSet   map[int]bool    // set of file.lines indices that match, computed per render
+	history    []string        // submitted queries, oldest-first; in-memory, session-scoped
+	historyIdx int             // current recall position; len(history) means "draft" slot (no recall active)
 }
 
 // commitsState holds the commit log for the info popup, fetched

--- a/app/ui/search.go
+++ b/app/ui/search.go
@@ -121,13 +121,11 @@ func (m *Model) cancelSearch() {
 // oldest entries are dropped. historyIdx is reset to the draft slot so the
 // next recall starts from "no recall active".
 func (m *Model) appendSearchHistory(query string) {
-	if n := len(m.search.history); n > 0 && m.search.history[n-1] == query {
-		m.search.historyIdx = len(m.search.history)
-		return
-	}
-	m.search.history = append(m.search.history, query)
-	if len(m.search.history) > searchHistoryMax {
-		m.search.history = m.search.history[len(m.search.history)-searchHistoryMax:]
+	if n := len(m.search.history); n == 0 || m.search.history[n-1] != query {
+		m.search.history = append(m.search.history, query)
+		if len(m.search.history) > searchHistoryMax {
+			m.search.history = m.search.history[len(m.search.history)-searchHistoryMax:]
+		}
 	}
 	m.search.historyIdx = len(m.search.history)
 }

--- a/app/ui/search.go
+++ b/app/ui/search.go
@@ -140,13 +140,8 @@ func (m *Model) recallHistory(direction int) {
 	if len(m.search.history) == 0 {
 		return
 	}
-	idx := m.search.historyIdx + direction
-	if idx < 0 {
-		idx = 0
-	}
-	if idx > len(m.search.history) {
-		idx = len(m.search.history)
-	}
+	idx := max(m.search.historyIdx+direction, 0)
+	idx = min(idx, len(m.search.history))
 	if idx == len(m.search.history) {
 		m.search.input.SetValue("")
 	} else {

--- a/app/ui/search.go
+++ b/app/ui/search.go
@@ -7,6 +7,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// searchHistoryMax bounds the retained per-session search-query history.
+// when exceeded, oldest entries are dropped.
+const searchHistoryMax = 50
+
 // startSearch creates a search textinput and enters searching mode.
 func (m *Model) startSearch() tea.Cmd {
 	m.clearPendingInputState()
@@ -17,6 +21,7 @@ func (m *Model) startSearch() tea.Cmd {
 	ti.Width = max(10, m.layout.width-m.layout.treeWidth-10)
 	m.search.input = ti
 	m.search.active = true
+	m.search.historyIdx = len(m.search.history)
 	return cmd
 }
 
@@ -32,6 +37,7 @@ func (m *Model) submitSearch() {
 	}
 
 	m.search.term = strings.ToLower(query)
+	m.appendSearchHistory(query)
 	m.search.matches = nil
 	m.search.cursor = 0
 
@@ -110,6 +116,46 @@ func (m *Model) cancelSearch() {
 	m.search.active = false
 }
 
+// appendSearchHistory records query in the in-session history. consecutive
+// duplicates are skipped (less-style dedup). when the cap is exceeded, the
+// oldest entries are dropped. historyIdx is reset to the draft slot so the
+// next recall starts from "no recall active".
+func (m *Model) appendSearchHistory(query string) {
+	if n := len(m.search.history); n > 0 && m.search.history[n-1] == query {
+		m.search.historyIdx = len(m.search.history)
+		return
+	}
+	m.search.history = append(m.search.history, query)
+	if len(m.search.history) > searchHistoryMax {
+		m.search.history = m.search.history[len(m.search.history)-searchHistoryMax:]
+	}
+	m.search.historyIdx = len(m.search.history)
+}
+
+// recallHistory walks the in-session search history. direction -1 walks toward
+// older queries, +1 walks toward newer. clamps to [0, len(history)]; the
+// upper bound represents the "draft" slot (input cleared, no recall active).
+// no-op when history is empty.
+func (m *Model) recallHistory(direction int) {
+	if len(m.search.history) == 0 {
+		return
+	}
+	idx := m.search.historyIdx + direction
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > len(m.search.history) {
+		idx = len(m.search.history)
+	}
+	if idx == len(m.search.history) {
+		m.search.input.SetValue("")
+	} else {
+		m.search.input.SetValue(m.search.history[idx])
+	}
+	m.search.input.CursorEnd()
+	m.search.historyIdx = idx
+}
+
 // realignSearchCursor updates searchCursor to the nearest visible match at or after diffCursor.
 // called after adjustCursorIfHidden moves diffCursor so the [X/Y] display stays accurate
 // and n/N navigation starts from the correct position.
@@ -173,6 +219,12 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyEsc:
 		m.cancelSearch()
+		return m, nil
+	case tea.KeyUp, tea.KeyCtrlP:
+		m.recallHistory(-1)
+		return m, nil
+	case tea.KeyDown, tea.KeyCtrlN:
+		m.recallHistory(+1)
 		return m, nil
 	default:
 		var cmd tea.Cmd

--- a/app/ui/search.go
+++ b/app/ui/search.go
@@ -180,7 +180,8 @@ func (m *Model) findFirstVisibleMatch(startIdx int) int {
 	return -1
 }
 
-// clearSearch resets all search state.
+// clearSearch resets per-query search state (term, matches, cursor, matchSet).
+// session-scoped history fields are intentionally preserved.
 func (m *Model) clearSearch() {
 	m.search.term = ""
 	m.search.matches = nil

--- a/app/ui/search_test.go
+++ b/app/ui/search_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1311,4 +1312,315 @@ func TestModel_SearchWithTOCActive(t *testing.T) {
 		// active section should reflect the cursor position after search nav (Section entry at lineIdx=2)
 		assert.Equal(t, 2, tocActiveLineIdx(t, model.file.mdTOC), "TOC should track active section after search jump (lineIdx=2)")
 	})
+}
+
+// helper: build a model with the given diff lines and return it ready to search.
+func newSearchHistoryModel(t *testing.T) Model {
+	t.Helper()
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "alpha line", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "beta added", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "gamma context", ChangeType: diff.ChangeContext},
+	}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	model := result.(Model)
+	result, _ = model.Update(fileLoadedMsg{file: "a.go", lines: lines})
+	model = result.(Model)
+	model.layout.focus = paneDiff
+	return model
+}
+
+// helper: submit a query through submitSearch and return the resulting model.
+func submitQueryThroughInput(model Model, query string) Model {
+	model.search.active = true
+	model.search.input = textinput.New()
+	model.search.input.SetValue(query)
+	model.submitSearch()
+	return model
+}
+
+func TestModel_SearchHistory_AppendsOnSubmit(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	model = submitQueryThroughInput(model, "gamma")
+
+	assert.Equal(t, []string{"alpha", "beta", "gamma"}, model.search.history)
+	assert.Equal(t, len(model.search.history), model.search.historyIdx, "historyIdx should reset to draft slot after submit")
+}
+
+func TestModel_SearchHistory_ZeroMatchQueryStillAppended(t *testing.T) {
+	// queries that match nothing must still be recallable so the user can edit and retry.
+	// this verifies the append placement is BEFORE the match scan.
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "no-such-text")
+
+	assert.Empty(t, model.search.matches, "query should produce zero matches")
+	assert.Equal(t, []string{"no-such-text"}, model.search.history, "zero-match query must still appear in history")
+}
+
+func TestModel_SearchHistory_ConsecutiveDuplicatesNotAppended(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "alpha")
+
+	assert.Equal(t, []string{"alpha"}, model.search.history, "consecutive duplicates should be deduped")
+}
+
+func TestModel_SearchHistory_NonConsecutiveDuplicateAppends(t *testing.T) {
+	// resubmitting an older entry moves it to "most recent".
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	model = submitQueryThroughInput(model, "alpha")
+
+	assert.Equal(t, []string{"alpha", "beta", "alpha"}, model.search.history)
+}
+
+func TestModel_SearchHistory_CapEnforced(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	// push searchHistoryMax+1 unique entries; oldest must be dropped.
+	for i := 0; i < searchHistoryMax+1; i++ {
+		q := fmt.Sprintf("q%d", i)
+		model = submitQueryThroughInput(model, q)
+	}
+
+	require.Len(t, model.search.history, searchHistoryMax)
+	assert.Equal(t, "q1", model.search.history[0], "oldest entry q0 should have been dropped")
+	assert.Equal(t, fmt.Sprintf("q%d", searchHistoryMax), model.search.history[searchHistoryMax-1], "newest entry should be at the tail")
+}
+
+func TestModel_SearchHistory_WhitespaceOnlyNotAppended(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model.search.active = true
+	model.search.input = textinput.New()
+	model.search.input.SetValue("   ")
+	model.submitSearch()
+
+	assert.Empty(t, model.search.history, "whitespace-only query should not be added to history")
+}
+
+func TestModel_SearchHistory_ClearSearchPreservesHistory(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	require.Len(t, model.search.history, 2)
+	idxBefore := model.search.historyIdx
+
+	model.clearSearch()
+
+	assert.Equal(t, []string{"alpha", "beta"}, model.search.history, "history must survive clearSearch")
+	assert.Equal(t, idxBefore, model.search.historyIdx, "historyIdx must survive clearSearch")
+}
+
+func TestModel_SearchHistory_StartSearchResetsIdxToDraft(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	// simulate partial recall having moved idx away from draft.
+	model.search.historyIdx = 0
+
+	model.startSearch()
+
+	assert.Equal(t, len(model.search.history), model.search.historyIdx, "startSearch must reset idx to draft slot")
+}
+
+func TestModel_SearchHistory_RecallEmptyHistoryNoop(t *testing.T) {
+	model := newSearchHistoryModel(t)
+	model.search.input = textinput.New()
+
+	// no submitted queries yet; recall in either direction must be a no-op.
+	model.recallHistory(-1)
+	assert.Empty(t, model.search.input.Value(), "input should remain empty")
+	assert.Equal(t, 0, model.search.historyIdx, "idx should not change with empty history")
+
+	model.recallHistory(+1)
+	assert.Empty(t, model.search.input.Value())
+	assert.Equal(t, 0, model.search.historyIdx)
+}
+
+func TestModel_SearchHistory_UpRecallsThroughOlderEntries(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	model = submitQueryThroughInput(model, "gamma")
+	// simulate user re-entering search prompt.
+	model.startSearch()
+
+	// first Up: most recent = "gamma".
+	model.recallHistory(-1)
+	assert.Equal(t, "gamma", model.search.input.Value())
+
+	// second Up: "beta".
+	model.recallHistory(-1)
+	assert.Equal(t, "beta", model.search.input.Value())
+
+	// third Up: "alpha".
+	model.recallHistory(-1)
+	assert.Equal(t, "alpha", model.search.input.Value())
+}
+
+func TestModel_SearchHistory_UpAtOldestStaysSticky(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	model.startSearch()
+
+	model.recallHistory(-1) // beta
+	model.recallHistory(-1) // alpha (oldest)
+	require.Equal(t, "alpha", model.search.input.Value())
+	require.Equal(t, 0, model.search.historyIdx)
+
+	// further Up at oldest is a sticky no-op.
+	model.recallHistory(-1)
+	assert.Equal(t, 0, model.search.historyIdx, "idx should stay at 0")
+	assert.Equal(t, "alpha", model.search.input.Value(), "input should still hold oldest entry")
+}
+
+func TestModel_SearchHistory_DownPastNewestClearsInput(t *testing.T) {
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	model.startSearch()
+
+	model.recallHistory(-1) // beta
+	require.Equal(t, "beta", model.search.input.Value())
+
+	// Down once: past newest → draft slot, input cleared.
+	model.recallHistory(+1)
+	assert.Empty(t, model.search.input.Value(), "down past newest should clear input")
+	assert.Equal(t, len(model.search.history), model.search.historyIdx, "idx should be at draft slot")
+
+	// further Down stays at draft slot.
+	model.recallHistory(+1)
+	assert.Empty(t, model.search.input.Value())
+	assert.Equal(t, len(model.search.history), model.search.historyIdx)
+}
+
+func TestModel_SearchHistory_UpDownInteractive(t *testing.T) {
+	// exercise the same path through bubbletea Update so KeyUp/KeyDown wiring is covered.
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+
+	// re-enter search prompt via '/'.
+	result, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = result.(Model)
+	require.True(t, model.search.active)
+
+	// Up: most recent = "beta".
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	model = result.(Model)
+	assert.Equal(t, "beta", model.search.input.Value(), "KeyUp should recall most recent")
+
+	// Up: "alpha".
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	model = result.(Model)
+	assert.Equal(t, "alpha", model.search.input.Value())
+
+	// Down: back to "beta".
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = result.(Model)
+	assert.Equal(t, "beta", model.search.input.Value())
+
+	// Down: draft slot, input cleared.
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = result.(Model)
+	assert.Empty(t, model.search.input.Value(), "second KeyDown should clear input at draft slot")
+}
+
+func TestModel_SearchHistory_CtrlPCtrlNParity(t *testing.T) {
+	// Ctrl+P / Ctrl+N must behave identically to Up / Down.
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+
+	result, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = result.(Model)
+
+	// Ctrl+P = Up.
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	model = result.(Model)
+	assert.Equal(t, "beta", model.search.input.Value())
+
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	model = result.(Model)
+	assert.Equal(t, "alpha", model.search.input.Value())
+
+	// Ctrl+N = Down.
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	model = result.(Model)
+	assert.Equal(t, "beta", model.search.input.Value())
+
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	model = result.(Model)
+	assert.Empty(t, model.search.input.Value(), "Ctrl+N past newest should clear input")
+}
+
+func TestModel_SearchHistory_RecallThenEscThenStartFresh(t *testing.T) {
+	// recall → Esc → '/' again. the input must be empty (draft slot), not the recalled value.
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+
+	// '/' to enter search.
+	result, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = result.(Model)
+
+	// Up: recalled value appears.
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	model = result.(Model)
+	require.Equal(t, "beta", model.search.input.Value())
+
+	// Esc: cancel without submitting.
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = result.(Model)
+	require.False(t, model.search.active)
+
+	// '/' again: input must be empty at draft slot, history unchanged.
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = result.(Model)
+	assert.True(t, model.search.active)
+	assert.Empty(t, model.search.input.Value(), "after recall+Esc+/, input must be empty (draft slot)")
+	assert.Equal(t, len(model.search.history), model.search.historyIdx, "idx should be at draft slot after fresh /")
+	assert.Equal(t, []string{"alpha", "beta"}, model.search.history, "history should be unchanged by recall+Esc")
+}
+
+func TestModel_SearchHistory_RecalledThenSubmittedAppendsAgain(t *testing.T) {
+	// recalling an older entry and pressing Enter appends it again (moves to most recent),
+	// unless it is already the most recent (dedup).
+	model := newSearchHistoryModel(t)
+
+	model = submitQueryThroughInput(model, "alpha")
+	model = submitQueryThroughInput(model, "beta")
+	require.Equal(t, []string{"alpha", "beta"}, model.search.history)
+
+	// re-enter search, recall "alpha" (older), submit.
+	result, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = result.(Model)
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyUp}) // beta
+	model = result.(Model)
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyUp}) // alpha
+	model = result.(Model)
+	require.Equal(t, "alpha", model.search.input.Value())
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = result.(Model)
+
+	assert.Equal(t, []string{"alpha", "beta", "alpha"}, model.search.history, "resubmitted older entry should appear again as most recent")
 }

--- a/app/ui/search_test.go
+++ b/app/ui/search_test.go
@@ -1387,7 +1387,7 @@ func TestModel_SearchHistory_CapEnforced(t *testing.T) {
 	model := newSearchHistoryModel(t)
 
 	// push searchHistoryMax+1 unique entries; oldest must be dropped.
-	for i := 0; i < searchHistoryMax+1; i++ {
+	for i := range searchHistoryMax + 1 {
 		q := fmt.Sprintf("q%d", i)
 		model = submitQueryThroughInput(model, q)
 	}

--- a/app/ui/search_test.go
+++ b/app/ui/search_test.go
@@ -1439,15 +1439,19 @@ func TestModel_SearchHistory_StartSearchResetsIdxToDraft(t *testing.T) {
 func TestModel_SearchHistory_RecallEmptyHistoryNoop(t *testing.T) {
 	model := newSearchHistoryModel(t)
 	model.search.input = textinput.New()
+	// pre-set a non-zero sentinel so the no-op contract is verifiable
+	// (otherwise an unconditional reset to 0 would also pass the assertion).
+	const sentinel = 7
+	model.search.historyIdx = sentinel
 
 	// no submitted queries yet; recall in either direction must be a no-op.
 	model.recallHistory(-1)
 	assert.Empty(t, model.search.input.Value(), "input should remain empty")
-	assert.Equal(t, 0, model.search.historyIdx, "idx should not change with empty history")
+	assert.Equal(t, sentinel, model.search.historyIdx, "idx should not change with empty history")
 
 	model.recallHistory(+1)
 	assert.Empty(t, model.search.input.Value())
-	assert.Equal(t, 0, model.search.historyIdx)
+	assert.Equal(t, sentinel, model.search.historyIdx)
 }
 
 func TestModel_SearchHistory_UpRecallsThroughOlderEntries(t *testing.T) {

--- a/app/ui/search_test.go
+++ b/app/ui/search_test.go
@@ -1394,7 +1394,8 @@ func TestModel_SearchHistory_CapEnforced(t *testing.T) {
 
 	require.Len(t, model.search.history, searchHistoryMax)
 	assert.Equal(t, "q1", model.search.history[0], "oldest entry q0 should have been dropped")
-	assert.Equal(t, fmt.Sprintf("q%d", searchHistoryMax), model.search.history[searchHistoryMax-1], "newest entry should be at the tail")
+	newest := fmt.Sprintf("q%d", searchHistoryMax)
+	assert.Equal(t, newest, model.search.history[searchHistoryMax-1], "newest entry should be at the tail")
 }
 
 func TestModel_SearchHistory_WhitespaceOnlyNotAppended(t *testing.T) {
@@ -1622,5 +1623,5 @@ func TestModel_SearchHistory_RecalledThenSubmittedAppendsAgain(t *testing.T) {
 	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = result.(Model)
 
-	assert.Equal(t, []string{"alpha", "beta", "alpha"}, model.search.history, "resubmitted older entry should appear again as most recent")
+	assert.Equal(t, []string{"alpha", "beta", "alpha"}, model.search.history, "resubmitted older entry moves to most recent")
 }

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -2,6 +2,7 @@ package sidepane
 
 import (
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -425,8 +426,8 @@ func (ft *FileTree) renderFileEntry(e treeEntry, idx, width int, rc renderCtx) s
 			runes := []rune(e.name)
 			w := 0
 			start := len(runes)
-			for i := len(runes) - 1; i >= 0; i-- {
-				rw := runewidth.RuneWidth(runes[i])
+			for i, r := range slices.Backward(runes) {
+				rw := runewidth.RuneWidth(r)
 				if w+rw > budget {
 					break
 				}
@@ -474,8 +475,8 @@ func (ft *FileTree) truncateDirName(name string, maxWidth int) string {
 	runes := []rune(name)
 	w := 0
 	start := len(runes)
-	for i := len(runes) - 1; i >= 0; i-- {
-		rw := runewidth.RuneWidth(runes[i])
+	for i, r := range slices.Backward(runes) {
+		rw := runewidth.RuneWidth(r)
 		if w+rw > maxWidth-1 { // reserve 1 cell for "…"
 			break
 		}
@@ -545,8 +546,8 @@ func (ft *FileTree) moveToFirst() {
 
 // moveToLast moves cursor to the last file entry.
 func (ft *FileTree) moveToLast() {
-	for i := len(ft.entries) - 1; i >= 0; i-- {
-		if !ft.entries[i].isDir {
+	for i, e := range slices.Backward(ft.entries) {
+		if !e.isDir {
 			ft.cursor = i
 			return
 		}
@@ -574,9 +575,9 @@ func (ft *FileTree) prevFile() {
 	if len(files) == 0 {
 		return
 	}
-	for i := len(files) - 1; i >= 0; i-- {
-		if files[i] < ft.cursor {
-			ft.cursor = files[i]
+	for _, f := range slices.Backward(files) {
+		if f < ft.cursor {
+			ft.cursor = f
 			return
 		}
 	}

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -160,8 +161,8 @@ func (m Model) truncateLeftToWidth(s string, budget int) string {
 	tailBudget := budget - 1 // 1 cell for the leading "…"
 	runes := []rune(s)
 	w, cutIdx := 0, len(runes)
-	for i := len(runes) - 1; i >= 0; i-- {
-		rw := runewidth.RuneWidth(runes[i])
+	for i, r := range slices.Backward(runes) {
+		rw := runewidth.RuneWidth(r)
 		if w+rw > tailBudget {
 			break
 		}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,7 +123,7 @@ Each source file has a matching `_test.go`.
 | `loadedFileState` (`m.file`) | current file's loaded state | `lines`, `highlighted`, `intraRanges`, `blameData`, `mdTOC`, `singleFile` |
 | `modeState` (`m.modes`) | user-togglable view modes | `wrap`, `collapsed`, `compact`, `compactContext`, `lineNumbers`, `wordDiff`, `showBlame` |
 | `navigationState` (`m.nav`) | cursor position | `diffCursor`, `pendingHunkJump` |
-| `searchState` (`m.search`) | search lifecycle | `active`, `term`, `matches`, `cursor`, `input`, `matchSet` |
+| `searchState` (`m.search`) | search lifecycle | `active`, `term`, `matches`, `cursor`, `input`, `matchSet`, `history`, `historyIdx` |
 | `annotationState` (`m.annot`) | annotation input lifecycle | `annotating`, `fileAnnotating`, `cursorOnAnnotation`, `input` |
 
 Methods remain on `Model` — the sub-structs group mutable state for clarity, not to create mini-models.

--- a/docs/plans/20260507-search-history.md
+++ b/docs/plans/20260507-search-history.md
@@ -139,17 +139,17 @@ Rejected alternatives (from brainstorm):
 - [x] run `go test ./app/ui/...` — must pass before next task.
 
 ### Task 2: Verify acceptance criteria
-- [ ] verify each Overview bullet is implemented:
+- [x] verify each Overview bullet is implemented:
   - Up / Ctrl+P walks backward
   - Down / Ctrl+N walks forward
   - Down past newest clears input
   - in-session only (no persistence file created, no config key added)
-- [ ] verify edge cases from Technical Details (empty history, oldest, cap, dedup, cancel-doesn't-append).
-- [ ] run full test suite: `go test ./...`.
-- [ ] run race detector: `go test -race ./...`.
-- [ ] run linter: `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0` from repo root.
-- [ ] run formatters: `~/.claude/format.sh` (or gofmt/goimports if not available).
-- [ ] verify no new files were created (per design — additive change only).
+- [x] verify edge cases from Technical Details (empty history, oldest, cap, dedup, cancel-doesn't-append).
+- [x] run full test suite: `go test ./...`.
+- [x] run race detector: `go test -race ./...`.
+- [x] run linter: `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0` from repo root.
+- [x] run formatters: `~/.claude/format.sh` (or gofmt/goimports if not available).
+- [x] verify no new files were created (per design — additive change only).
 
 ### Task 3: [Final] Update documentation and finalize
 

--- a/docs/plans/20260507-search-history.md
+++ b/docs/plans/20260507-search-history.md
@@ -116,13 +116,13 @@ Rejected alternatives (from brainstorm):
 - Modify: `app/ui/search.go`
 - Modify: `app/ui/search_test.go`
 
-- [ ] add `history []string` and `historyIdx int` fields to `searchState` in `app/ui/model.go`, with comments documenting the "draft = `len(history)`" convention.
-- [ ] add `searchHistoryMax = 50` const at the top of `app/ui/search.go`.
-- [ ] update `startSearch` in `app/ui/search.go` to reset `m.search.historyIdx = len(m.search.history)` after creating the textinput.
-- [ ] update `submitSearch` in `app/ui/search.go` to dedup-append the trimmed query (skip if equal to last entry), enforce the cap by re-slicing from the tail, and reset `historyIdx` to `len(history)` on the success path.
-- [ ] add `recallHistory(direction int)` method on `*Model` in `app/ui/search.go` that clamps `historyIdx`, calls `input.SetValue` (empty at draft slot, else `history[idx]`), and `input.CursorEnd`.
-- [ ] update `handleSearchKey` in `app/ui/search.go` to intercept `tea.KeyUp`/`tea.KeyCtrlP` and `tea.KeyDown`/`tea.KeyCtrlN` before the `default:` forward, calling `recallHistory` with `-1` / `+1`.
-- [ ] write tests in `app/ui/search_test.go`:
+- [x] add `history []string` and `historyIdx int` fields to `searchState` in `app/ui/model.go`, with comments documenting the "draft = `len(history)`" convention.
+- [x] add `searchHistoryMax = 50` const at the top of `app/ui/search.go`.
+- [x] update `startSearch` in `app/ui/search.go` to reset `m.search.historyIdx = len(m.search.history)` after creating the textinput.
+- [x] update `submitSearch` in `app/ui/search.go` to dedup-append the trimmed query (skip if equal to last entry), enforce the cap by re-slicing from the tail, and reset `historyIdx` to `len(history)` on the success path.
+- [x] add `recallHistory(direction int)` method on `*Model` in `app/ui/search.go` that clamps `historyIdx`, calls `input.SetValue` (empty at draft slot, else `history[idx]`), and `input.CursorEnd`.
+- [x] update `handleSearchKey` in `app/ui/search.go` to intercept `tea.KeyUp`/`tea.KeyCtrlP` and `tea.KeyDown`/`tea.KeyCtrlN` before the `default:` forward, calling `recallHistory` with `-1` / `+1`.
+- [x] write tests in `app/ui/search_test.go`:
   - submitting unique queries appends to history, idx resets to `len(history)`.
   - submitting a query with **zero matches** still appends to history (verifies append placement is before the match scan).
   - consecutive duplicate submit does not grow history.
@@ -136,7 +136,7 @@ Rejected alternatives (from brainstorm):
   - **recall-then-Esc transition**: enter search, press Up to recall, press Esc, press `/` again — input must be empty (draft slot) and `historyIdx == len(history)`.
   - empty-input submit (whitespace only) does not append to history.
   - `clearSearch` does not touch history fields (history slice and idx survive a `clearSearch` call).
-- [ ] run `go test ./app/ui/...` — must pass before next task.
+- [x] run `go test ./app/ui/...` — must pass before next task.
 
 ### Task 2: Verify acceptance criteria
 - [ ] verify each Overview bullet is implemented:

--- a/docs/plans/20260507-search-history.md
+++ b/docs/plans/20260507-search-history.md
@@ -1,0 +1,188 @@
+# In-Session Search History
+
+## Overview
+- adds in-session recall of previously submitted `/`-search queries inside the search prompt.
+- pressing `Up` / `Ctrl+P` walks backward through past queries; `Down` / `Ctrl+N` walks forward; `Down` past the newest entry clears the input.
+- closes [issue #170](https://github.com/umputun/revdiff/issues/170): "Search history is missing".
+- history is in-memory only — not persisted across revdiff invocations. No CLI flags, no new config keys, no new files.
+
+## Context (from discovery)
+- files/components involved:
+  - `app/ui/model.go` — `searchState` struct (lines 301-309) holds search lifecycle fields; two new fields go here.
+  - `app/ui/search.go` — `startSearch`, `submitSearch`, `clearSearch`, `handleSearchKey` are the touchpoints; one new helper method is added.
+  - `app/ui/search_test.go` — paired test file per the project's "one test file per source file" rule.
+- related patterns found:
+  - `searchState` already groups all search lifecycle state (`active`, `term`, `matches`, `cursor`, `input`, `matchSet`); history fits naturally as more state on the same struct.
+  - `handleSearchKey` already intercepts specific `tea.KeyType` values (Enter, Esc) before forwarding to the embedded `textinput.Model`; the same pattern works for Up/Down/Ctrl+P/Ctrl+N.
+  - other state-grouping structs in the file follow the same shape (`navigationState`, `commitsState`, `reloadState`), so adding fields stays consistent with the convention.
+- dependencies identified: none. `bubbles/textinput` already provides `SetValue` and `CursorEnd`; `bubbletea` already exposes `tea.KeyUp`, `tea.KeyDown`, `tea.KeyCtrlP`, `tea.KeyCtrlN`.
+
+## Development Approach
+- **testing approach**: Regular (code first, then tests within the same task)
+- complete each task fully before moving to the next.
+- make small, focused changes.
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task.
+  - tests are not optional — they are a required part of the checklist.
+  - write unit tests for new functions/methods.
+  - write unit tests for modified functions/methods.
+  - add new test cases for new code paths.
+  - update existing test cases if behavior changes.
+  - tests cover both success and error scenarios.
+- **CRITICAL: all tests must pass before starting next task** — no exceptions.
+- **CRITICAL: update this plan file when scope changes during implementation**.
+- run tests after each change.
+- maintain backward compatibility — search behavior without using Up/Down is byte-identical to current.
+
+## Testing Strategy
+- **unit tests**: required for every task (see Development Approach).
+- **e2e tests**: project has no UI-based e2e suite; not applicable.
+- run via `go test ./app/ui/...` (or the full `go test ./...` at task gates).
+- race detector run at the final acceptance task: `go test -race ./...`.
+
+## Progress Tracking
+- mark completed items with `[x]` immediately when done.
+- add newly discovered tasks with ➕ prefix.
+- document issues/blockers with ⚠️ prefix.
+- update plan if implementation deviates from original scope.
+- keep plan in sync with actual work done.
+
+## Solution Overview
+
+**Approach: extend `searchState` with two fields and intercept history-recall keys in `handleSearchKey` before delegating to the textinput.**
+
+This is the smallest design that keeps the existing concern-grouping intact:
+- search lifecycle stays in one struct (`searchState`) and one source file (`search.go`).
+- no new package, no new file, no new exported surface.
+- the textinput is still the source of truth for the typed buffer; history navigation just calls `SetValue` on it.
+
+Rejected alternatives (from brainstorm):
+- nested `searchHistoryState` substruct — over-structured for two fields and three trivial operations.
+- separate `app/ui/searchhistory/` package — pure in-memory state with no OS boundary, so the `app/editor/` precedent does not apply; would be overengineering per CLAUDE.md "Minimize exported surface" and "prefer simple and focused solutions".
+
+## Technical Details
+
+**State changes** (`app/ui/model.go`, on `searchState`):
+- `history []string` — submitted queries, oldest-first.
+- `historyIdx int` — current position; `len(history)` represents the "no recall active" state (input shows whatever the user typed or empty).
+
+**Constants** (`app/ui/search.go`):
+- `searchHistoryMax = 50` — bound on retained queries; oldest entries are dropped when the cap is exceeded.
+
+**Behavior contract:**
+
+1. **`startSearch`** — after creating the textinput, set `m.search.historyIdx = len(m.search.history)`. This makes each new `/` invocation start at the "draft" position regardless of how the previous search ended (submit, Esc, focus loss).
+
+2. **`submitSearch`** — append happens **immediately after the empty-input clear-and-return guard, before the match scan** (`m.search.term = strings.ToLower(query)`). This placement matters: zero-match queries must still be recallable so the user can edit and retry. The three return paths that follow (no matches, no visible match, match found) all preserve the appended history. Append logic:
+   - skip the append if `history[len-1] == query` (consecutive-duplicate dedup, less-style).
+   - if the cap is exceeded, slice off the oldest entry: `history = history[len(history)-searchHistoryMax:]`.
+   - reset `historyIdx = len(history)` so the next `/` starts fresh at the draft slot.
+   - re-submitting an older entry (recalled, then Enter) appends it again, moving it to "most recent".
+
+3. **`handleSearchKey`** — add cases before the `default:` forward:
+   - `tea.KeyUp`, `tea.KeyCtrlP` → `m.recallHistory(-1)`, return without forwarding.
+   - `tea.KeyDown`, `tea.KeyCtrlN` → `m.recallHistory(+1)`, return without forwarding.
+
+4. **`recallHistory(direction int)`** — new helper, executed in this order:
+   - **first**: short-circuit if `len(m.search.history) == 0` (no-op).
+   - clamp `m.search.historyIdx + direction` to `[0, len(history)]`.
+   - if the clamped index equals `len(history)`: `input.SetValue("")`.
+   - else: `input.SetValue(history[clampedIdx])`.
+   - call `input.CursorEnd()` to place the cursor at end of recalled text.
+   - update `m.search.historyIdx`.
+
+   `recallHistory` is a method on `*Model`. It is invoked from value-receiver `handleSearchKey(m Model, ...)` via standard Go auto-addressing of the local copy (`m.recallHistory(...)` becomes `(&m).recallHistory(...)`); mutations land on that copy and are returned through `return m, nil`. This is the same pattern already used by `submitSearch`/`startSearch`/`cancelSearch`. **Do not "fix" this receiver inconsistency by changing `handleSearchKey` to a pointer receiver — bubbletea's update flow expects value semantics.**
+
+5. **`clearSearch` is intentionally not modified.** It resets `term`, `matches`, `cursor`, `matchSet` after Esc-without-submit or empty-input submit. History must survive those resets — it spans the full session, not a single search. Do not add `history = nil` or `historyIdx = 0` to `clearSearch`.
+
+**Edge cases handled:**
+- empty history + Up/Down → no-op (clamp + len-zero guard).
+- Up at oldest entry → stays at index 0.
+- Down at "draft" position → stays there.
+- recalled-then-cancelled (Esc) → next `/` starts fresh; the recalled value is **not** appended (only `submitSearch` appends).
+- recalled-then-submitted → appended via the dedup-append path; if it was already most-recent, dedup skips the append.
+
+**Compatibility:** users who never press Up/Down see byte-identical behavior to the current implementation — `textinput.Update` was a no-op for those keys anyway, so reclaiming them does not regress anything.
+
+## What Goes Where
+- **Implementation Steps** (`[ ]` checkboxes): all code, tests, and acceptance verification.
+- **Post-Completion** (no checkboxes): manual smoke (open revdiff, run a few searches, exercise Up/Down/Ctrl+P/Ctrl+N).
+
+## Implementation Steps
+
+### Task 1: Add history state and recall behavior to search
+
+**Files:**
+- Modify: `app/ui/model.go`
+- Modify: `app/ui/search.go`
+- Modify: `app/ui/search_test.go`
+
+- [ ] add `history []string` and `historyIdx int` fields to `searchState` in `app/ui/model.go`, with comments documenting the "draft = `len(history)`" convention.
+- [ ] add `searchHistoryMax = 50` const at the top of `app/ui/search.go`.
+- [ ] update `startSearch` in `app/ui/search.go` to reset `m.search.historyIdx = len(m.search.history)` after creating the textinput.
+- [ ] update `submitSearch` in `app/ui/search.go` to dedup-append the trimmed query (skip if equal to last entry), enforce the cap by re-slicing from the tail, and reset `historyIdx` to `len(history)` on the success path.
+- [ ] add `recallHistory(direction int)` method on `*Model` in `app/ui/search.go` that clamps `historyIdx`, calls `input.SetValue` (empty at draft slot, else `history[idx]`), and `input.CursorEnd`.
+- [ ] update `handleSearchKey` in `app/ui/search.go` to intercept `tea.KeyUp`/`tea.KeyCtrlP` and `tea.KeyDown`/`tea.KeyCtrlN` before the `default:` forward, calling `recallHistory` with `-1` / `+1`.
+- [ ] write tests in `app/ui/search_test.go`:
+  - submitting unique queries appends to history, idx resets to `len(history)`.
+  - submitting a query with **zero matches** still appends to history (verifies append placement is before the match scan).
+  - consecutive duplicate submit does not grow history.
+  - resubmitting an older entry appends it (moves to most recent).
+  - cap enforced: pushing 51 entries drops the oldest.
+  - Up recalls most recent, then older with subsequent presses.
+  - Up at oldest is a no-op (idx stays at 0, input keeps the oldest entry).
+  - Down past newest clears the input and idx == len(history).
+  - Ctrl+P / Ctrl+N parity with Up / Down (single shared assertion path is fine).
+  - `startSearch` resets `historyIdx` to `len(history)` even when called after a partial recall (simulate by setting historyIdx to 0 then re-entering).
+  - **recall-then-Esc transition**: enter search, press Up to recall, press Esc, press `/` again — input must be empty (draft slot) and `historyIdx == len(history)`.
+  - empty-input submit (whitespace only) does not append to history.
+  - `clearSearch` does not touch history fields (history slice and idx survive a `clearSearch` call).
+- [ ] run `go test ./app/ui/...` — must pass before next task.
+
+### Task 2: Verify acceptance criteria
+- [ ] verify each Overview bullet is implemented:
+  - Up / Ctrl+P walks backward
+  - Down / Ctrl+N walks forward
+  - Down past newest clears input
+  - in-session only (no persistence file created, no config key added)
+- [ ] verify edge cases from Technical Details (empty history, oldest, cap, dedup, cancel-doesn't-append).
+- [ ] run full test suite: `go test ./...`.
+- [ ] run race detector: `go test -race ./...`.
+- [ ] run linter: `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0` from repo root.
+- [ ] run formatters: `~/.claude/format.sh` (or gofmt/goimports if not available).
+- [ ] verify no new files were created (per design — additive change only).
+
+### Task 3: [Final] Update documentation and finalize
+
+**Files:**
+- Modify: `README.md`
+- Modify: `site/docs.html`
+- Modify: `.claude-plugin/skills/revdiff/references/usage.md`
+- Modify: `plugins/codex/skills/revdiff/references/usage.md`
+- Move: this plan to `docs/plans/completed/`
+
+Concrete docs-sync edits — none of these are conditional. The new behavior must appear in all four files in lockstep, and the two `usage.md` copies must remain byte-identical (md5-verified).
+
+- [ ] **README.md** — locate the search keybindings table (around lines 628-631 — `/`, `n`, `N`, `Esc` rows) and add two new rows describing the in-prompt recall keys. Suggested wording (table cells stay short):
+  - `↑ / Ctrl+P` — Recall previous search query (in search prompt)
+  - `↓ / Ctrl+N` — Recall next search query / clear (in search prompt)
+- [ ] **site/docs.html** — locate the matching keybindings rows (around lines 480-482) and add the same two rows in the existing `<tr><td><code>...</code></td><td>...</td></tr>` shape, with prose matching the README.
+- [ ] **`.claude-plugin/skills/revdiff/references/usage.md`** — locate the search keybindings table (around lines 115-117) and add the same two rows.
+- [ ] **`plugins/codex/skills/revdiff/references/usage.md`** — apply the identical edit (the simplest path is to copy the modified `.claude-plugin/...` file over this one). Then verify with `diff` and `md5`:
+   ```
+   diff .claude-plugin/skills/revdiff/references/usage.md plugins/codex/skills/revdiff/references/usage.md && echo identical
+   ```
+   The check must print `identical` before this step is marked done.
+- [ ] no `site/index.html` version-badge change in this PR — that bump belongs to the release that ships this feature, not to the feature PR.
+- [ ] mark all checkboxes `[x]` and move this plan: `mkdir -p docs/plans/completed && mv docs/plans/20260507-search-history.md docs/plans/completed/`.
+
+## Post-Completion
+*Items requiring manual intervention or external systems — informational only*
+
+**Manual verification** (recommended before merge):
+- run `./.bin/revdiff` against any repo with a few changes; press `/`, type a query, Enter, then `/` again and press Up — previous query should appear with cursor at end.
+- press Up several more times to confirm older queries surface and oldest is sticky.
+- press Down to walk forward; one Down past the newest must clear the input.
+- press Ctrl+P / Ctrl+N to confirm parity with Up / Down.
+- press Esc mid-recall, then `/` again — the input must be empty, not the value that was being recalled when Esc fired.
+
+**No external system updates** — feature is local to revdiff binary; no consuming projects, no deployment changes.

--- a/docs/plans/completed/20260507-search-history.md
+++ b/docs/plans/completed/20260507-search-history.md
@@ -162,18 +162,18 @@ Rejected alternatives (from brainstorm):
 
 Concrete docs-sync edits — none of these are conditional. The new behavior must appear in all four files in lockstep, and the two `usage.md` copies must remain byte-identical (md5-verified).
 
-- [ ] **README.md** — locate the search keybindings table (around lines 628-631 — `/`, `n`, `N`, `Esc` rows) and add two new rows describing the in-prompt recall keys. Suggested wording (table cells stay short):
+- [x] **README.md** — locate the search keybindings table (around lines 628-631 — `/`, `n`, `N`, `Esc` rows) and add two new rows describing the in-prompt recall keys. Suggested wording (table cells stay short):
   - `↑ / Ctrl+P` — Recall previous search query (in search prompt)
   - `↓ / Ctrl+N` — Recall next search query / clear (in search prompt)
-- [ ] **site/docs.html** — locate the matching keybindings rows (around lines 480-482) and add the same two rows in the existing `<tr><td><code>...</code></td><td>...</td></tr>` shape, with prose matching the README.
-- [ ] **`.claude-plugin/skills/revdiff/references/usage.md`** — locate the search keybindings table (around lines 115-117) and add the same two rows.
-- [ ] **`plugins/codex/skills/revdiff/references/usage.md`** — apply the identical edit (the simplest path is to copy the modified `.claude-plugin/...` file over this one). Then verify with `diff` and `md5`:
+- [x] **site/docs.html** — locate the matching keybindings rows (around lines 480-482) and add the same two rows in the existing `<tr><td><code>...</code></td><td>...</td></tr>` shape, with prose matching the README.
+- [x] **`.claude-plugin/skills/revdiff/references/usage.md`** — locate the search keybindings table (around lines 115-117) and add the same two rows.
+- [x] **`plugins/codex/skills/revdiff/references/usage.md`** — apply the identical edit (the simplest path is to copy the modified `.claude-plugin/...` file over this one). Then verify with `diff` and `md5`:
    ```
    diff .claude-plugin/skills/revdiff/references/usage.md plugins/codex/skills/revdiff/references/usage.md && echo identical
    ```
    The check must print `identical` before this step is marked done.
-- [ ] no `site/index.html` version-badge change in this PR — that bump belongs to the release that ships this feature, not to the feature PR.
-- [ ] mark all checkboxes `[x]` and move this plan: `mkdir -p docs/plans/completed && mv docs/plans/20260507-search-history.md docs/plans/completed/`.
+- [x] no `site/index.html` version-badge change in this PR — that bump belongs to the release that ships this feature, not to the feature PR.
+- [x] mark all checkboxes `[x]` and move this plan: `mkdir -p docs/plans/completed && mv docs/plans/20260507-search-history.md docs/plans/completed/`.
 
 ## Post-Completion
 *Items requiring manual intervention or external systems — informational only*

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -128,6 +128,8 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `/` | Start search in diff pane |
 | `n` | Next search match (overrides next file when search active) |
 | `N` | Previous search match |
+| `↑` / `Ctrl+P` | Recall previous search query (in search prompt) |
+| `↓` / `Ctrl+N` | Recall next search query / clear (in search prompt) |
 | `Esc` | Cancel search input / clear search results |
 
 **Annotations:**

--- a/site/docs.html
+++ b/site/docs.html
@@ -491,6 +491,8 @@ color-border = #6272a4
                 <tr><td><code>/</code></td><td>Start search in diff pane</td></tr>
                 <tr><td><code>n</code></td><td>Next search match (when search active)</td></tr>
                 <tr><td><code>N</code></td><td>Previous search match</td></tr>
+                <tr><td><code>↑</code> / <code>Ctrl+P</code></td><td>Recall previous search query (in search prompt)</td></tr>
+                <tr><td><code>↓</code> / <code>Ctrl+N</code></td><td>Recall next search query / clear (in search prompt)</td></tr>
                 <tr><td><code>Esc</code></td><td>Cancel search / clear results</td></tr>
             </tbody>
         </table>


### PR DESCRIPTION
Up / Ctrl+P recalls the previous submitted query inside the search prompt; Down / Ctrl+N walks forward and clears past the newest entry. History is in-memory, scoped to the session, capped at 50 entries with consecutive-duplicate dedup. README, site/docs.html, both plugin `usage.md` copies, and the in-app help overlay all list the new keys.

Fixes #170.
