### PR TITLE
Fix note about sandbox `excludedCommands`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Priority: tmux → Zellij → kitty → wezterm/Kaku → cmux → ghostty → iT
 >
 > ```json
 > {
->   "permissions": {
+>   "sandbox": {
 >     "excludedCommands": ["*/launch-revdiff.sh*"]
 >   }
 > }


### PR DESCRIPTION
This key moved from `permissions` to `sandbox` at some point