### PR TITLE
Add pi revdiff review agent tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,14 @@
     "annotations",
     "tui"
   ],
+  "files": [
+    "plugins/pi/",
+    ".claude-plugin/skills/revdiff/scripts/"
+  ],
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.60",
-    "@mariozechner/pi-tui": "^0.60"
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
+    "typebox": "^1.1.24"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff-pi",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pi package for revdiff interactive diff review",
   "license": "MIT",
   "repository": {

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -4,7 +4,7 @@ This directory contains the **pi-specific** integration for revdiff.
 
 ## Contents
 
-- `extensions/revdiff.ts` — pi extension that launches revdiff, captures annotations, and shows them in pi
+- `extensions/revdiff.ts` — pi extension that launches revdiff, captures annotations, exposes the `revdiff_review` agent tool, and shows results in pi
 - `extensions/revdiff-post-edit.ts` — optional post-edit reminder extension (disabled by default)
 - `skills/revdiff/SKILL.md` — pi skill describing the review workflow and commands
 

--- a/plugins/pi/extensions/revdiff-post-edit.ts
+++ b/plugins/pi/extensions/revdiff-post-edit.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 const CONFIG_TYPE = "revdiff-reminder-config";
 const STATUS_KEY = "revdiff-reminder";

--- a/plugins/pi/extensions/revdiff.ts
+++ b/plugins/pi/extensions/revdiff.ts
@@ -5,12 +5,13 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type {
+	AgentToolUpdateCallback,
 	ExtensionAPI,
-	ExtensionCommandContext,
 	ExtensionContext,
 	Theme,
-} from "@mariozechner/pi-coding-agent";
-import { Box, matchesKey, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-coding-agent";
+import { Box, matchesKey, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
 
 const STATE_TYPE = "revdiff-state";
 const LAST_LAUNCH_TYPE = "revdiff-last-launch";
@@ -153,7 +154,7 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 		setReviewState(ctx, restoredReview, false);
 	}
 
-	async function startReview(ctx: ExtensionCommandContext, launch: LaunchSpec): Promise<void> {
+	async function startReview(ctx: ExtensionContext, launch: LaunchSpec): Promise<void> {
 		pi.events.emit("revdiff:launch", { ...launch });
 		if (!ctx.hasUI) {
 			ctx.ui.notify("/revdiff requires the interactive TUI", "warning");
@@ -180,7 +181,7 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 
 		if (result.annotations.length === 0) {
 			setReviewState(ctx, undefined);
-			ctx.ui.notify(`Review complete — no annotations for ${launch.label}`, "success");
+			ctx.ui.notify(`Review complete — no annotations for ${launch.label}`, "info");
 			return;
 		}
 
@@ -195,11 +196,11 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 			{ triggerTurn: false },
 		);
 
-		ctx.ui.notify(`Captured ${result.annotations.length} annotation${result.annotations.length === 1 ? "" : "s"}`, "success");
+		ctx.ui.notify(`Captured ${result.annotations.length} annotation${result.annotations.length === 1 ? "" : "s"}`, "info");
 		await handleAction(ctx, result, await openResultsPanel(ctx, result));
 	}
 
-	async function handleAction(ctx: ExtensionCommandContext, state: ReviewState, action: PanelAction): Promise<void> {
+	async function handleAction(ctx: ExtensionContext, state: ReviewState, action: PanelAction): Promise<void> {
 		if (action === "clear") {
 			setReviewState(ctx, undefined);
 			ctx.ui.notify("Cleared revdiff annotations", "info");
@@ -299,6 +300,75 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 		},
 	});
 
+	pi.registerTool({
+		name: "revdiff_review",
+		label: "revdiff review",
+		description: "Launch revdiff in pi, capture interactive review annotations, and return them to the agent.",
+		promptSnippet: "Launch an interactive revdiff review and return captured annotations.",
+		promptGuidelines: [
+			"Use revdiff_review when the user asks to review a diff, inspect changes interactively, or gather revdiff annotations inside pi.",
+			"After revdiff_review returns annotations, address them directly instead of asking the user to run /revdiff or /revdiff-apply.",
+		],
+		parameters: Type.Object({
+			args: Type.Optional(
+				Type.String({
+					description:
+						"Optional revdiff arguments as a shell-like string, for example 'main', '--staged', '--only README.md', or '--all-files --exclude vendor'. Omit for smart detection.",
+				}),
+			),
+			mode: Type.Optional(
+				Type.String({ description: "Optional launch mode: 'direct' (default) or 'overlay'." }),
+			),
+			openPanel: Type.Optional(
+				Type.Boolean({ description: "Open the pi results panel after capture. Defaults to false for agent-driven reviews." }),
+			),
+		}),
+		async execute(_toolCallId, params, _signal, onUpdate, ctx) {
+			if (!ctx.hasUI) {
+				return toolTextResult("revdiff_review requires the interactive pi TUI.");
+			}
+
+			const mode = parseToolMode(params.mode);
+			if (params.mode && !mode) {
+				return toolTextResult("Invalid mode. Use 'direct' or 'overlay'.");
+			}
+
+			const rawArgs = [params.args?.trim() ?? "", mode ? `--pi-${mode}` : ""].filter(Boolean).join(" ");
+			const launch = await resolveLaunchSpec(rawArgs, ctx);
+			if (!launch) {
+				return toolTextResult("Could not resolve a revdiff launch target.");
+			}
+
+			pi.events.emit("revdiff:launch", { ...launch });
+			const result = await runAgentReview(ctx, launch, onUpdate);
+			if (!result) {
+				return toolTextResult("revdiff review did not complete.");
+			}
+
+			setLastLaunch({
+				args: [...result.args],
+				label: result.label,
+				mode: result.mode,
+				createdAt: result.createdAt,
+			});
+			setReviewState(ctx, result.annotations.length === 0 ? undefined : result);
+
+			if (params.openPanel === true && result.annotations.length > 0) {
+				await handleAction(ctx, result, await openResultsPanel(ctx, result));
+			}
+
+			if (result.annotations.length === 0) {
+				return toolTextResult(`Review complete — no annotations for ${result.label}.`, result);
+			}
+
+			const noun = result.annotations.length === 1 ? "annotation" : "annotations";
+			return toolTextResult(
+				[`Captured ${result.annotations.length} ${noun} for ${result.label}.`, result.rawOutput.trim()].filter(Boolean).join("\n\n"),
+				result,
+			);
+		},
+	});
+
 	pi.on("session_start", async (_event, ctx) => {
 		restoreState(ctx);
 	});
@@ -308,9 +378,37 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 	});
 }
 
