### PR TITLE
feat: decouple mouse wheel from diff cursor

### DIFF
--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -190,7 +190,7 @@ On narrow terminals, the left-hand segments are dropped before the icons: search
 
 revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.
 
-- **Scroll wheel** — scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.
+- **Scroll wheel** — scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch. In the diff pane the wheel scrolls the viewport only — the diff cursor stays on its current logical line and is pinned to the visible edge if scrolling pushes it off-screen.
 - **Shift+scroll** — half-page scroll in whichever pane the cursor is over.
 - **Left-click in the tree** — focuses the tree and selects/loads the clicked entry. Clicking a directory row moves the cursor but does not load a file.
 - **Left-click in the diff** — focuses the diff and moves the cursor to the clicked line. Enables a "click, then `a`" annotation flow.

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ On narrow terminals, the left-hand segments are dropped before the icons: search
 
 revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.
 
-- **Scroll wheel**: scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.
+- **Scroll wheel**: scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch. In the diff pane the wheel scrolls the viewport only — the diff cursor stays on its current logical line and is pinned to the visible edge if scrolling pushes it off-screen.
 - **Shift+scroll**: half-page scroll in whichever pane the cursor is over.
 - **Left-click in the tree**: focuses the tree and selects/loads the clicked entry (same as pressing `j`/`k` to land there). Clicking a directory row moves the cursor but does not load a file.
 - **Left-click in the diff**: focuses the diff and moves the cursor to the clicked line. Enables a "click, then `a`" annotation flow.

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -866,4 +866,3 @@ func TestParseArgs_InstallThemeFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"dracula", "nord"}, opts.InstallTheme)
 }
-

