### PR TITLE
Make open-editor binding configurable via keymap

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -141,6 +141,6 @@ unmap q
 map ctrl+d half_page_down
 ```
 
-Available actions: `down`, `up`, `page_down`, `page_up`, `half_page_down`, `half_page_up`, `home`, `end`, `scroll_left`, `scroll_right`, `scroll_center`, `scroll_top`, `scroll_bottom`, `next_item`, `prev_item`, `next_hunk`, `prev_hunk`, `toggle_pane`, `focus_tree`, `focus_diff`, `search`, `confirm`, `annotate_file`, `delete_annotation`, `annot_list`, `toggle_collapsed`, `toggle_compact`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `theme_select`, `filter`, `info`, `quit`, `discard_quit`, `help`, `dismiss`
+Available actions: `down`, `up`, `page_down`, `page_up`, `half_page_down`, `half_page_up`, `home`, `end`, `scroll_left`, `scroll_right`, `scroll_center`, `scroll_top`, `scroll_bottom`, `next_item`, `prev_item`, `next_hunk`, `prev_hunk`, `toggle_pane`, `focus_tree`, `focus_diff`, `search`, `confirm`, `annotate_file`, `delete_annotation`, `annot_list`, `open_editor`, `toggle_collapsed`, `toggle_compact`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `theme_select`, `filter`, `info`, `quit`, `discard_quit`, `help`, `dismiss`
 
-Modal keys (annotation input, search input, confirm discard) are not remappable.
+Fixed modal keys (Enter, Esc in annotation/search input, confirm discard) are not remappable. Keymap-resolved actions like `open_editor` work during annotation input and can be rebound. Chord bindings do not fire during text input — use single-key `ctrl+*` bindings for actions that need to work during annotation input.

--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -142,10 +142,10 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `@` | Toggle annotation list popup (navigate and jump to any annotation) |
 | `}` / `{` | Jump to next/previous annotation (always crosses file boundaries; silent no-op at the first/last annotation) |
 | `d` | Delete annotation under cursor |
-| `Ctrl+E` (during annotation input) | Open `$EDITOR` for multi-line annotation |
+| `Ctrl+E` (during annotation input) | Open `$EDITOR` for multi-line annotation (`open_editor` — rebindable) |
 | `Esc` | Cancel annotation input |
 
-While the annotation input is active, press `Ctrl+E` to hand off the current text to an external editor for multi-line comments. Editor resolution: `$EDITOR` → `$VISUAL` → `vi`. Values with arguments work (e.g. `EDITOR="code --wait"`). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (`@`), and emitted with embedded newlines in the structured output.
+While the annotation input is active, press `Ctrl+E` (or whatever key is bound to `open_editor`) to hand off the current text to an external editor for multi-line comments. Editor resolution: `$EDITOR` → `$VISUAL` → `vi`. Values with arguments work (e.g. `EDITOR="code --wait"`). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (`@`), and emitted with embedded newlines in the structured output.
 
 **View:**
 

--- a/README.md
+++ b/README.md
@@ -659,10 +659,10 @@ In the Claude Code and Codex plugins, you can also tell the agent to use a past 
 | `@` | Toggle annotation list popup (navigate and jump to any annotation) |
 | `}` / `{` | Jump to next/previous annotation (always crosses file boundaries; silent no-op at the first/last annotation) |
 | `d` | Delete annotation under cursor |
-| `Ctrl+E` (during annotation input) | Open `$EDITOR` for multi-line annotation |
+| `Ctrl+E` (during annotation input) | Open `$EDITOR` for multi-line annotation (`open_editor` — rebindable) |
 | `Esc` | Cancel annotation input |
 
-While the annotation input is active, press `Ctrl+E` to hand off the current text to an external editor for multi-line comments. Editor resolution: `$EDITOR` → `$VISUAL` → `vi`. Values with arguments work (e.g. `EDITOR="code --wait"`). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (`@`), and emitted with embedded newlines in the structured output.
+While the annotation input is active, press `Ctrl+E` (or whatever key is bound to `open_editor`) to hand off the current text to an external editor for multi-line comments. Editor resolution: `$EDITOR` → `$VISUAL` → `vi`. Values with arguments work (e.g. `EDITOR="code --wait"`). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (`@`), and emitted with embedded newlines in the structured output.
 
 **View:**
 
@@ -753,7 +753,7 @@ mkdir -p ~/.config/revdiff
 revdiff --dump-keys > ~/.config/revdiff/keybindings
 ```
 
-Then edit to taste. Modal keys (annotation input, search input, confirm discard) are not remappable.
+Then edit to taste. Fixed modal keys (Enter, Esc in annotation/search input, confirm discard) are not remappable. Keymap-resolved actions like `open_editor` work during annotation input and can be rebound.
 
 **Chord bindings (ctrl/alt leader):** bind a two-stage chord by joining the leader and second key with `>`. The leader must be a `ctrl+*` or `alt+*` combo; the second stage is any single key. Only two stages are supported.
 
@@ -762,7 +762,7 @@ map ctrl+w>x mark_reviewed
 map alt+t>n theme_select
 ```
 
-When the leader is pressed, the status bar shows `Pending: ctrl+w, esc to cancel`; press the second key to dispatch, or `esc` to cancel silently. Binding a key as both a standalone action and a chord prefix drops the standalone binding (the chord wins, with a warning). Chord bindings work under non-Latin keyboard layouts — the second-stage key is translated via the same layout-resolve fallback as single-key bindings.
+When the leader is pressed, the status bar shows `Pending: ctrl+w, esc to cancel`; press the second key to dispatch, or `esc` to cancel silently. Binding a key as both a standalone action and a chord prefix drops the standalone binding (the chord wins, with a warning). Chord bindings work under non-Latin keyboard layouts — the second-stage key is translated via the same layout-resolve fallback as single-key bindings. Note: chord bindings do not fire during text input (annotation and search prompts) — the leader key is consumed by the text input widget. Use single-key `ctrl+*` bindings for actions like `open_editor` that need to work during annotation input.
 
 **macOS note:** `alt+*` leaders require your terminal to send Option as Meta/Alt. Most terminals default to "Option composes special characters" (e.g. `Option+T` → `†`), in which case Alt chords silently won't fire. To enable: iTerm2 → *Profiles → Keys → Left/Right Option key → `Esc+`*; Terminal.app → *Profiles → Keyboard → Use Option as Meta key*; Kitty → `macos_option_as_alt yes`; Ghostty → `macos-option-as-alt = true`. If you'd rather not touch terminal settings, use `ctrl+*` leaders — those work everywhere with no configuration.
 
@@ -777,7 +777,7 @@ When the leader is pressed, the status bar shows `Pending: ctrl+w, esc to cancel
 
 **Search:** `search`
 
-**Annotations:** `confirm` (annotate line / select file), `annotate_file`, `delete_annotation`, `annot_list`, `next_annotation`, `prev_annotation`
+**Annotations:** `confirm` (annotate line / select file), `annotate_file`, `delete_annotation`, `annot_list`, `open_editor`, `next_annotation`, `prev_annotation`
 
 **View:** `toggle_collapsed`, `toggle_compact`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_word_diff`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `theme_select`, `filter`, `info`, `reload`
 

--- a/app/keymap/keymap.go
+++ b/app/keymap/keymap.go
@@ -64,6 +64,7 @@ const (
 	ActionThemeSelect      Action = "theme_select"
 	ActionInfo             Action = "info"
 	ActionReload           Action = "reload"
+	ActionOpenEditor       Action = "open_editor"
 )
 
 // SectionPane is the help section name for pane-related keybindings.
@@ -84,8 +85,9 @@ var validActions = map[Action]bool{
 	ActionToggleLineNums: true, ActionToggleBlame: true, ActionToggleWordDiff: true, ActionToggleHunk: true,
 	ActionMarkReviewed: true, ActionFilter: true, ActionToggleUntracked: true,
 	ActionQuit: true, ActionDiscardQuit: true, ActionHelp: true, ActionDismiss: true, ActionThemeSelect: true,
-	ActionInfo:   true,
-	ActionReload: true,
+	ActionInfo:       true,
+	ActionReload:     true,
+	ActionOpenEditor: true,
 }
 
 // deprecatedActionAliases maps obsolete action names parsed from user
@@ -207,6 +209,7 @@ func defaultDescriptions() []HelpEntry {
 		{ActionAnnotateFile, "annotate file", "Annotations"},
 		{ActionDeleteAnnotation, "delete annotation", "Annotations"},
 		{ActionAnnotList, "annotation list", "Annotations"},
+		{ActionOpenEditor, "open annotation in $EDITOR", "Annotations"},
 		{ActionNextAnnotation, "next annotation (across files)", "Annotations"},
 		{ActionPrevAnnotation, "previous annotation (across files)", "Annotations"},
 
@@ -263,6 +266,7 @@ func defaultBindings() map[string]Action {
 		"A":      ActionAnnotateFile,
 		"d":      ActionDeleteAnnotation,
 		"@":      ActionAnnotList,
+		"ctrl+e": ActionOpenEditor,
 		"}":      ActionNextAnnotation,
 		"{":      ActionPrevAnnotation,
 		"v":      ActionToggleCollapsed,

--- a/app/keymap/keymap_test.go
+++ b/app/keymap/keymap_test.go
@@ -34,7 +34,7 @@ func TestDefault_allExpectedBindings(t *testing.T) {
 		{"tab", ActionTogglePane}, {"h", ActionFocusTree}, {"l", ActionFocusDiff},
 		{"/", ActionSearch},
 		{"a", ActionConfirm}, {"enter", ActionConfirm},
-		{"A", ActionAnnotateFile}, {"d", ActionDeleteAnnotation}, {"@", ActionAnnotList},
+		{"A", ActionAnnotateFile}, {"d", ActionDeleteAnnotation}, {"@", ActionAnnotList}, {"ctrl+e", ActionOpenEditor},
 		{"}", ActionNextAnnotation}, {"{", ActionPrevAnnotation},
 		{"v", ActionToggleCollapsed}, {"C", ActionToggleCompact}, {"w", ActionToggleWrap}, {"t", ActionToggleTree},
 		{"L", ActionToggleLineNums}, {"B", ActionToggleBlame}, {"W", ActionToggleWordDiff},
@@ -243,6 +243,29 @@ func TestActionToggleCompact_HelpEntry(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "ActionToggleCompact should have a help entry")
+}
+
+func TestActionOpenEditor_IsValid(t *testing.T) {
+	assert.True(t, IsValidAction(ActionOpenEditor))
+}
+
+func TestActionOpenEditor_DefaultBinding(t *testing.T) {
+	km := Default()
+	assert.Equal(t, ActionOpenEditor, km.Resolve("ctrl+e"))
+}
+
+func TestActionOpenEditor_HelpEntry(t *testing.T) {
+	entries := defaultDescriptions()
+	var found bool
+	for _, e := range entries {
+		if e.Action == ActionOpenEditor {
+			assert.Equal(t, "open annotation in $EDITOR", e.Description)
+			assert.Equal(t, "Annotations", e.Section)
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "ActionOpenEditor should have a help entry")
 }
 
 func TestActionScrollConstants_InNavigationActions(t *testing.T) {

--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/umputun/revdiff/app/annotation"
 	"github.com/umputun/revdiff/app/diff"
+	"github.com/umputun/revdiff/app/keymap"
 	"github.com/umputun/revdiff/app/ui/style"
 )
 
@@ -76,25 +77,30 @@ func (m *Model) startAnnotation() tea.Cmd {
 		return nil
 	}
 
-	placeholder := "annotation... (Ctrl+E for editor)"
+	editorKey := m.editorKeyDisplay()
+	placeholder := "annotation..."
+	if editorKey != "" {
+		placeholder = fmt.Sprintf("annotation... (%s for editor)", editorKey)
+	}
 
 	// pre-fill with existing annotation if one exists. multi-line comments are
 	// NOT set via ti.SetValue because textinput's sanitizer collapses \n to
 	// space; instead, stash the original in existingMultiline and hint at it
-	// via the placeholder so Ctrl+E can seed the editor from it and Enter with
-	// empty input preserves it unchanged.
+	// via the placeholder so the editor key can seed the editor from it and
+	// Enter with empty input preserves it unchanged.
 	lineNum := m.diffLineNum(dl)
 	var preFill, existingMultiline string
 	for _, a := range m.store.Get(m.file.name) {
-		if a.Line == lineNum && a.Type == string(dl.ChangeType) {
-			if strings.Contains(a.Comment, "\n") {
-				existingMultiline = a.Comment
-				placeholder = "[existing multi-line — Ctrl+E to edit]"
-			} else {
-				preFill = a.Comment
-			}
-			break
+		if a.Line != lineNum || a.Type != string(dl.ChangeType) {
+			continue
 		}
+		if strings.Contains(a.Comment, "\n") {
+			existingMultiline = a.Comment
+			placeholder = m.multiLinePlaceholder()
+		} else {
+			preFill = a.Comment
+		}
+		break
 	}
 
 	ti, cmd := m.newAnnotationInput(placeholder, 3+lipgloss.Width(m.annotPrefix())) // cursor col + annotation prefix + border margin
@@ -138,23 +144,28 @@ func (m *Model) startFileAnnotation() tea.Cmd {
 		return nil
 	}
 
-	placeholder := "file-level annotation... (Ctrl+E for editor)"
+	editorKey := m.editorKeyDisplay()
+	placeholder := "file-level annotation..."
+	if editorKey != "" {
+		placeholder = fmt.Sprintf("file-level annotation... (%s for editor)", editorKey)
+	}
 
 	// pre-fill with existing file-level annotation if one exists. multi-line
 	// comments bypass ti.SetValue (textinput sanitizer flattens \n to space);
-	// instead stash in existingMultiline so Ctrl+E can seed and Enter with empty
-	// input preserves it unchanged.
+	// instead stash in existingMultiline so the editor key can seed and Enter
+	// with empty input preserves it unchanged.
 	var preFill, existingMultiline string
 	for _, a := range m.store.Get(m.file.name) {
-		if a.Line == 0 {
-			if strings.Contains(a.Comment, "\n") {
-				existingMultiline = a.Comment
-				placeholder = "[existing multi-line — Ctrl+E to edit]"
-			} else {
-				preFill = a.Comment
-			}
-			break
+		if a.Line != 0 {
+			continue
 		}
+		if strings.Contains(a.Comment, "\n") {
+			existingMultiline = a.Comment
+			placeholder = m.multiLinePlaceholder()
+		} else {
+			preFill = a.Comment
+		}
+		break
 	}
 
 	ti, cmd := m.newAnnotationInput(placeholder, 3+lipgloss.Width(m.annotFilePrefix())) // cursor col + file annotation prefix + border margin
@@ -312,6 +323,27 @@ func (m *Model) deleteAnnotation() tea.Cmd {
 	return nil
 }
 
+// editorKeyDisplay returns the display name for the open_editor binding
+// (e.g. "Ctrl+E") for use in placeholder text. Returns empty when unbound.
+// Filters out chord bindings since they don't fire during annotation input.
+func (m Model) editorKeyDisplay() string {
+	keys := m.keymap.KeysFor(keymap.ActionOpenEditor)
+	var single []string
+	for _, k := range keys {
+		if strings.Index(k, ">") <= 0 {
+			single = append(single, m.displayKeyName(k))
+		}
+	}
+	return strings.Join(single, " / ")
+}
+
+func (m Model) multiLinePlaceholder() string {
+	if key := m.editorKeyDisplay(); key != "" {
+		return fmt.Sprintf("[existing multi-line — %s to edit]", key)
+	}
+	return "[existing multi-line]"
+}
+
 // handleAnnotateKey handles key messages during annotation input mode.
 func (m Model) handleAnnotateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
@@ -321,12 +353,11 @@ func (m Model) handleAnnotateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyEsc:
 		m.cancelAnnotation()
 		return m, nil
-	case tea.KeyCtrlE:
-		// hand off to $EDITOR for multi-line annotation input.
-		// keep annotating=true so editorFinishedMsg routes back through the annotation flow.
-		cmd := m.openEditor()
-		return m, cmd
 	default:
+		if m.keymap.Resolve(msg.String()) == keymap.ActionOpenEditor {
+			cmd := m.openEditor()
+			return m, cmd
+		}
 		var cmd tea.Cmd
 		m.annot.input, cmd = m.annot.input.Update(msg)
 		m.layout.viewport.SetContent(m.renderDiff()) // re-render so typed characters are visible immediately

--- a/app/ui/annotate_test.go
+++ b/app/ui/annotate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/umputun/revdiff/app/annotation"
 	"github.com/umputun/revdiff/app/diff"
+	"github.com/umputun/revdiff/app/keymap"
 	"github.com/umputun/revdiff/app/ui/mocks"
 	"github.com/umputun/revdiff/app/ui/overlay"
 	"github.com/umputun/revdiff/app/ui/sidepane"
@@ -2508,6 +2509,85 @@ func TestModel_AnnotationPlaceholderMentionsEditor(t *testing.T) {
 	m2.file.name = "a.go"
 	m2.startFileAnnotation()
 	assert.Contains(t, m2.annot.input.Placeholder, "Ctrl+E", "file-level placeholder must mention Ctrl+E")
+}
+
+func TestModel_AnnotationPlaceholderRemappedEditor(t *testing.T) {
+	lines := []diff.DiffLine{{NewNum: 1, Content: "x", ChangeType: diff.ChangeAdd}}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.tree = testNewFileTree([]string{"a.go"})
+	m.layout.focus = paneDiff
+	m.file.name = "a.go"
+	m.file.lines = lines
+	m.nav.diffCursor = 0
+
+	m.keymap.Unbind("ctrl+e")
+	m.keymap.Bind("ctrl+g", keymap.ActionOpenEditor)
+
+	m.startAnnotation()
+	assert.Contains(t, m.annot.input.Placeholder, "Ctrl+G", "placeholder must reflect remapped key")
+	assert.NotContains(t, m.annot.input.Placeholder, "Ctrl+E", "placeholder must not mention old key")
+}
+
+func TestModel_AnnotationPlaceholderUnboundEditor(t *testing.T) {
+	lines := []diff.DiffLine{{NewNum: 1, Content: "x", ChangeType: diff.ChangeAdd}}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.tree = testNewFileTree([]string{"a.go"})
+	m.layout.focus = paneDiff
+	m.file.name = "a.go"
+	m.file.lines = lines
+	m.nav.diffCursor = 0
+
+	m.keymap.Unbind("ctrl+e")
+
+	m.startAnnotation()
+	assert.NotContains(t, m.annot.input.Placeholder, "Ctrl+E", "placeholder must not mention editor when unbound")
+	assert.NotContains(t, m.annot.input.Placeholder, "for editor", "placeholder must not mention editor when unbound")
+}
+
+func TestModel_RemappedEditorKeyOpensEditor(t *testing.T) {
+	lines := []diff.DiffLine{{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext}}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.tree = testNewFileTree([]string{"a.go"})
+	m.layout.focus = paneDiff
+	m.file.name = "a.go"
+	m.file.lines = lines
+	m.nav.diffCursor = 0
+
+	m.keymap.Unbind("ctrl+e")
+	m.keymap.Bind("ctrl+g", keymap.ActionOpenEditor)
+
+	fake := mockEditor("edited", nil)
+	m.editor = fake
+
+	m.startAnnotation()
+	m.annot.input.SetValue("seed")
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	model := result.(Model)
+	require.NotNil(t, cmd, "remapped ctrl+g should trigger editor")
+	require.Len(t, fake.CommandCalls(), 1, "editor.Command called once")
+	assert.Equal(t, "seed", fake.CommandCalls()[0].Content)
+	assert.True(t, model.annot.annotating)
+}
+
+func TestModel_UnboundEditorKeyFallsThrough(t *testing.T) {
+	lines := []diff.DiffLine{{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext}}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.tree = testNewFileTree([]string{"a.go"})
+	m.layout.focus = paneDiff
+	m.file.name = "a.go"
+	m.file.lines = lines
+	m.nav.diffCursor = 0
+
+	m.keymap.Unbind("ctrl+e")
+
+	fake := mockEditor("edited", nil)
+	m.editor = fake
+
+	m.startAnnotation()
+
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	assert.Empty(t, fake.CommandCalls(), "unbound ctrl+e must not open editor")
 }
 
 func TestModel_VisualRowToDiffLine_EmptyFile(t *testing.T) {

--- a/app/ui/handlers.go
+++ b/app/ui/handlers.go
@@ -32,7 +32,11 @@ func (m Model) displayKeyName(key string) string {
 		return d
 	}
 	if strings.HasPrefix(key, "ctrl+") {
-		return "Ctrl+" + key[5:]
+		suffix := key[5:]
+		if suffix != "" {
+			return "Ctrl+" + strings.ToUpper(suffix[:1]) + suffix[1:]
+		}
+		return "Ctrl+"
 	}
 	return key
 }

--- a/app/ui/handlers_test.go
+++ b/app/ui/handlers_test.go
@@ -738,6 +738,24 @@ func TestModel_ToggleCompactMode_CursorResetsAfterReload(t *testing.T) {
 	assert.Equal(t, 1, model.nav.diffCursor, "cursor must reset to first non-divider line after compact re-fetch")
 }
 
+func TestDisplayKeyName(t *testing.T) {
+	m := testModel(nil, nil)
+	tests := []struct{ input, want string }{
+		{"ctrl+e", "Ctrl+E"},
+		{"ctrl+d", "Ctrl+D"},
+		{"ctrl+u", "Ctrl+U"},
+		{"ctrl+w>x", "Ctrl+W>x"},
+		{"ctrl+", "Ctrl+"},
+		{"j", "j"},
+		{"pgdown", "PgDn"},
+		{"enter", "Enter"},
+		{" ", "Space"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, m.displayKeyName(tt.input), "displayKeyName(%q)", tt.input)
+	}
+}
+
 func TestBuildHelpSpec_SearchPromptHistoryEntries(t *testing.T) {
 	m := testModel([]string{"a.go"}, nil)
 

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -141,6 +141,6 @@ unmap q
 map ctrl+d half_page_down
 ```
 
-Available actions: `down`, `up`, `page_down`, `page_up`, `half_page_down`, `half_page_up`, `home`, `end`, `scroll_left`, `scroll_right`, `scroll_center`, `scroll_top`, `scroll_bottom`, `next_item`, `prev_item`, `next_hunk`, `prev_hunk`, `toggle_pane`, `focus_tree`, `focus_diff`, `search`, `confirm`, `annotate_file`, `delete_annotation`, `annot_list`, `toggle_collapsed`, `toggle_compact`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `theme_select`, `filter`, `info`, `quit`, `discard_quit`, `help`, `dismiss`
+Available actions: `down`, `up`, `page_down`, `page_up`, `half_page_down`, `half_page_up`, `home`, `end`, `scroll_left`, `scroll_right`, `scroll_center`, `scroll_top`, `scroll_bottom`, `next_item`, `prev_item`, `next_hunk`, `prev_hunk`, `toggle_pane`, `focus_tree`, `focus_diff`, `search`, `confirm`, `annotate_file`, `delete_annotation`, `annot_list`, `open_editor`, `toggle_collapsed`, `toggle_compact`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `theme_select`, `filter`, `info`, `quit`, `discard_quit`, `help`, `dismiss`
 
-Modal keys (annotation input, search input, confirm discard) are not remappable.
+Fixed modal keys (Enter, Esc in annotation/search input, confirm discard) are not remappable. Keymap-resolved actions like `open_editor` work during annotation input and can be rebound. Chord bindings do not fire during text input — use single-key `ctrl+*` bindings for actions that need to work during annotation input.

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -142,10 +142,10 @@ Use `--stdin` to review arbitrary piped or redirected text as one synthetic file
 | `@` | Toggle annotation list popup (navigate and jump to any annotation) |
 | `}` / `{` | Jump to next/previous annotation (always crosses file boundaries; silent no-op at the first/last annotation) |
 | `d` | Delete annotation under cursor |
-| `Ctrl+E` (during annotation input) | Open `$EDITOR` for multi-line annotation |
+| `Ctrl+E` (during annotation input) | Open `$EDITOR` for multi-line annotation (`open_editor` — rebindable) |
 | `Esc` | Cancel annotation input |
 
-While the annotation input is active, press `Ctrl+E` to hand off the current text to an external editor for multi-line comments. Editor resolution: `$EDITOR` → `$VISUAL` → `vi`. Values with arguments work (e.g. `EDITOR="code --wait"`). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (`@`), and emitted with embedded newlines in the structured output.
+While the annotation input is active, press `Ctrl+E` (or whatever key is bound to `open_editor`) to hand off the current text to an external editor for multi-line comments. Editor resolution: `$EDITOR` → `$VISUAL` → `vi`. Values with arguments work (e.g. `EDITOR="code --wait"`). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (`@`), and emitted with embedded newlines in the structured output.
 
 **View:**
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -508,11 +508,11 @@ color-border = #6272a4
                 <tr><td><code>@</code></td><td>Toggle annotation list popup</td></tr>
                 <tr><td><code>}</code> / <code>{</code></td><td>Jump to next/previous annotation (always crosses file boundaries; silent no-op at the first/last annotation)</td></tr>
                 <tr><td><code>d</code></td><td>Delete annotation under cursor</td></tr>
-                <tr><td><code>Ctrl+E</code></td><td>Open <code>$EDITOR</code> for multi-line annotation (during annotation input)</td></tr>
+                <tr><td><code>Ctrl+E</code></td><td>Open <code>$EDITOR</code> for multi-line annotation (<code>open_editor</code> &mdash; rebindable, during annotation input)</td></tr>
                 <tr><td><code>Esc</code></td><td>Cancel annotation input</td></tr>
             </tbody>
         </table>
-        <p>While the annotation input is active, press <code>Ctrl+E</code> to hand off the current text to an external editor for multi-line comments. Editor resolution: <code>$EDITOR</code> &rarr; <code>$VISUAL</code> &rarr; <code>vi</code>. Values with arguments work (e.g. <code>EDITOR="code --wait"</code>). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (<code>@</code>), and emitted with embedded newlines in the structured output.</p>
+        <p>While the annotation input is active, press <code>Ctrl+E</code> (or whatever key is bound to <code>open_editor</code>) to hand off the current text to an external editor for multi-line comments. Editor resolution: <code>$EDITOR</code> &rarr; <code>$VISUAL</code> &rarr; <code>vi</code>. Values with arguments work (e.g. <code>EDITOR="code --wait"</code>). On editor save and quit, the full file contents (including newlines) become the annotation. Quitting the editor with an empty file cancels the annotation and preserves any previously stored note on that line. Multi-line annotations are rendered line-by-line in the diff view, shown flattened in the annotation list popup (<code>@</code>), and emitted with embedded newlines in the structured output.</p>
 
         <h2 id="view">View toggles</h2>
         <table>
@@ -586,19 +586,19 @@ map ctrl+u half_page_up
 map x quit
 unmap q</code></div>
         <p>Generate a template: <code>revdiff --dump-keys > ~/.config/revdiff/keybindings</code></p>
-        <p>Modal keys (annotation input, search input, confirm discard) are not remappable.</p>
+        <p>Fixed modal keys (Enter, Esc in annotation/search input, confirm discard) are not remappable. Keymap-resolved actions like <code>open_editor</code> work during annotation input and can be rebound.</p>
         <h3>Chord bindings (ctrl/alt leader)</h3>
         <p>Bind a two-stage chord by joining the leader and second key with <code>&gt;</code>. The leader must be a <code>ctrl+*</code> or <code>alt+*</code> combo; the second stage is any single key. Only two stages are supported.</p>
         <div class="code-block"><code>map ctrl+w&gt;x mark_reviewed
 map alt+t&gt;n theme_select</code></div>
-        <p>When the leader is pressed, the status bar shows <code>Pending: ctrl+w, esc to cancel</code>; press the second key to dispatch, or <code>esc</code> to cancel silently. Binding a key as both a standalone action and a chord prefix drops the standalone binding (the chord wins, with a warning). Chord bindings work under non-Latin keyboard layouts &mdash; the second-stage key is translated via the same layout-resolve fallback as single-key bindings.</p>
+        <p>When the leader is pressed, the status bar shows <code>Pending: ctrl+w, esc to cancel</code>; press the second key to dispatch, or <code>esc</code> to cancel silently. Binding a key as both a standalone action and a chord prefix drops the standalone binding (the chord wins, with a warning). Chord bindings work under non-Latin keyboard layouts &mdash; the second-stage key is translated via the same layout-resolve fallback as single-key bindings. Note: chord bindings do not fire during text input (annotation and search prompts) &mdash; use single-key <code>ctrl+*</code> bindings for actions like <code>open_editor</code> that need to work during annotation input.</p>
         <p><strong>macOS note:</strong> <code>alt+*</code> leaders require your terminal to send Option as Meta/Alt. Most terminals default to &quot;Option composes special characters&quot; (e.g. <code>Option+T</code> &rarr; <code>&dagger;</code>), in which case Alt chords silently won&apos;t fire. To enable: iTerm2 &rarr; <em>Profiles &rarr; Keys &rarr; Left/Right Option key &rarr; <code>Esc+</code></em>; Terminal.app &rarr; <em>Profiles &rarr; Keyboard &rarr; Use Option as Meta key</em>; Kitty &rarr; <code>macos_option_as_alt yes</code>; Ghostty &rarr; <code>macos-option-as-alt = true</code>. If you&apos;d rather not touch terminal settings, use <code>ctrl+*</code> leaders &mdash; those work everywhere with no configuration.</p>
         <h3>Available actions</h3>
         <p><strong>Navigation:</strong> <code>down</code>, <code>up</code>, <code>page_down</code>, <code>page_up</code>, <code>half_page_down</code>, <code>half_page_up</code>, <code>home</code>, <code>end</code>, <code>scroll_left</code>, <code>scroll_right</code>, <code>scroll_center</code>, <code>scroll_top</code>, <code>scroll_bottom</code></p>
         <p><strong>File/Hunk:</strong> <code>next_item</code>, <code>prev_item</code>, <code>next_hunk</code>, <code>prev_hunk</code></p>
         <p><strong>Pane:</strong> <code>toggle_pane</code>, <code>focus_tree</code>, <code>focus_diff</code></p>
         <p><strong>Search:</strong> <code>search</code></p>
-        <p><strong>Annotations:</strong> <code>confirm</code>, <code>annotate_file</code>, <code>delete_annotation</code>, <code>annot_list</code>, <code>next_annotation</code>, <code>prev_annotation</code></p>
+        <p><strong>Annotations:</strong> <code>confirm</code>, <code>annotate_file</code>, <code>delete_annotation</code>, <code>annot_list</code>, <code>open_editor</code>, <code>next_annotation</code>, <code>prev_annotation</code></p>
         <p><strong>View:</strong> <code>toggle_collapsed</code>, <code>toggle_compact</code>, <code>toggle_wrap</code>, <code>toggle_tree</code>, <code>toggle_line_numbers</code>, <code>toggle_blame</code>, <code>toggle_word_diff</code>, <code>toggle_hunk</code>, <code>toggle_untracked</code>, <code>mark_reviewed</code>, <code>theme_select</code>, <code>filter</code>, <code>info</code>, <code>reload</code></p>
         <p><strong>Quit:</strong> <code>quit</code>, <code>discard_quit</code>, <code>help</code>, <code>dismiss</code></p>
 


### PR DESCRIPTION
the `Ctrl+E` key that opens `$EDITOR` during annotation input was hardcoded, conflicting with the standard readline/emacs end-of-line binding. This routes it through the keymap system as the `open_editor` action so users can remap it via `~/.config/revdiff/keybindings`.

**what changed:**
- `ActionOpenEditor` added to keymap with `ctrl+e` default binding
- `handleAnnotateKey` resolves through keymap instead of hardcoded `tea.KeyCtrlE`
- placeholder text dynamically reflects the bound key, omits hint when unbound
- chord bindings filtered from placeholder (chords do not fire during text input)
- `displayKeyName` uppercases only first char after `ctrl+` to preserve chord case
- `open_editor` added to available-actions lists across all doc surfaces
- chord limitation during modal text input documented in README, docs.html, and plugin configs

**to remap:**
```
unmap ctrl+e
map ctrl+g open_editor
```

Addresses #190
