### PR TITLE
improve: scale annot_list popup width up to 140 cols on wide terminals

### DIFF
--- a/app/ui/overlay/annotlist.go
+++ b/app/ui/overlay/annotlist.go
@@ -13,6 +13,13 @@ import (
 	"github.com/umputun/revdiff/app/ui/style"
 )
 
+const (
+	annotPopupMaxWidth  = 140 // maximum popup width
+	annotPopupMinWidth  = 20  // minimum popup width
+	annotPopupMargin    = 10  // horizontal margin from terminal edges
+	annotPopupBorderPad = 4   // border (2) + padding (2) for content width
+)
+
 type annotListOverlay struct {
 	items      []AnnotationItem
 	cursor     int
@@ -29,7 +36,7 @@ func (a *annotListOverlay) open(spec AnnotListSpec) {
 
 func (a *annotListOverlay) render(ctx RenderCtx, mgr *Manager) string {
 	a.height = ctx.Height
-	popupWidth := max(min(ctx.Width-10, 140), 20)
+	popupWidth := max(min(ctx.Width-annotPopupMargin, annotPopupMaxWidth), annotPopupMinWidth)
 	a.popupWidth = popupWidth
 
 	if len(a.items) == 0 {
@@ -37,7 +44,7 @@ func (a *annotListOverlay) render(ctx RenderCtx, mgr *Manager) string {
 	}
 
 	maxVisibleItems := a.maxVisible(ctx.Height)
-	contentWidth := popupWidth - 4 // 2 for border + 2 for padding
+	contentWidth := popupWidth - annotPopupBorderPad
 
 	var lines []string
 	for i := a.offset; i < len(a.items) && i < a.offset+maxVisibleItems; i++ {
@@ -59,7 +66,7 @@ func (a *annotListOverlay) render(ctx RenderCtx, mgr *Manager) string {
 
 func (a *annotListOverlay) emptyOverlay(popupWidth int, resolver Resolver, mgr *Manager) string {
 	text := "no annotations"
-	innerWidth := popupWidth - 4
+	innerWidth := popupWidth - annotPopupBorderPad
 	pad := max((innerWidth-lipgloss.Width(text))/2, 0)
 	centered := strings.Repeat(" ", pad) + text
 

--- a/app/ui/overlay/annotlist.go
+++ b/app/ui/overlay/annotlist.go
@@ -29,7 +29,7 @@ func (a *annotListOverlay) open(spec AnnotListSpec) {
 
 func (a *annotListOverlay) render(ctx RenderCtx, mgr *Manager) string {
 	a.height = ctx.Height
-	popupWidth := max(min(ctx.Width-10, 70), 20)
+	popupWidth := max(min(ctx.Width-10, 140), 20)
 	a.popupWidth = popupWidth
 
 	if len(a.items) == 0 {

--- a/app/ui/overlay/annotlist_test.go
+++ b/app/ui/overlay/annotlist_test.go
@@ -84,17 +84,18 @@ func TestAnnotListOverlay_RenderPopupWidthScaling(t *testing.T) {
 	mgr := NewManager()
 	mgr.OpenAnnotList(annotListSpec(items...))
 
-	// rendered width = popupWidth + 2 (1-col border on each side, padding is inside Width)
+	// rendered width = popupWidth + 2 (1-col border on each side; padding lives inside lipgloss Width)
+	const borderCols = 2
 	tests := []struct {
-		name    string
-		ctxW    int
-		wantW   int
-		comment string
+		name      string
+		ctxW      int
+		wantPopup int
+		comment   string
 	}{
-		{"narrow terminal floors at 20", 25, 22, "min cap protects readability"},
-		{"medium terminal scales by ctx width", 60, 52, "ctx.Width-10 below the upper cap"},
-		{"upper cap kicks in at 150", 150, 142, "popup capped at 140 to avoid dominating wide screens"},
-		{"wide terminal stays at 140", 220, 142, "extra columns past 140 ignored"},
+		{"narrow terminal floors at min cap", 25, annotPopupMinWidth, "min cap protects readability"},
+		{"medium terminal scales by ctx width", 60, 50, "ctx.Width-margin below the upper cap"},
+		{"upper cap kicks in just past max", 150, annotPopupMaxWidth, "popup capped to avoid dominating wide screens"},
+		{"wide terminal stays at max cap", 220, annotPopupMaxWidth, "extra columns past max cap ignored"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -106,9 +107,37 @@ func TestAnnotListOverlay_RenderPopupWidthScaling(t *testing.T) {
 					maxLine = w
 				}
 			}
-			assert.Equal(t, tt.wantW, maxLine, tt.comment)
+			assert.Equal(t, tt.wantPopup+borderCols, maxLine, tt.comment)
 		})
 	}
+}
+
+func TestAnnotListOverlay_RenderWidePopupFitsMoreCommentText(t *testing.T) {
+	// the user-visible payoff of the wider cap: long comments must fit more chars
+	// before truncation on a wide terminal than on a narrow one. locks the
+	// behavior the cap bump was meant to deliver, not just the popup geometry.
+	longComment := strings.Repeat("ABCDEFGHIJ ", 20) // 220 chars
+	items := []AnnotationItem{annotItem("a.go", 1, "+", longComment)}
+	mgr := NewManager()
+	mgr.OpenAnnotList(annotListSpec(items...))
+
+	render := func(ctxW int) string {
+		ctx := RenderCtx{Width: ctxW, Height: 30, Resolver: style.PlainResolver()}
+		return mgr.annotLst.render(ctx, mgr)
+	}
+	visibleAlpha := func(s string) int {
+		var n int
+		for _, r := range s {
+			if r >= 'A' && r <= 'J' {
+				n++
+			}
+		}
+		return n
+	}
+
+	narrow := visibleAlpha(render(80)) // popup capped to 70
+	wide := visibleAlpha(render(200))  // popup uses up to annotPopupMaxWidth
+	assert.Greater(t, wide, narrow, "wide terminal must show more comment chars before truncation")
 }
 
 func TestAnnotListOverlay_RenderScrollOffset(t *testing.T) {

--- a/app/ui/overlay/annotlist_test.go
+++ b/app/ui/overlay/annotlist_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -76,6 +77,38 @@ func TestAnnotListOverlay_RenderTruncation(t *testing.T) {
 	result := mgr.annotLst.render(ctx, mgr)
 	assert.Contains(t, result, "...")
 	assert.NotContains(t, result, longComment)
+}
+
+func TestAnnotListOverlay_RenderPopupWidthScaling(t *testing.T) {
+	items := []AnnotationItem{annotItem("a.go", 1, "+", "note")}
+	mgr := NewManager()
+	mgr.OpenAnnotList(annotListSpec(items...))
+
+	// rendered width = popupWidth + 2 (1-col border on each side, padding is inside Width)
+	tests := []struct {
+		name    string
+		ctxW    int
+		wantW   int
+		comment string
+	}{
+		{"narrow terminal floors at 20", 25, 22, "min cap protects readability"},
+		{"medium terminal scales by ctx width", 60, 52, "ctx.Width-10 below the upper cap"},
+		{"upper cap kicks in at 150", 150, 142, "popup capped at 140 to avoid dominating wide screens"},
+		{"wide terminal stays at 140", 220, 142, "extra columns past 140 ignored"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := RenderCtx{Width: tt.ctxW, Height: 30, Resolver: style.PlainResolver()}
+			result := mgr.annotLst.render(ctx, mgr)
+			var maxLine int
+			for ln := range strings.SplitSeq(result, "\n") {
+				if w := lipgloss.Width(ln); w > maxLine {
+					maxLine = w
+				}
+			}
+			assert.Equal(t, tt.wantW, maxLine, tt.comment)
+		})
+	}
 }
 
 func TestAnnotListOverlay_RenderScrollOffset(t *testing.T) {


### PR DESCRIPTION
Bumps the annotation list popup's upper width cap from 70 to 140 cols (`app/ui/overlay/annotlist.go:32`) so it uses available screen real estate on wide terminals. Comment text gets ~2x more room before truncation; terminals under 80 cols are unchanged.

The 2-line layout proposed in the issue is not included: it halves visible-entry density which matters for users with many annotations. The width bump alone addresses the core "wasted screen space" complaint.

Addresses #191
