### PR TITLE
fix(pi): narrow revdiff review trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff-pi",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pi package for revdiff interactive diff review",
   "license": "MIT",
   "repository": {

--- a/plugins/pi/extensions/revdiff.ts
+++ b/plugins/pi/extensions/revdiff.ts
@@ -304,7 +304,8 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 		description: "Launch revdiff in pi, capture interactive review annotations, and return them to the agent.",
 		promptSnippet: "Launch an interactive revdiff review and return captured annotations.",
 		promptGuidelines: [
-			"Use revdiff_review when the user asks to review a diff, inspect changes interactively, or gather revdiff annotations inside pi.",
+			"Use revdiff_review only when the user explicitly asks for revdiff, an interactive annotation pass, or captured revdiff annotations inside pi.",
+			"Do not use revdiff_review for ordinary autonomous code-review requests like 'review the code', 'review my changes', or 'review the diff'; inspect the code directly instead.",
 			"After revdiff_review returns annotations, address them directly instead of asking the user to run /revdiff or /revdiff-apply.",
 		],
 		parameters: Type.Object({

--- a/plugins/pi/skills/revdiff/SKILL.md
+++ b/plugins/pi/skills/revdiff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: revdiff
-description: Pi-only interactive diff and file review with revdiff. Use when the user wants to review a diff, browse files for annotation, or revisit the last captured revdiff comments inside pi.
+description: Pi-only interactive diff and file review with revdiff. Use when the user explicitly asks for revdiff, interactive annotations, or captured revdiff comments inside pi.
 ---
 
 # revdiff for pi
@@ -10,7 +10,7 @@ Use the revdiff pi extension for interactive review sessions.
 
 ## Agent usage
 
-When the user asks you to review a diff, inspect changes with revdiff, or gather revdiff annotations, call the `revdiff_review` tool. Do **not** tell the user to run `/revdiff`; slash commands are user-invoked only.
+Call the `revdiff_review` tool only when the user explicitly asks for revdiff, an interactive annotation pass, or captured revdiff annotations. Do **not** call it for ordinary autonomous requests like "review the code", "review my changes", or "review the diff"; handle those by inspecting the code directly. Do **not** tell the user to run `/revdiff`; slash commands are user-invoked only.
 
 Tool examples:
 


### PR DESCRIPTION
## Summary

- narrow Pi revdiff skill triggers so ordinary code review requests do not launch the TUI
- clarify that captured revdiff annotations still route through the revdiff workflow
- bump plugin package version to `0.2.1`

Fixes #188
