### PR TITLE
Revert "feat(opencode): add --symlink flag to setup.sh"

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -25,15 +25,7 @@
 bash setup.sh
 ```
 
-The script creates the target directories if needed, copies all files, marks the shell scripts as executable, and registers the plan-review plugin in `~/.config/opencode/opencode.json`.
-
-Use the `--symlink` flag to create symlinks instead of copies. This makes updating as simple as a `git pull` inside this repo — no need to re-run the script after every change:
-
-```sh
-bash setup.sh --symlink
-```
-
-Or manually:
+The script creates the target directories if needed, copies all files, marks the shell scripts as executable, and registers the plan-review plugin in `~/.config/opencode/opencode.json`. Or manually:
 
 ```sh
 mkdir -p ~/.config/opencode/commands ~/.config/opencode/tools ~/.config/opencode/plugins

--- a/plugins/opencode/setup.sh
+++ b/plugins/opencode/setup.sh
@@ -6,14 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 OPENCODE_CONFIG="$HOME/.config/opencode"
 
-USE_SYMLINK=false
-for arg in "$@"; do
-  case "$arg" in
-    --symlink) USE_SYMLINK=true ;;
-  esac
-done
-
-install_file() {
+copy_file() {
   local src="$1"
   local dst="$2"
   local make_exec="${3:-}"
@@ -23,15 +16,9 @@ install_file() {
     return 1
   fi
 
-  if [[ "$USE_SYMLINK" == true ]]; then
-    ln -sf "$src" "$dst"
-    echo "Linked ${src#"$REPO_ROOT"/} as $dst"
-  else
-    cp "$src" "$dst"
-    echo "Copied ${src#"$REPO_ROOT"/} -> $dst"
-  fi
-
+  cp "$src" "$dst"
   [[ "$make_exec" == "exec" ]] && chmod +x "$dst"
+  echo "Copied ${src#"$REPO_ROOT"/} -> $dst"
 }
 
 mkdir -p "$OPENCODE_CONFIG/commands"
@@ -40,11 +27,11 @@ mkdir -p "$OPENCODE_CONFIG/plugins"
 
 errors=0
 
-install_file "$REPO_ROOT/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh"  "$OPENCODE_CONFIG/tools/launch-revdiff.sh" exec || ((errors++))
-install_file "$REPO_ROOT/plugins/revdiff-planning/scripts/launch-plan-review.sh"   "$OPENCODE_CONFIG/plugins/launch-plan-review.sh" exec || ((errors++))
-install_file "$SCRIPT_DIR/commands/revdiff.md"  "$OPENCODE_CONFIG/commands/revdiff.md" || ((errors++))
-install_file "$SCRIPT_DIR/tools/revdiff.ts"     "$OPENCODE_CONFIG/tools/revdiff.ts" || ((errors++))
-install_file "$SCRIPT_DIR/plugins/revdiff-plan-review.ts"   "$OPENCODE_CONFIG/plugins/revdiff-plan-review.ts" || ((errors++))
+copy_file "$REPO_ROOT/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh"  "$OPENCODE_CONFIG/tools/launch-revdiff.sh" exec || ((errors++))
+copy_file "$REPO_ROOT/plugins/revdiff-planning/scripts/launch-plan-review.sh"   "$OPENCODE_CONFIG/plugins/launch-plan-review.sh" exec || ((errors++))
+copy_file "$SCRIPT_DIR/commands/revdiff.md"  "$OPENCODE_CONFIG/commands/revdiff.md" || ((errors++))
+copy_file "$SCRIPT_DIR/tools/revdiff.ts"     "$OPENCODE_CONFIG/tools/revdiff.ts" || ((errors++))
+copy_file "$SCRIPT_DIR/plugins/revdiff-plan-review.ts"   "$OPENCODE_CONFIG/plugins/revdiff-plan-review.ts" || ((errors++))
 
 OPENCODE_JSON="$HOME/.config/opencode/opencode.json"
 PLUGIN_ENTRY="./plugins/revdiff-plan-review.ts"


### PR DESCRIPTION
Reverting for the following reasons. Unfortunately, when I tested, everything "worked" because I had already run the setup script once without `--symlink` but I just re-ran it and realized it was only symlinking 3 files and not 5, which unfortunately also affects the origin logic path as well.

- Bash returns the return value of the last statement. Because I moved the `echo` into the `if` statement, it was failing on the first call to the function without the `exec` arg due to `[[[ "$make_exec" == "exec" ]] && chmod +x "$dst"` returning false.
 
  Ideally, this would be fine and just report a false set of errors at the end, but `((errors++))` also returns a non-zero exit code (interestingly `((++errors))` does not), so the entire script was failing at that point.
- Once I fixed the issue above, I ran into an issue where OpenCode was no longer working because their loader resolves symlinks and it couldn't find the necessary libraries relative to the repo, so this whole thing is a non-starter.

In an ideal scenario, this gets shipped as a "real" plugin, but I think automating `git pull && ./plugins/opencode/setup.sh` is fine for now.

Again, my sincere apologies for my oversight in testing, I should have been more thorough.