### PR TITLE
feat(app): add shell completion script generation

### DIFF
--- a/app/completions.go
+++ b/app/completions.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+func printCompletionScript(w io.Writer, shell, bin string) error {
+	cmd := filepath.Base(bin)
+	name := sanitizeShellIdent(cmd)
+	switch shell {
+	case "bash":
+		fmt.Fprintf(w, bashCompletionTemplate, name, bin, name, bin)
+	case "zsh":
+		fmt.Fprintf(w, zshCompletionTemplate, bin, name, bin, name, bin)
+	case "fish":
+		fmt.Fprintf(w, fishCompletionTemplate, name, bin, cmd, name)
+	}
+	return nil
+}
+
+// sanitizeShellIdent turns a binary name into a valid shell identifier.
+func sanitizeShellIdent(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if unicode.IsLetter(r) || r == '_' || (i > 0 && unicode.IsDigit(r)) {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// bashCompletionTemplate aligns with the official go-flags bash completion
+// example, with one addition: when the current token is empty we inject "--"
+// so go-flags completes option names rather than falling through to positional
+// completion (our positional args are plain strings with no Completer).
+var bashCompletionTemplate = `_%s() {
+    local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    if [ ${#args[@]} -eq 0 ] || ([ ${#args[@]} -eq 1 ] && [ -z "${args[0]}" ]); then
+        args=("--")
+    fi
+    local IFS=$'\n'
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 %s "${args[@]}"))
+    return 0
+}
+complete -F _%s %s
+`
+
+// zshCompletionTemplate aligns with the open PR #414 for go-flags zsh
+// completion, with the same empty-token "--" injection.
+var zshCompletionTemplate = `#compdef %s
+_%s() {
+    local args=("${words[@]:1}")
+    if [ ${#args[@]} -eq 0 ] || ([ ${#args[@]} -eq 1 ] && [ -z "${args[1]}" ]); then
+        args=("--")
+    fi
+    local IFS=$'\n'
+    local -a completions
+    completions=($(GO_FLAGS_COMPLETION=1 %s "${args[@]}"))
+    compadd -a completions
+}
+compdef _%s %s
+`
+
+// fishCompletionTemplate follows fish conventions (commandline -opc / -ct)
+// with the same empty-token "--" injection and explicit "" append for value
+// completion.
+var fishCompletionTemplate = `function __%s_complete
+    set -l args (commandline -opc | tail -n +2)
+    set -l cur (commandline -ct)
+    if test (count $args) -eq 0
+        set args "--"
+    else if test -z "$cur"
+        set args $args ""
+    end
+    env GO_FLAGS_COMPLETION=1 %s $args
+end
+complete -c %s -f -a '(__%s_complete)'
+`

--- a/app/completions_test.go
+++ b/app/completions_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintCompletionScript_Bash(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCompletionScript(&buf, "bash", "/usr/local/bin/revdiff")
+	require.NoError(t, err)
+	body := buf.String()
+	assert.Contains(t, body, "_revdiff")
+	assert.Contains(t, body, "GO_FLAGS_COMPLETION=1 /usr/local/bin/revdiff")
+	assert.Contains(t, body, "complete -F _revdiff /usr/local/bin/revdiff")
+	// bare <TAB> injects "--" to avoid positional fallback
+	assert.Contains(t, body, `if [ ${#args[@]} -eq 0 ] || ([ ${#args[@]} -eq 1 ] && [ -z "${args[0]}" ]); then`)
+	assert.Contains(t, body, `args=("--")`)
+}
+
+func TestPrintCompletionScript_Zsh(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCompletionScript(&buf, "zsh", "revdiff")
+	require.NoError(t, err)
+	body := buf.String()
+	assert.Contains(t, body, "#compdef revdiff")
+	assert.Contains(t, body, "GO_FLAGS_COMPLETION=1 revdiff")
+	// bare <TAB> injects "--" to avoid positional fallback
+	assert.Contains(t, body, `if [ ${#args[@]} -eq 0 ] || ([ ${#args[@]} -eq 1 ] && [ -z "${args[1]}" ]); then`)
+	assert.Contains(t, body, `args=("--")`)
+}
+
+func TestPrintCompletionScript_Fish(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCompletionScript(&buf, "fish", "revdiff")
+	require.NoError(t, err)
+	body := buf.String()
+	assert.Contains(t, body, "function __revdiff_complete")
+	assert.Contains(t, body, "commandline -opc")
+	assert.Contains(t, body, "commandline -ct")
+	assert.Contains(t, body, "complete -c revdiff")
+	assert.Contains(t, body, "GO_FLAGS_COMPLETION=1 revdiff")
+}
+
+func TestPrintCompletionScript_SanitizeName(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCompletionScript(&buf, "bash", "./my-tool.bin")
+	require.NoError(t, err)
+	body := buf.String()
+	// identifier-safe name should be used in function name, full path in invocation
+	assert.Contains(t, body, "_my_tool_bin")
+	assert.Contains(t, body, "GO_FLAGS_COMPLETION=1 ./my-tool.bin")
+	assert.Contains(t, body, "complete -F _my_tool_bin ./my-tool.bin")
+}
+
+func TestCompletionShellComplete(t *testing.T) {
+	var cs completionShell
+
+	t.Run("empty prefix returns all", func(t *testing.T) {
+		res := cs.Complete("")
+		items := make([]string, len(res))
+		for i, c := range res {
+			items[i] = c.Item
+		}
+		assert.Equal(t, []string{"bash", "zsh", "fish"}, items)
+	})
+
+	t.Run("partial match", func(t *testing.T) {
+		res := cs.Complete("ba")
+		require.Len(t, res, 1)
+		assert.Equal(t, "bash", res[0].Item)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		res := cs.Complete("xyz")
+		assert.Empty(t, res)
+	})
+
+	t.Run("prefix z returns zsh", func(t *testing.T) {
+		res := cs.Complete("z")
+		require.Len(t, res, 1)
+		assert.Equal(t, "zsh", res[0].Item)
+	})
+}
+
+func TestSanitizeShellIdent(t *testing.T) {
+	assert.Equal(t, "revdiff", sanitizeShellIdent("revdiff"))
+	assert.Equal(t, "my_tool", sanitizeShellIdent("my-tool"))
+	assert.Equal(t, "my_tool_bin", sanitizeShellIdent("my-tool.bin"))
+	assert.Equal(t, "_23", sanitizeShellIdent("123"))
+	assert.Equal(t, "___", sanitizeShellIdent("!@#"))
+}

--- a/app/config.go
+++ b/app/config.go
@@ -11,6 +11,22 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
+// completionShell is a string alias that implements flags.Completer so the
+// --completions choice values are suggested during shell completion.
+type completionShell string
+
+// Complete returns the available shell names matching the given prefix.
+func (c *completionShell) Complete(match string) []flags.Completion {
+	choices := []string{"bash", "zsh", "fish"}
+	var res []flags.Completion
+	for _, ch := range choices {
+		if strings.HasPrefix(ch, match) {
+			res = append(res, flags.Completion{Item: ch})
+		}
+	}
+	return res
+}
+
 type options struct {
 	Refs struct {
 		Base    string `positional-arg-name:"base" description:"git ref to diff against (default: uncommitted changes)"`
@@ -60,6 +76,7 @@ type options struct {
 	InstallTheme     []string `long:"install-theme" no-ini:"true" description:"install theme(s) from gallery or local file path and exit"`
 	Config           string   `long:"config" env:"REVDIFF_CONFIG" no-ini:"true" description:"path to config file"`
 	DumpConfig       bool     `long:"dump-config" no-ini:"true" description:"print default config to stdout and exit"`
+	Completions      completionShell `long:"completions" choice:"bash" choice:"zsh" choice:"fish" no-ini:"true" description:"print shell completion script"`
 	Version          bool     `short:"V" long:"version" no-ini:"true" description:"show version info"`
 
 	Colors struct {

--- a/app/main.go
+++ b/app/main.go
@@ -49,6 +49,14 @@ func main() {
 		os.Exit(0)
 	}
 
+	if opts.Completions != "" {
+		if err := printCompletionScript(os.Stdout, string(opts.Completions), os.Args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	if opts.DumpKeys {
 		km := keymap.LoadOrDefault(resolveFlagPath(os.Args[1:], "keys", "REVDIFF_KEYS", defaultKeysPath))
 		if err := km.Dump(os.Stdout); err != nil {


### PR DESCRIPTION
Add a --completions flag that prints bash, zsh, or fish completion
scripts and wires shell-name completion into the flag itself.
Includes tests for template output and identifier sanitisation.

There was a necessary workaround because the CLI does not implement subcommands which are what is completed when there
is nothing after the command so the completion scripts for the shells add a "--" to the completion command and then
fetches the completions.

<img width="817" height="239" alt="image" src="https://github.com/user-attachments/assets/d9220781-fe84-4c42-8420-ee321774eb41" />

<img width="612" height="59" alt="image" src="https://github.com/user-attachments/assets/833d8dd7-4331-4204-8354-e92dccb81209" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shell auto-completion support for bash, zsh, and fish shells through a new `--completions` flag.
  * Generate customized completion scripts for your preferred shell to enable intelligent command-line auto-completion.
  * Completion scripts provide smart command suggestions, streamline command discovery, and reduce manual typing for enhanced CLI productivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/umputun/revdiff/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->