### PR TITLE
feat(opencode): add --symlink flag to setup.sh

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -25,7 +25,15 @@
 bash setup.sh
 ```
 
-The script creates the target directories if needed, copies all files, marks the shell scripts as executable, and registers the plan-review plugin in `~/.config/opencode/opencode.json`. Or manually:
+The script creates the target directories if needed, copies all files, marks the shell scripts as executable, and registers the plan-review plugin in `~/.config/opencode/opencode.json`.
+
+Use the `--symlink` flag to create symlinks instead of copies. This makes updating as simple as a `git pull` inside this repo — no need to re-run the script after every change:
+
+```sh
+bash setup.sh --symlink
+```
+
+Or manually:
 
 ```sh
 mkdir -p ~/.config/opencode/commands ~/.config/opencode/tools ~/.config/opencode/plugins

--- a/plugins/opencode/setup.sh
+++ b/plugins/opencode/setup.sh
@@ -6,7 +6,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 OPENCODE_CONFIG="$HOME/.config/opencode"
 
-copy_file() {
+USE_SYMLINK=false
+for arg in "$@"; do
+  case "$arg" in
+    --symlink) USE_SYMLINK=true ;;
+  esac
+done
+
+install_file() {
   local src="$1"
   local dst="$2"
   local make_exec="${3:-}"
@@ -16,9 +23,15 @@ copy_file() {
     return 1
   fi
 
-  cp "$src" "$dst"
+  if [[ "$USE_SYMLINK" == true ]]; then
+    ln -sf "$src" "$dst"
+    echo "Linked ${src#"$REPO_ROOT"/} as $dst"
+  else
+    cp "$src" "$dst"
+    echo "Copied ${src#"$REPO_ROOT"/} -> $dst"
+  fi
+
   [[ "$make_exec" == "exec" ]] && chmod +x "$dst"
-  echo "Copied ${src#"$REPO_ROOT"/} -> $dst"
 }
 
 mkdir -p "$OPENCODE_CONFIG/commands"
@@ -27,11 +40,11 @@ mkdir -p "$OPENCODE_CONFIG/plugins"
 
 errors=0
 
-copy_file "$REPO_ROOT/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh"  "$OPENCODE_CONFIG/tools/launch-revdiff.sh" exec || ((errors++))
-copy_file "$REPO_ROOT/plugins/revdiff-planning/scripts/launch-plan-review.sh"   "$OPENCODE_CONFIG/plugins/launch-plan-review.sh" exec || ((errors++))
-copy_file "$SCRIPT_DIR/commands/revdiff.md"  "$OPENCODE_CONFIG/commands/revdiff.md" || ((errors++))
-copy_file "$SCRIPT_DIR/tools/revdiff.ts"     "$OPENCODE_CONFIG/tools/revdiff.ts" || ((errors++))
-copy_file "$SCRIPT_DIR/plugins/revdiff-plan-review.ts"   "$OPENCODE_CONFIG/plugins/revdiff-plan-review.ts" || ((errors++))
+install_file "$REPO_ROOT/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh"  "$OPENCODE_CONFIG/tools/launch-revdiff.sh" exec || ((errors++))
+install_file "$REPO_ROOT/plugins/revdiff-planning/scripts/launch-plan-review.sh"   "$OPENCODE_CONFIG/plugins/launch-plan-review.sh" exec || ((errors++))
+install_file "$SCRIPT_DIR/commands/revdiff.md"  "$OPENCODE_CONFIG/commands/revdiff.md" || ((errors++))
+install_file "$SCRIPT_DIR/tools/revdiff.ts"     "$OPENCODE_CONFIG/tools/revdiff.ts" || ((errors++))
+install_file "$SCRIPT_DIR/plugins/revdiff-plan-review.ts"   "$OPENCODE_CONFIG/plugins/revdiff-plan-review.ts" || ((errors++))
 
 OPENCODE_JSON="$HOME/.config/opencode/opencode.json"
 PLUGIN_ENTRY="./plugins/revdiff-plan-review.ts"


### PR DESCRIPTION
## Problem

The OpenCode plugin setup script (`plugins/opencode/setup.sh`) currently copies all files into `~/.config/opencode/`. After every update to the revdiff repo, users must re-run the script to pick up changes. This is tedious for anyone developing or tracking the plugin closely.

## Solution

Add a `--symlink` flag to `setup.sh` that creates symlinks instead of copies. This lets updates propagate automatically after a simple `git pull` in the revdiff repo — no re-run needed.

## Changes

- `plugins/opencode/setup.sh`: Accept `--symlink` argument, use `ln -sf` instead of `cp` when the flag is set, rename internal helper from `copy_file` to `install_file`.
- `plugins/opencode/README.md`: Document the new flag and explain when to use it.

## Test Plan

- [x] Run `bash plugins/opencode/setup.sh --symlink` and verify symlinks are created in `~/.config/opencode/`.
- [x] Run `bash plugins/opencode/setup.sh` (without flag) and verify files are still copied.