### PR TITLE
fix Zellij popup size handling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "revdiff",
       "source": "./",
       "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
   "author": {
     "name": "umputun",

--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -62,8 +62,8 @@ When launched via the Claude Code plugin skill, revdiff opens in a terminal over
 
 | Env var | Description | Default |
 |---------|-------------|---------|
-| `REVDIFF_POPUP_WIDTH` | Tmux popup width (e.g., `100%`, `80%`) | `90%` |
-| `REVDIFF_POPUP_HEIGHT` | Tmux popup height / wezterm split percent | `90%` |
+| `REVDIFF_POPUP_WIDTH` | Tmux/Zellij popup width (e.g., `100%`, `80%`) | `90%` |
+| `REVDIFF_POPUP_HEIGHT` | Tmux/Zellij popup height / wezterm split percent | `90%` |
 
 ## Themes
 

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -63,7 +63,7 @@ for arg in "$@"; do
 done
 OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 
-# popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux and wezterm)
+# popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux, zellij, and wezterm)
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 
@@ -95,10 +95,8 @@ $REVDIFF_CMD; touch $(sq "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    ZELLIJ_W="${POPUP_W%%%}"
-    ZELLIJ_H="${POPUP_H%%%}"
     zellij run --floating --close-on-exit \
-        --width "$ZELLIJ_W" --height "$ZELLIJ_H" \
+        --width "$POPUP_W" --height "$POPUP_H" \
         --name "$OVERLAY_TITLE" --cwd "$CWD" \
         -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff-pi",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Pi package for revdiff interactive diff review",
   "license": "MIT",
   "repository": {

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -62,8 +62,8 @@ When launched via the Claude Code plugin skill, revdiff opens in a terminal over
 
 | Env var | Description | Default |
 |---------|-------------|---------|
-| `REVDIFF_POPUP_WIDTH` | Tmux popup width (e.g., `100%`, `80%`) | `90%` |
-| `REVDIFF_POPUP_HEIGHT` | Tmux popup height / wezterm split percent | `90%` |
+| `REVDIFF_POPUP_WIDTH` | Tmux/Zellij popup width (e.g., `100%`, `80%`) | `90%` |
+| `REVDIFF_POPUP_HEIGHT` | Tmux/Zellij popup height / wezterm split percent | `90%` |
 
 ## Themes
 

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -65,7 +65,7 @@ for arg in "$@"; do
 done
 OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 
-# popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux and wezterm)
+# popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux, zellij, and wezterm)
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 
@@ -97,10 +97,8 @@ $REVDIFF_CMD; touch $(sq "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    ZELLIJ_W="${POPUP_W%%%}"
-    ZELLIJ_H="${POPUP_H%%%}"
     zellij run --floating --close-on-exit \
-        --width "$ZELLIJ_W" --height "$ZELLIJ_H" \
+        --width "$POPUP_W" --height "$POPUP_H" \
         --name "$OVERLAY_TITLE" --cwd "$CWD" \
         -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
 


### PR DESCRIPTION
Pass `REVDIFF_POPUP_WIDTH` and `REVDIFF_POPUP_HEIGHT` through to `zellij run` unchanged so values like `90%` stay percentages instead of fixed cell counts.

Also updates plugin docs and bumps the Claude and Pi package versions.