--- a/app/diff/compare_test.go
+++ b/app/diff/compare_test.go
@@ -207,11 +207,11 @@ func TestCompareReader_FileDiff_BinaryFiles(t *testing.T) {
 
 func TestCompareReader_FileDiff_NoTrailingNewline(t *testing.T) {
 	cases := []struct {
-		name           string
-		oldContent     string
-		newContent     string
-		wantAdd        int
-		wantRemove     int
+		name       string
+		oldContent string
+		newContent string
+		wantAdd    int
+		wantRemove int
 	}{
 		{"both with newline", "a\nb\n", "a\nc\n", 1, 1},
 		{"both without newline", "a\nb", "a\nc", 1, 1},

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -252,7 +252,7 @@ func (m Model) clickTree(y int) (tea.Model, tea.Cmd) {
 // scrollDiffViewportBy shifts the diff viewport's YOffset by delta and pins
 // the diff cursor to the visible range when the cursor would otherwise leave
 // the viewport. delta > 0 scrolls down, delta < 0 scrolls up. no-op when no
-// file is loaded or the requested offset is already at the clamp boundary.
+// file is loaded or the clamped target equals the current offset.
 // the content is re-rendered only when the cursor moves — a pure viewport
 // shift does not need a re-render since the rendered content is unchanged.
 func (m *Model) scrollDiffViewportBy(delta int) {
@@ -272,13 +272,24 @@ func (m *Model) scrollDiffViewportBy(delta int) {
 	m.layout.viewport.SetYOffset(target)
 }
 
-// pinDiffCursorTo clamps the diff cursor so its visual range overlaps the
-// viewport range that would be visible at newOffset. when the cursor's
-// visual range still overlaps the viewport, it is left alone. when the
-// cursor sits above the viewport, it is pinned to the topmost visible row;
-// when below, to the bottommost visible row. returns true when the cursor
-// actually changed position (idx or annotation flag), so callers know
-// whether a re-render is required.
+// pinDiffCursorTo moves the diff cursor onto the visible viewport range when it
+// would otherwise be off-screen at newOffset; when the cursor marker is already
+// within the viewport, it is left alone. when the cursor sits above the viewport,
+// it is pinned to the topmost visible row; when below, to the bottommost visible
+// row. returns true when the cursor actually changed position (idx or annotation
+// flag), so callers know whether a re-render is required.
+//
+// the in-view check uses cursorTop (first visual row, where the cursor marker is
+// rendered) rather than cursorBottom. in wrap mode a diff line spans multiple rows;
+// using cursorBottom would incorrectly treat the cursor as visible when only its
+// tail wrap-continuation rows are in the viewport while the marker row is above it.
+//
+// for the top-pin case, if the cursor line straddles the viewport top boundary
+// (cursorTop < viewTop <= cursorBottom) the target row is advanced past the
+// cursor line's last visual row so that the next line — whose marker is inside
+// the viewport — is selected. when the entire wrapped span exceeds the viewport
+// height the advance is clamped to viewBottom and the function returns false
+// (no visible alternative exists).
 func (m *Model) pinDiffCursorTo(newOffset int) bool {
 	if len(m.file.lines) == 0 {
 		return false
@@ -286,12 +297,18 @@ func (m *Model) pinDiffCursorTo(newOffset int) bool {
 	cursorTop, cursorBottom := m.cursorVisualRange()
 	viewTop := newOffset
 	viewBottom := newOffset + m.layout.viewport.Height - 1
-	if cursorBottom >= viewTop && cursorTop <= viewBottom {
-		return false
+	if cursorTop >= viewTop && cursorTop <= viewBottom {
+		return false // cursor marker already visible
 	}
 	targetRow := viewBottom
 	if cursorTop < viewTop {
-		targetRow = viewTop
+		// cursor is above the viewport; in wrap mode the cursor line may have
+		// continuation rows visible at viewTop — advance past them.
+		if cursorBottom >= viewTop {
+			targetRow = min(cursorBottom+1, viewBottom)
+		} else {
+			targetRow = viewTop
+		}
 	}
 	idx, onAnnot := m.visualRowToDiffLine(targetRow)
 	if idx == m.nav.diffCursor && onAnnot == m.annot.cursorOnAnnotation {

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -190,15 +190,16 @@ func (m Model) wheelStepFor(zone hitZone, shift bool) int {
 // delta is positive for wheel-down, negative for wheel-up. the pane is
 // selected by the hit zone, not the current pane focus: users expect the
 // wheel to act on whichever pane the pointer is over.
+//
+// diff-pane wheel scrolls the viewport only; the diff cursor stays on its
+// current logical line unless the line is scrolled out of view, in which
+// case the cursor is pinned to the topmost or bottommost visible line so
+// the highlight stays on screen. this matches less/vim mouse behavior and
+// keeps the cursor from being yanked along with the wheel.
 func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 	switch zone {
 	case hitDiff:
-		switch {
-		case delta > 0:
-			m.moveDiffCursorDownBy(delta)
-		case delta < 0:
-			m.moveDiffCursorUpBy(-delta)
-		}
+		m.scrollDiffViewportBy(delta)
 		m.syncTOCActiveSection()
 	case hitTree:
 		motion := sidepane.MotionPageDown
@@ -246,6 +247,59 @@ func (m Model) clickTree(y int) (tea.Model, tea.Cmd) {
 	m.pendingAnnotJump = nil
 	m.nav.pendingHunkJump = nil
 	return m.loadSelectedIfChanged()
+}
+
+// scrollDiffViewportBy shifts the diff viewport's YOffset by delta and pins
+// the diff cursor to the visible range when the cursor would otherwise leave
+// the viewport. delta > 0 scrolls down, delta < 0 scrolls up. no-op when no
+// file is loaded or the requested offset is already at the clamp boundary.
+// the content is re-rendered only when the cursor moves — a pure viewport
+// shift does not need a re-render since the rendered content is unchanged.
+func (m *Model) scrollDiffViewportBy(delta int) {
+	if m.file.name == "" {
+		return
+	}
+	maxOffset := max(0, m.layout.viewport.TotalLineCount()-m.layout.viewport.Height)
+	current := m.layout.viewport.YOffset
+	target := max(0, min(current+delta, maxOffset))
+	if target == current {
+		return
+	}
+	cursorMoved := m.pinDiffCursorTo(target)
+	if cursorMoved {
+		m.layout.viewport.SetContent(m.renderDiff())
+	}
+	m.layout.viewport.SetYOffset(target)
+}
+
+// pinDiffCursorTo clamps the diff cursor so its visual range overlaps the
+// viewport range that would be visible at newOffset. when the cursor's
+// visual range still overlaps the viewport, it is left alone. when the
+// cursor sits above the viewport, it is pinned to the topmost visible row;
+// when below, to the bottommost visible row. returns true when the cursor
+// actually changed position (idx or annotation flag), so callers know
+// whether a re-render is required.
+func (m *Model) pinDiffCursorTo(newOffset int) bool {
+	if len(m.file.lines) == 0 {
+		return false
+	}
+	cursorTop, cursorBottom := m.cursorVisualRange()
+	viewTop := newOffset
+	viewBottom := newOffset + m.layout.viewport.Height - 1
+	if cursorBottom >= viewTop && cursorTop <= viewBottom {
+		return false
+	}
+	targetRow := viewBottom
+	if cursorTop < viewTop {
+		targetRow = viewTop
+	}
+	idx, onAnnot := m.visualRowToDiffLine(targetRow)
+	if idx == m.nav.diffCursor && onAnnot == m.annot.cursorOnAnnotation {
+		return false
+	}
+	m.nav.diffCursor = idx
+	m.annot.cursorOnAnnotation = onAnnot
+	return true
 }
 
 // clickDiff handles a left-click press in the diff viewport. the click

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -212,16 +212,56 @@ func TestModel_HandleMouse_WheelInDiff(t *testing.T) {
 	}
 	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
 	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
 
-	// pointer in diff pane (x=60 is past tree columns 0..37)
+	// wheel-down scrolls the viewport by wheelStep; the cursor at line 0
+	// is now above the visible range and is pinned to the new top.
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	assert.Equal(t, wheelStep, model.nav.diffCursor, "wheel-down should advance cursor by wheelStep")
+	assert.Equal(t, wheelStep, model.layout.viewport.YOffset, "wheel-down must scroll viewport by wheelStep")
+	assert.Equal(t, wheelStep, model.nav.diffCursor, "cursor must pin to top of visible range when scrolled off-screen")
 
-	// wheel-up returns cursor to top
+	// wheel-up scrolls the viewport back; cursor at line 3 stays in view, so it does not move.
 	result, _ = model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
 	model = result.(Model)
-	assert.Equal(t, 0, model.nav.diffCursor, "wheel-up should move cursor back up by wheelStep")
+	assert.Equal(t, 0, model.layout.viewport.YOffset, "wheel-up must scroll viewport back to the top")
+	assert.Equal(t, wheelStep, model.nav.diffCursor, "cursor stays put when its visual range still overlaps the viewport")
+}
+
+func TestModel_HandleMouse_WheelInDiff_CursorStaysWhenInView(t *testing.T) {
+	// when the cursor is well inside the viewport, plain wheel scrolling that
+	// does not push the cursor out must leave the cursor on its original line.
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
+	m.nav.diffCursor = 20 // cursor sits comfortably inside the 30-row viewport
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
+	assert.Equal(t, 20, model.nav.diffCursor, "cursor must not move while still inside the viewport")
+}
+
+func TestModel_HandleMouse_WheelInDiff_NoopWhenContentFits(t *testing.T) {
+	// when the entire diff fits in the viewport (TotalLineCount <= Height),
+	// there is no room to scroll and wheel events become no-ops. cursor and
+	// YOffset both stay put.
+	lines := make([]diff.DiffLine, 5)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.Equal(t, 0, model.layout.viewport.YOffset, "wheel must not change YOffset when content fits")
+	assert.Equal(t, 0, model.nav.diffCursor, "wheel must not change cursor when content fits")
 }
 
 func TestModel_HandleMouse_ShiftWheelHalfPage(t *testing.T) {
@@ -232,10 +272,12 @@ func TestModel_HandleMouse_ShiftWheelHalfPage(t *testing.T) {
 	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
 	m.file.lines = lines
 	m.layout.viewport = viewport.New(80, 20) // Height=20 so half-page = 10
+	m.layout.viewport.SetContent(m.renderDiff())
 
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, true))
 	model := result.(Model)
-	assert.Equal(t, 10, model.nav.diffCursor, "shift+wheel should move cursor by viewport.Height/2")
+	assert.Equal(t, 10, model.layout.viewport.YOffset, "shift+wheel must scroll viewport by half page")
+	assert.Equal(t, 10, model.nav.diffCursor, "cursor must pin to top of visible range after half-page scroll")
 }
 
 func TestModel_HandleMouse_WheelInTreeMovesTreeCursor(t *testing.T) {
@@ -852,18 +894,18 @@ func TestModel_HandleMouse_LeftClickInTOCJumpsViewport(t *testing.T) {
 
 func TestModel_HandleMouse_WheelInDiffSyncsTOCActiveSection(t *testing.T) {
 	// mirrors the keyboard-navigation TOC-sync guarantee (diffnav.go:464):
-	// moving the diff cursor via wheel must keep mdTOC.activeSection aligned
-	// with the new cursor position, otherwise switching focus back to the TOC
-	// highlights the stale section.
+	// when wheel scrolling pushes the cursor off the top and pins it to the
+	// new top visible line, mdTOC.activeSection must follow so switching focus
+	// back to the TOC highlights the correct section. requires a diff long
+	// enough for the viewport to actually scroll.
 	files := []string{"README.md"}
-	lines := []diff.DiffLine{
-		{NewNum: 1, Content: "# First", ChangeType: diff.ChangeContext},
-		{NewNum: 2, Content: "body", ChangeType: diff.ChangeContext},
-		{NewNum: 3, Content: "## Second", ChangeType: diff.ChangeContext},
-		{NewNum: 4, Content: "body", ChangeType: diff.ChangeContext},
-		{NewNum: 5, Content: "### Third", ChangeType: diff.ChangeContext},
-		{NewNum: 6, Content: "body", ChangeType: diff.ChangeContext},
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "body", ChangeType: diff.ChangeContext}
 	}
+	lines[0] = diff.DiffLine{NewNum: 1, Content: "# First", ChangeType: diff.ChangeContext}
+	lines[10] = diff.DiffLine{NewNum: 11, Content: "## Second", ChangeType: diff.ChangeContext}
+	lines[20] = diff.DiffLine{NewNum: 21, Content: "### Third", ChangeType: diff.ChangeContext}
 	m := mouseTestModel(t, files, map[string][]diff.DiffLine{"README.md": lines})
 	m.file.lines = lines
 	m.file.singleFile = true
@@ -871,18 +913,19 @@ func TestModel_HandleMouse_WheelInDiffSyncsTOCActiveSection(t *testing.T) {
 	require.NotNil(t, m.file.mdTOC)
 	m.layout.focus = paneDiff
 	m.nav.diffCursor = 0
+	m.layout.viewport.SetContent(m.renderDiff())
 
-	// wheel-down in diff pane (x=60 lands past treeWidth, y=5 > diffTopRow)
-	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 5, false))
+	// shift+wheel-down advances the viewport by half a page (15 rows);
+	// cursor at line 0 is now off the top and pins to line 15, past the
+	// "## Second" header. TOC active section must follow.
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 5, true))
 	model := result.(Model)
 
-	// after wheel, diffCursor advanced; TOC active-section must reflect it
-	require.Positive(t, model.nav.diffCursor, "wheel-down must advance diffCursor")
+	require.GreaterOrEqual(t, model.nav.diffCursor, 10, "wheel-down must scroll past the second section header")
 	model.file.mdTOC.SyncCursorToActiveSection()
 	idx, ok := model.file.mdTOC.CurrentLineIdx()
-	assert.True(t, ok, "TOC active section must be set after wheel in diff")
-	// cursor moved past line 2 (## Second at lineIdx=2); active section must be Second or Third
-	assert.GreaterOrEqual(t, idx, 2, "TOC active section must match diff cursor region after wheel")
+	assert.True(t, ok, "TOC active section must be set after wheel-driven cursor pin")
+	assert.GreaterOrEqual(t, idx, 10, "TOC active section must match diff cursor region after wheel")
 }
 
 func TestModel_HandleMouse_ClickInDiffSyncsTOCActiveSection(t *testing.T) {

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -264,6 +264,95 @@ func TestModel_HandleMouse_WheelInDiff_NoopWhenContentFits(t *testing.T) {
 	assert.Equal(t, 0, model.nav.diffCursor, "wheel must not change cursor when content fits")
 }
 
+func TestModel_HandleMouse_WheelUp_PinsCursorToBottom(t *testing.T) {
+	// wheel-up when cursor is below the new viewport range must pin the cursor
+	// to the bottommost visible row. exercises the targetRow=viewBottom branch.
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
+	// start with viewport scrolled down and cursor at the bottom of the file.
+	m.layout.viewport.SetYOffset(30)
+	m.nav.diffCursor = 59
+	require.Equal(t, 30, m.layout.viewport.YOffset)
+
+	// wheel-up: viewport scrolls up by wheelStep, cursor at 59 is below new view.
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
+	model := result.(Model)
+	newOffset := 30 - wheelStep
+	assert.Equal(t, newOffset, model.layout.viewport.YOffset, "wheel-up must scroll viewport up by wheelStep")
+	wantCursor := newOffset + model.layout.viewport.Height - 1
+	assert.Equal(t, wantCursor, model.nav.diffCursor, "cursor must pin to bottom of new visible range")
+}
+
+func TestModel_HandleMouse_WheelDown_NoopAtMaxOffset(t *testing.T) {
+	// when the viewport is already at maximum scroll offset, wheel-down must be
+	// a no-op: YOffset and cursor both stay unchanged.
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
+	maxOffset := m.layout.viewport.TotalLineCount() - m.layout.viewport.Height
+	require.Positive(t, maxOffset, "test requires a scrollable diff")
+	m.layout.viewport.SetYOffset(maxOffset)
+	m.nav.diffCursor = 30
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	assert.Equal(t, maxOffset, model.layout.viewport.YOffset, "wheel-down at max offset must not change YOffset")
+	assert.Equal(t, 30, model.nav.diffCursor, "wheel-down at max offset must not change cursor")
+}
+
+func TestModel_HandleMouse_WheelInWrapMode_PinsToFirstVisibleLine(t *testing.T) {
+	// in wrap mode a long line occupies multiple visual rows. wheel scrolling that
+	// moves the viewport so that only the continuation rows of the cursor line are
+	// visible (marker row is above the viewport) must pin the cursor to the first
+	// line that starts within the new viewport, not leave the cursor on the
+	// off-screen marker row.
+	//
+	// setup: viewport height=5, content that fills at least 2 pages.
+	// line 0 is long enough to wrap into 3 visual rows; lines 1-20 are short.
+	// initial cursor=0, wheel-down by 2 rows (wheelStep < line-0 height):
+	// viewTop=2 lands inside line 0's continuation; cursor must advance to line 1.
+	const vpHeight = 5
+	const longContent = "A very long line that is definitely wider than the viewport width of five columns XXXXXXXXXXX"
+	lines := make([]diff.DiffLine, 20)
+	lines[0] = diff.DiffLine{NewNum: 1, Content: longContent, ChangeType: diff.ChangeContext}
+	for i := 1; i < len(lines); i++ {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "short", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.modes.wrap = true
+	// use a very narrow viewport so the long line wraps visibly.
+	m.layout.viewport = viewport.New(10, vpHeight)
+	m.layout.viewport.SetContent(m.renderDiff())
+	require.Equal(t, 0, m.nav.diffCursor)
+
+	// how many visual rows does line 0 take in this narrow viewport?
+	cursorTop, cursorBottom := m.cursorVisualRange()
+	require.Greater(t, cursorBottom, cursorTop, "line 0 must wrap into multiple rows for this test to be meaningful")
+
+	// wheel-down by 1 moves the viewport so that only a continuation row of line 0 is at the top.
+	// cursor should advance to the first line whose marker row is within the new viewport.
+	scrollAmt := cursorTop + 1 // push past the marker row but stay inside the wrapped span
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 8, 3, false))
+	model := result.(Model)
+	_ = scrollAmt
+	// cursor must not remain at line 0 if line 0's marker row is now above the viewport.
+	if model.layout.viewport.YOffset > cursorTop {
+		assert.Positive(t, model.nav.diffCursor,
+			"cursor must advance past line 0 when its marker row is above the viewport (YOffset=%d, cursorTop=%d)",
+			model.layout.viewport.YOffset, cursorTop)
+	}
+}
+
 func TestModel_HandleMouse_ShiftWheelHalfPage(t *testing.T) {
 	lines := make([]diff.DiffLine, 100)
 	for i := range lines {

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -309,48 +309,64 @@ func TestModel_HandleMouse_WheelDown_NoopAtMaxOffset(t *testing.T) {
 	assert.Equal(t, 30, model.nav.diffCursor, "wheel-down at max offset must not change cursor")
 }
 
-func TestModel_HandleMouse_WheelInWrapMode_PinsToFirstVisibleLine(t *testing.T) {
-	// in wrap mode a long line occupies multiple visual rows. wheel scrolling that
-	// moves the viewport so that only the continuation rows of the cursor line are
-	// visible (marker row is above the viewport) must pin the cursor to the first
-	// line that starts within the new viewport, not leave the cursor on the
-	// off-screen marker row.
-	//
-	// setup: viewport height=5, content that fills at least 2 pages.
-	// line 0 is long enough to wrap into 3 visual rows; lines 1-20 are short.
-	// initial cursor=0, wheel-down by 2 rows (wheelStep < line-0 height):
-	// viewTop=2 lands inside line 0's continuation; cursor must advance to line 1.
-	const vpHeight = 5
-	const longContent = "A very long line that is definitely wider than the viewport width of five columns XXXXXXXXXXX"
-	lines := make([]diff.DiffLine, 20)
-	lines[0] = diff.DiffLine{NewNum: 1, Content: longContent, ChangeType: diff.ChangeContext}
+func TestModel_HandleMouse_WheelInWrapMode_CursorAboveViewport(t *testing.T) {
+	// in wrap mode, when wheel-down scrolls the viewport so that the cursor's first
+	// visual row (marker row) is entirely above the new viewTop, the cursor must pin
+	// to the first line whose marker row is within the new viewport.
+	// this exercises the cursorTop < viewTop && cursorBottom < viewTop path.
+	lines := make([]diff.DiffLine, 40)
+	lines[0] = diff.DiffLine{NewNum: 1, Content: strings.Repeat("X", 90), ChangeType: diff.ChangeContext}
 	for i := 1; i < len(lines); i++ {
 		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "short", ChangeType: diff.ChangeContext}
 	}
 	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
 	m.file.lines = lines
 	m.modes.wrap = true
-	// use a very narrow viewport so the long line wraps visibly.
-	m.layout.viewport = viewport.New(10, vpHeight)
 	m.layout.viewport.SetContent(m.renderDiff())
-	require.Equal(t, 0, m.nav.diffCursor)
 
-	// how many visual rows does line 0 take in this narrow viewport?
 	cursorTop, cursorBottom := m.cursorVisualRange()
-	require.Greater(t, cursorBottom, cursorTop, "line 0 must wrap into multiple rows for this test to be meaningful")
+	require.Equal(t, 0, cursorTop)
+	require.Greater(t, cursorBottom, cursorTop, "line 0 must wrap for this test to be meaningful")
+	// with wheelStep=3 past cursorBottom, cursor is entirely above the new viewport.
+	require.Less(t, cursorBottom, wheelStep, "cursorBottom must be < wheelStep to exercise the above-viewport path")
 
-	// wheel-down by 1 moves the viewport so that only a continuation row of line 0 is at the top.
-	// cursor should advance to the first line whose marker row is within the new viewport.
-	scrollAmt := cursorTop + 1 // push past the marker row but stay inside the wrapped span
-	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 8, 3, false))
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	_ = scrollAmt
-	// cursor must not remain at line 0 if line 0's marker row is now above the viewport.
-	if model.layout.viewport.YOffset > cursorTop {
-		assert.Positive(t, model.nav.diffCursor,
-			"cursor must advance past line 0 when its marker row is above the viewport (YOffset=%d, cursorTop=%d)",
-			model.layout.viewport.YOffset, cursorTop)
+	require.Equal(t, wheelStep, model.layout.viewport.YOffset)
+	assert.Positive(t, model.nav.diffCursor, "cursor must advance to a line whose marker row is in the new viewport")
+}
+
+func TestModel_HandleMouse_WheelInWrapMode_StraddlePinsToNextLine(t *testing.T) {
+	// in wrap mode, when wheel-down scrolls the viewport so that viewTop lands
+	// INSIDE the cursor line's wrapped span (cursorTop < viewTop <= cursorBottom),
+	// the cursor must advance past the continuation rows to the next line.
+	// this exercises the cursorBottom+1 straddle branch in pinDiffCursorTo.
+	//
+	// mouseTestModel layout: width=120, treeWidth=36 → wrapWidth≈77 chars/row.
+	// a 350-char line wraps to 5 rows (rows 0-4), so cursorBottom=4 > wheelStep=3.
+	// after wheel-down, viewTop=3 lands inside rows 0-4 → straddle fires.
+	lines := make([]diff.DiffLine, 40)
+	lines[0] = diff.DiffLine{NewNum: 1, Content: strings.Repeat("X", 350), ChangeType: diff.ChangeContext}
+	for i := 1; i < len(lines); i++ {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "short", ChangeType: diff.ChangeContext}
 	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.modes.wrap = true
+	m.layout.viewport.SetContent(m.renderDiff())
+
+	cursorTop, cursorBottom := m.cursorVisualRange()
+	require.Equal(t, 0, cursorTop)
+	require.Greater(t, cursorBottom, wheelStep,
+		"cursorBottom (%d) must exceed wheelStep (%d) to exercise the straddle branch", cursorBottom, wheelStep)
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	require.Equal(t, wheelStep, model.layout.viewport.YOffset,
+		"viewport must scroll by wheelStep")
+	// viewTop=wheelStep is inside line 0's span [0, cursorBottom]; cursor must advance to line 1.
+	assert.Equal(t, 1, model.nav.diffCursor,
+		"cursor must advance to line 1 (first line after the straddling wrapped span)")
 }
 
 func TestModel_HandleMouse_ShiftWheelHalfPage(t *testing.T) {

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -190,7 +190,7 @@ On narrow terminals, the left-hand segments are dropped before the icons: search
 
 revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.
 
-- **Scroll wheel** — scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.
+- **Scroll wheel** — scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch. In the diff pane the wheel scrolls the viewport only — the diff cursor stays on its current logical line and is pinned to the visible edge if scrolling pushes it off-screen.
 - **Shift+scroll** — half-page scroll in whichever pane the cursor is over.
 - **Left-click in the tree** — focuses the tree and selects/loads the clicked entry. Clicking a directory row moves the cursor but does not load a file.
 - **Left-click in the diff** — focuses the diff and moves the cursor to the clicked line. Enables a "click, then `a`" annotation flow.

--- a/site/docs.html
+++ b/site/docs.html
@@ -557,7 +557,7 @@ color-border = #6272a4
         <h2 id="mouse-support">Mouse support</h2>
         <p>revdiff enables mouse tracking by default so the scroll wheel and left-click work consistently across terminals.</p>
         <ul>
-            <li><strong>Scroll wheel</strong> &mdash; scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch.</li>
+            <li><strong>Scroll wheel</strong> &mdash; scrolls whichever pane the cursor is over (tree/TOC or diff). Three lines per notch. In the diff pane the wheel scrolls the viewport only &mdash; the diff cursor stays on its current logical line and is pinned to the visible edge if scrolling pushes it off-screen.</li>
             <li><strong>Shift+scroll</strong> &mdash; half-page scroll in whichever pane the cursor is over.</li>
             <li><strong>Left-click in the tree</strong> &mdash; focuses the tree and selects/loads the clicked entry (same as pressing <code>j</code>/<code>k</code> to land there). Clicking a directory row moves the cursor but does not load a file.</li>
             <li><strong>Left-click in the diff</strong> &mdash; focuses the diff and moves the cursor to the clicked line. Enables a &ldquo;click, then <code>a</code>&rdquo; annotation flow.</li>


### PR DESCRIPTION
scrolling the diff with a trackpad felt inertial and hard to stop. Each wheel notch moved the cursor (not just the viewport), and the viewport was dragged along to keep the cursor row stable. Under trackpad momentum the terminal emits a burst of wheel events for one swipe, so cursor and view kept marching after the finger lifted. The scroll felt automatic and cumulative.

wheel events in the diff pane now scroll the viewport only. The cursor stays on its current logical line; if scrolling pushes it off-screen, it gets pinned to the topmost or bottommost visible row so the highlight stays on screen. This matches the less/vim mouse model: wheel pans the view, the cursor is just a saved logical position.

**implementation**

`handleWheel` for `hitDiff` calls a new `scrollDiffViewportBy(delta)` helper that clamps against `TotalLineCount-Height`, calls `pinDiffCursorTo(newOffset)` to clamp the cursor when its visual range falls outside the new viewport range, then sets `YOffset`. Content is re-rendered only when the cursor actually moves.

**tests**

updated/added in `app/ui/mouse_test.go`:

- `WheelInDiff` asserts viewport scroll + cursor pin
- new `WheelInDiff_CursorStaysWhenInView` for the in-view case
- new `WheelInDiff_NoopWhenContentFits` for short diffs
- `ShiftWheelHalfPage` asserts new YOffset semantics
- `WheelInDiffSyncsTOCActiveSection` uses long enough content for the viewport to actually scroll

**docs**

`README.md` and both plugin reference copies (`.claude-plugin/...` and `plugins/codex/...`, byte-identical) updated to describe the new wheel semantics.