+async function runAgentReview(
+	ctx: ExtensionContext,
+	launch: LaunchSpec,
+	onUpdate: AgentToolUpdateCallback<ReviewState | null> | undefined,
+): Promise<ReviewState | undefined> {
+	onUpdate?.({ content: [{ type: "text", text: `Launching revdiff for ${launch.label}...` }], details: null });
+	const result = await runReview(ctx, launch);
+	if (!result) {
+		return undefined;
+	}
+	return result;
+}
+
+function parseToolMode(mode: string | undefined): LaunchMode | undefined {
+	if (!mode) {
+		return undefined;
+	}
+	const normalized = mode.trim().toLowerCase();
+	if (normalized === "direct" || normalized === "overlay") {
+		return normalized;
+	}
+	return undefined;
+}
+
+function toolTextResult(content: string, details?: ReviewState) {
+	return { content: [{ type: "text" as const, text: content }], details: details ?? null };
+}
+
 async function applyReview(
 	pi: ExtensionAPI,
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	state: ReviewState,
 	clearReviewState: () => void,
 ): Promise<void> {
@@ -327,7 +425,7 @@ async function applyReview(
 	clearReviewState();
 }
 
-async function resolveLaunchSpec(rawArgs: string, ctx: ExtensionCommandContext): Promise<LaunchSpec | undefined> {
+async function resolveLaunchSpec(rawArgs: string, ctx: ExtensionContext): Promise<LaunchSpec | undefined> {
 	const trimmed = rawArgs.trim();
 	if (!trimmed) {
 		const detected = await detectSmartLaunch(ctx);
@@ -368,7 +466,7 @@ async function resolveLaunchSpec(rawArgs: string, ctx: ExtensionCommandContext):
 	return { args: tokens, label: describeArgs(tokens), mode };
 }
 
-async function detectSmartLaunch(ctx: ExtensionCommandContext): Promise<Omit<LaunchSpec, "mode"> | undefined> {
+async function detectSmartLaunch(ctx: ExtensionContext): Promise<Omit<LaunchSpec, "mode"> | undefined> {
 	const detected = detectSmartRef();
 	if (!detected) {
 		ctx.ui.notify("Not inside a git repo. Use /revdiff --only <file> to review a standalone file.", "warning");
@@ -400,14 +498,14 @@ async function detectSmartLaunch(ctx: ExtensionCommandContext): Promise<Omit<Lau
 	return { args: [detected.suggestedRef], label: detected.suggestedRef };
 }
 
-async function runReview(ctx: ExtensionCommandContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
+async function runReview(ctx: ExtensionContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
 	if (launch.mode === "overlay") {
 		return runOverlayReview(ctx, launch);
 	}
 	return runDirectReview(ctx, launch);
 }
 
-async function runDirectReview(ctx: ExtensionCommandContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
+async function runDirectReview(ctx: ExtensionContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
 	const revdiffBin = resolveRevdiffBin();
 	if (!revdiffBin) {
 		ctx.ui.notify("revdiff binary not found. Install it or set REVDIFF_BIN.", "error");
@@ -455,7 +553,7 @@ async function runDirectReview(ctx: ExtensionCommandContext, launch: LaunchSpec)
 	return buildResult(launch, rawOutput);
 }
 
-async function runOverlayReview(ctx: ExtensionCommandContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
+async function runOverlayReview(ctx: ExtensionContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
 	const launcher = resolveLauncherScript();
 	if (!launcher) {
 		ctx.ui.notify("Overlay mode requested, but launch-revdiff.sh was not found", "error");
@@ -501,7 +599,7 @@ function buildResult(launch: LaunchSpec, rawOutput: string): ReviewState {
 	};
 }
 
-async function openResultsPanel(ctx: ExtensionCommandContext, state: ReviewState): Promise<PanelAction> {
+async function openResultsPanel(ctx: ExtensionContext, state: ReviewState): Promise<PanelAction> {
 	return ctx.ui.custom<PanelAction>(
 		(tui, theme, _kb, done) => new ReviewPanel(tui, theme, state, done),
 		{
@@ -878,7 +976,7 @@ function shellSplit(input: string): string[] {
 	return tokens;
 }
 
-function normalizeLaunchMode(mode: LaunchMode | undefined, ctx: ExtensionCommandContext): LaunchMode | undefined {
+function normalizeLaunchMode(mode: LaunchMode | undefined, ctx: ExtensionContext): LaunchMode | undefined {
 	const envMode = process.env.REVDIFF_PI_MODE;
 	const resolved = mode ?? (envMode === "overlay" ? "overlay" : "direct");
 	if (resolved === "overlay" && !resolveLauncherScript()) {

--- a/plugins/pi/extensions/revdiff.ts
+++ b/plugins/pi/extensions/revdiff.ts
@@ -5,7 +5,6 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type {
-	AgentToolUpdateCallback,
 	ExtensionAPI,
 	ExtensionContext,
 	Theme,
@@ -155,7 +154,6 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 	}
 
 	async function startReview(ctx: ExtensionContext, launch: LaunchSpec): Promise<void> {
-		pi.events.emit("revdiff:launch", { ...launch });
 		if (!ctx.hasUI) {
 			ctx.ui.notify("/revdiff requires the interactive TUI", "warning");
 			return;
@@ -165,7 +163,7 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 			return;
 		}
 
-		const result = await runReview(ctx, launch);
+		const result = await runReview(pi, ctx, launch);
 		if (!result) {
 			return;
 		}
@@ -317,7 +315,9 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 				}),
 			),
 			mode: Type.Optional(
-				Type.String({ description: "Optional launch mode: 'direct' (default) or 'overlay'." }),
+				Type.Union([Type.Literal("direct"), Type.Literal("overlay")], {
+					description: "Optional launch mode: 'direct' (default) or 'overlay'.",
+				}),
 			),
 			openPanel: Type.Optional(
 				Type.Boolean({ description: "Open the pi results panel after capture. Defaults to false for agent-driven reviews." }),
@@ -328,10 +328,9 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 				return toolTextResult("revdiff_review requires the interactive pi TUI.");
 			}
 
-			const mode = parseToolMode(params.mode);
-			if (params.mode && !mode) {
-				return toolTextResult("Invalid mode. Use 'direct' or 'overlay'.");
-			}
+			// Tool execution runs during the agent turn, so ctx.isIdle() is expected
+			// to be false here; the tool runner serializes this interactive call.
+			const mode = params.mode;
 
 			const rawArgs = [params.args?.trim() ?? "", mode ? `--pi-${mode}` : ""].filter(Boolean).join(" ");
 			const launch = await resolveLaunchSpec(rawArgs, ctx);
@@ -339,8 +338,8 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 				return toolTextResult("Could not resolve a revdiff launch target.");
 			}
 
-			pi.events.emit("revdiff:launch", { ...launch });
-			const result = await runAgentReview(ctx, launch, onUpdate);
+			onUpdate?.({ content: [{ type: "text", text: `Launching revdiff for ${launch.label}...` }], details: null });
+			const result = await runReview(pi, ctx, launch);
 			if (!result) {
 				return toolTextResult("revdiff review did not complete.");
 			}
@@ -354,7 +353,7 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 			setReviewState(ctx, result.annotations.length === 0 ? undefined : result);
 
 			if (params.openPanel === true && result.annotations.length > 0) {
-				await handleAction(ctx, result, await openResultsPanel(ctx, result));
+				await openResultsPanel(ctx, result, { readOnly: true });
 			}
 
 			if (result.annotations.length === 0) {
@@ -362,10 +361,7 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 			}
 
 			const noun = result.annotations.length === 1 ? "annotation" : "annotations";
-			return toolTextResult(
-				[`Captured ${result.annotations.length} ${noun} for ${result.label}.`, result.rawOutput.trim()].filter(Boolean).join("\n\n"),
-				result,
-			);
+			return toolTextResult(`Captured ${result.annotations.length} ${noun} for ${result.label}.`, result);
 		},
 	});
 
@@ -376,30 +372,6 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 	pi.on("session_tree", async (_event, ctx) => {
 		restoreState(ctx);
 	});
-}
-
-async function runAgentReview(
-	ctx: ExtensionContext,
-	launch: LaunchSpec,
-	onUpdate: AgentToolUpdateCallback<ReviewState | null> | undefined,
-): Promise<ReviewState | undefined> {
-	onUpdate?.({ content: [{ type: "text", text: `Launching revdiff for ${launch.label}...` }], details: null });
-	const result = await runReview(ctx, launch);
-	if (!result) {
-		return undefined;
-	}
-	return result;
-}
-
-function parseToolMode(mode: string | undefined): LaunchMode | undefined {
-	if (!mode) {
-		return undefined;
-	}
-	const normalized = mode.trim().toLowerCase();
-	if (normalized === "direct" || normalized === "overlay") {
-		return normalized;
-	}
-	return undefined;
 }
 
 function toolTextResult(content: string, details?: ReviewState) {
@@ -498,7 +470,8 @@ async function detectSmartLaunch(ctx: ExtensionContext): Promise<Omit<LaunchSpec
 	return { args: [detected.suggestedRef], label: detected.suggestedRef };
 }
 
-async function runReview(ctx: ExtensionContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
+async function runReview(pi: ExtensionAPI, ctx: ExtensionContext, launch: LaunchSpec): Promise<ReviewState | undefined> {
+	pi.events.emit("revdiff:launch", { ...launch });
 	if (launch.mode === "overlay") {
 		return runOverlayReview(ctx, launch);
 	}
@@ -534,7 +507,8 @@ async function runDirectReview(ctx: ExtensionContext, launch: LaunchSpec): Promi
 		return { render: () => [], invalidate() {} };
 	});
 
-	const rawOutput = existsSync(outputFile) ? readFileSync(outputFile, "utf8").trim() : "";
+	const outputExists = existsSync(outputFile);
+	const rawOutput = outputExists ? readFileSync(outputFile, "utf8").trim() : "";
 	try {
 		rmSync(tempDir, { recursive: true, force: true });
 	} catch {
@@ -545,8 +519,16 @@ async function runDirectReview(ctx: ExtensionContext, launch: LaunchSpec): Promi
 		ctx.ui.notify(`Failed to launch revdiff: ${launchError}`, "error");
 		return undefined;
 	}
-	if ((exitCode ?? 0) !== 0 && !rawOutput) {
-		ctx.ui.notify(`revdiff exited with code ${exitCode ?? 1}`, "warning");
+	if (typeof exitCode !== "number") {
+		ctx.ui.notify("revdiff review did not complete", "warning");
+		return undefined;
+	}
+	if (exitCode !== 0) {
+		ctx.ui.notify(`revdiff exited with code ${exitCode}`, "warning");
+		return undefined;
+	}
+	if (!outputExists) {
+		ctx.ui.notify("revdiff completed without writing annotations output", "warning");
 		return undefined;
 	}
 
@@ -599,9 +581,13 @@ function buildResult(launch: LaunchSpec, rawOutput: string): ReviewState {
 	};
 }
 
-async function openResultsPanel(ctx: ExtensionContext, state: ReviewState): Promise<PanelAction> {
+async function openResultsPanel(
+	ctx: ExtensionContext,
+	state: ReviewState,
+	options: { readOnly?: boolean } = {},
+): Promise<PanelAction> {
 	return ctx.ui.custom<PanelAction>(
-		(tui, theme, _kb, done) => new ReviewPanel(tui, theme, state, done),
+		(tui, theme, _kb, done) => new ReviewPanel(tui, theme, state, done, options.readOnly === true),
 		{
 			overlay: true,
 			overlayOptions: {
@@ -620,17 +606,20 @@ class ReviewPanel {
 	private theme: Theme;
 	private state: ReviewState;
 	private done: (value: PanelAction) => void;
+	private readOnly: boolean;
 
 	constructor(
 		tui: { requestRender: (full?: boolean) => void },
 		theme: Theme,
 		state: ReviewState,
 		done: (value: PanelAction) => void,
+		readOnly: boolean,
 	) {
 		this.tui = tui;
 		this.theme = theme;
 		this.state = state;
 		this.done = done;
+		this.readOnly = readOnly;
 	}
 
 	handleInput(data: string): void {
@@ -648,15 +637,15 @@ class ReviewPanel {
 			this.tui.requestRender();
 			return;
 		}
-		if (matchesKey(data, "return") || data === "a" || data === "A") {
+		if (!this.readOnly && (matchesKey(data, "return") || data === "a" || data === "A")) {
 			this.done("apply");
 			return;
 		}
-		if (data === "r" || data === "R") {
+		if (!this.readOnly && (data === "r" || data === "R")) {
 			this.done("rerun");
 			return;
 		}
-		if (data === "c" || data === "C") {
+		if (!this.readOnly && (data === "c" || data === "C")) {
 			this.done("clear");
 		}
 	}
@@ -682,8 +671,13 @@ class ReviewPanel {
 		}
 
 		lines.push(border(`├${"─".repeat(innerW)}┤`));
-		lines.push(row(th.fg("dim", "↑↓/j k move • Enter/a apply • r rerun")));
-		lines.push(row(th.fg("dim", "c clear • Esc close")));
+		if (this.readOnly) {
+			lines.push(row(th.fg("dim", "↑↓/j k move • Esc close")));
+			lines.push(row(""));
+		} else {
+			lines.push(row(th.fg("dim", "↑↓/j k move • Enter/a apply • r rerun")));
+			lines.push(row(th.fg("dim", "c clear • Esc close")));
+		}
 		lines.push(border(`╰${"─".repeat(innerW)}╯`));
 		return lines;
 	}

--- a/plugins/pi/skills/revdiff/SKILL.md
+++ b/plugins/pi/skills/revdiff/SKILL.md
@@ -8,7 +8,22 @@ description: Pi-only interactive diff and file review with revdiff. Use when the
 This skill is specific to the **pi** harness.
 Use the revdiff pi extension for interactive review sessions.
 
-## Commands
+## Agent usage
+
+When the user asks you to review a diff, inspect changes with revdiff, or gather revdiff annotations, call the `revdiff_review` tool. Do **not** tell the user to run `/revdiff`; slash commands are user-invoked only.
+
+Tool examples:
+
+- No args: smart detection, same default target as `/revdiff`
+- `args: "main"`: review the current branch against `main`
+- `args: "--staged"`: review staged changes
+- `args: "--only README.md"`: review one standalone file
+- `args: "--all-files --exclude vendor"`: review all tracked files except vendor
+- `mode: "overlay"`: use optional overlay mode instead of the default direct pi-native launcher
+
+After `revdiff_review` returns annotations, address them directly. If it returns no annotations, report that the review was clean.
+
+## User commands
 
 - `/revdiff [args]` — launch revdiff, capture annotations, and open the results side panel
 - `/revdiff-rerun [--pi-overlay|--pi-direct]` — rerun the last review with remembered args
@@ -17,9 +32,7 @@ Use the revdiff pi extension for interactive review sessions.
 - `/revdiff-clear` — clear the stored review state widget/panel
 - `/revdiff-reminders on|off` — enable or disable post-edit review reminders
 
-## Recommended usage
-
-Examples:
+## Recommended user command examples
 
 ```text
 /revdiff
@@ -40,7 +53,7 @@ Behavior:
   - on main/master with a clean tree → review `HEAD~1`
   - on a clean feature branch → review against the detected main branch
   - on a dirty feature branch → asks whether to review uncommitted changes or the branch diff
-- After revdiff exits, annotations are parsed and shown in a grouped right-side overlay panel
+- After revdiff exits, annotations are parsed and shown in a grouped right-side overlay panel for user-launched reviews
 - A persistent widget is shown below the editor until cleared or until a clean re-review produces no annotations
 - `/revdiff-rerun` remembers the last args, so the review loop stays tight
 - Optional post-edit reminders can suggest `/revdiff` or `/revdiff-rerun` after the agent uses `edit`/`write`
@@ -49,6 +62,6 @@ Behavior:
 ## Notes
 
 - The default mode launches the external `revdiff` binary in the current terminal session, temporarily suspending pi while revdiff is running
-- Optional overlay mode (`--pi-overlay` or `REVDIFF_PI_MODE=overlay`) reuses the existing `launch-revdiff.sh` script from the Claude plugin integration
+- Optional overlay mode (`--pi-overlay`, `mode: "overlay"`, or `REVDIFF_PI_MODE=overlay`) reuses the existing `launch-revdiff.sh` script from the Claude plugin integration
 - If `revdiff` is not on `PATH`, set `REVDIFF_BIN` to its absolute path
 - You can still use revdiff standalone outside pi; the extension is only a convenience layer around the existing binary


### PR DESCRIPTION
## Summary
- add a `revdiff_review` pi agent tool for interactive reviews
- update pi extension imports/dependencies and package included files
- document agent-tool usage in the pi skill

## Notes
- `@mariozechner/pi-*` is deprecated upstream and renamed to `@earendil-works/pi-*`; v0.74 is the first release with the agent-tool API.
- The new pi API drops the `success` notify level, so the two completion notifications now use `info`.

Refs #167