### PR TITLE
Revert "feat(opencode): add --symlink flag to setup.sh"

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -25,15 +25,7 @@
 bash setup.sh
 ```
 
-The script creates the target directories if needed, copies all files, marks the shell scripts as executable, and registers the plan-review plugin in `~/.config/opencode/opencode.json`.
-
-Use the `--symlink` flag to create symlinks instead of copies. This makes updating as simple as a `git pull` inside this repo — no need to re-run the script after every change:
-
-```sh
-bash setup.sh --symlink
-```
-
-Or manually:
+The script creates the target directories if needed, copies all files, marks the shell scripts as executable, and registers the plan-review plugin in `~/.config/opencode/opencode.json`. Or manually:
 
 ```sh
 mkdir -p ~/.config/opencode/commands ~/.config/opencode/tools ~/.config/opencode/plugins

--- a/plugins/opencode/setup.sh
+++ b/plugins/opencode/setup.sh
@@ -6,14 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 OPENCODE_CONFIG="$HOME/.config/opencode"
 
-USE_SYMLINK=false
-for arg in "$@"; do
-  case "$arg" in
-    --symlink) USE_SYMLINK=true ;;
-  esac
-done
-
-install_file() {
+copy_file() {
   local src="$1"
   local dst="$2"
   local make_exec="${3:-}"
@@ -23,15 +16,9 @@ install_file() {
     return 1
   fi
 
-  if [[ "$USE_SYMLINK" == true ]]; then
-    ln -sf "$src" "$dst"
-    echo "Linked ${src#"$REPO_ROOT"/} as $dst"
-  else
-    cp "$src" "$dst"
-    echo "Copied ${src#"$REPO_ROOT"/} -> $dst"
-  fi
-
+  cp "$src" "$dst"
   [[ "$make_exec" == "exec" ]] && chmod +x "$dst"
+  echo "Copied ${src#"$REPO_ROOT"/} -> $dst"
 }
 
 mkdir -p "$OPENCODE_CONFIG/commands"
@@ -40,11 +27,11 @@ mkdir -p "$OPENCODE_CONFIG/plugins"
 
 errors=0
 
-install_file "$REPO_ROOT/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh"  "$OPENCODE_CONFIG/tools/launch-revdiff.sh" exec || ((errors++))
-install_file "$REPO_ROOT/plugins/revdiff-planning/scripts/launch-plan-review.sh"   "$OPENCODE_CONFIG/plugins/launch-plan-review.sh" exec || ((errors++))
-install_file "$SCRIPT_DIR/commands/revdiff.md"  "$OPENCODE_CONFIG/commands/revdiff.md" || ((errors++))
-install_file "$SCRIPT_DIR/tools/revdiff.ts"     "$OPENCODE_CONFIG/tools/revdiff.ts" || ((errors++))
-install_file "$SCRIPT_DIR/plugins/revdiff-plan-review.ts"   "$OPENCODE_CONFIG/plugins/revdiff-plan-review.ts" || ((errors++))
+copy_file "$REPO_ROOT/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh"  "$OPENCODE_CONFIG/tools/launch-revdiff.sh" exec || ((errors++))
+copy_file "$REPO_ROOT/plugins/revdiff-planning/scripts/launch-plan-review.sh"   "$OPENCODE_CONFIG/plugins/launch-plan-review.sh" exec || ((errors++))
+copy_file "$SCRIPT_DIR/commands/revdiff.md"  "$OPENCODE_CONFIG/commands/revdiff.md" || ((errors++))
+copy_file "$SCRIPT_DIR/tools/revdiff.ts"     "$OPENCODE_CONFIG/tools/revdiff.ts" || ((errors++))
+copy_file "$SCRIPT_DIR/plugins/revdiff-plan-review.ts"   "$OPENCODE_CONFIG/plugins/revdiff-plan-review.ts" || ((errors++))
 
 OPENCODE_JSON="$HOME/.config/opencode/opencode.json"
 PLUGIN_ENTRY="./plugins/revdiff-plan-review.ts"


### PR DESCRIPTION
Reverts #197 per request from the original author in #198.

Two issues with the merged change:

**Bash return-value bug**: the new `install_file` ends with `[[ "$make_exec" == "exec" ]] && chmod +x "$dst"`. When `make_exec` is empty (3 of the 5 install calls), the `[[ ]]` short-circuits and the function returns exit 1. Caller's `|| ((errors++))` then runs `((errors++))` with `errors=0`, which evaluates to 0 and exits status 1 under bash arithmetic. With `set -euo pipefail`, the script aborts partway through. Symptom: only 2-3 of the 5 entries get installed on a fresh run, and the non-symlink path was affected too.

**OpenCode loader resolves symlinks**: even with the bash bug fixed, OpenCode follows symlinks before resolving relative paths, so the `.ts` files end up looking for their deps next to the source files in the revdiff repo and fail to load. Approach is a non-starter for OpenCode.

Closes the symlink idea for now. The `git pull && ./plugins/opencode/setup.sh` workflow remains the supported update path.

Related to #187, #198.
