### PR TITLE
Pi: allow custom apply prompt template

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ pi install https://github.com/umputun/revdiff
 - Direct and overlay modes treat exit code `10` as success-with-annotations and keep captured output
 - Optional overlay mode (`--pi-overlay` or `REVDIFF_PI_MODE=overlay`) reuses the existing `launch-revdiff.sh` script from the Claude plugin integration; pi invokes the bundled script directly and does not honor Claude-plugin overrides (`CLAUDE_PLUGIN_DATA` is not set in the pi runtime)
 - Optional post-edit reminders are available via `/revdiff-reminders on` and suggest running `/revdiff` or `/revdiff-rerun` after agent edits
+- `/revdiff-apply` uses `~/.config/revdiff/pi-apply-prompt.md` when present, or the path in `REVDIFF_PI_APPLY_PROMPT_FILE` when set. Templates support `{{target}}`, `{{mode}}`, `{{command}}`, and `{{annotations}}`; annotations are appended automatically when `{{annotations}}` is omitted
 - In the repo, the pi-specific resources live under `plugins/pi/` to keep harness integrations clearly separated
 
 ## Codex Plugin

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -29,6 +29,14 @@ To enable post-edit reminders after agent edits, run:
 /revdiff-reminders on
 ```
 
+To customize the prompt used by `/revdiff-apply`, create:
+
+```text
+~/.config/revdiff/pi-apply-prompt.md
+```
+
+Or set `REVDIFF_PI_APPLY_PROMPT_FILE` to another template path. Supported placeholders: `{{target}}`, `{{mode}}`, `{{command}}`, and `{{annotations}}`. If the template omits `{{annotations}}`, captured annotations are appended after the template.
+
 This integration is intentionally kept separate from other harnesses:
 
 - Claude Code integration lives in `.claude-plugin/`

--- a/plugins/pi/extensions/revdiff.ts
+++ b/plugins/pi/extensions/revdiff.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -32,6 +32,7 @@ const LAUNCH_REVDIFF_SCRIPT = path.join(
 	"scripts",
 	"launch-revdiff.sh",
 );
+const DEFAULT_APPLY_PROMPT_FILE = path.join(homedir(), ".config", "revdiff", "pi-apply-prompt.md");
 
 type LaunchMode = "direct" | "overlay";
 type PanelAction = "apply" | "clear" | "rerun" | undefined;
@@ -82,6 +83,16 @@ interface GroupedAnnotations {
 interface ParsedPiArgs {
 	args: string[];
 	mode?: LaunchMode;
+}
+
+interface ApplyPromptResult {
+	prompt: string;
+	warning?: string;
+}
+
+interface ApplyPromptTemplateResult {
+	content?: string;
+	warning?: string;
 }
 
 export default function revdiffExtension(pi: ExtensionAPI): void {
@@ -387,7 +398,10 @@ async function applyReview(
 	state: ReviewState,
 	clearReviewState: () => void,
 ): Promise<void> {
-	const prompt = buildApplyPrompt(state);
+	const { prompt, warning } = buildApplyPrompt(state);
+	if (warning) {
+		ctx.ui.notify(warning, "warning");
+	}
 	if (ctx.isIdle()) {
 		ctx.ui.notify("Sending revdiff annotations to the agent", "info");
 		pi.sendUserMessage(prompt);
@@ -764,17 +778,60 @@ function buildWidgetLines(theme: Theme, state: ReviewState): string[] {
 	return lines;
 }
 
-function buildApplyPrompt(state: ReviewState): string {
-	return [
-		"Please address the following revdiff annotations.",
-		`Review target: ${state.label}`,
-		`Launch mode: ${state.mode}`,
-		`Original command: revdiff${state.args.length > 0 ? ` ${state.args.join(" ")}` : ""}`,
-		"Start with a short plan, then make the necessary changes in the repository.",
-		state.rawOutput.trim(),
-	]
-		.filter(Boolean)
-		.join("\n\n");
+function buildApplyPrompt(state: ReviewState): ApplyPromptResult {
+	const annotations = state.rawOutput.trim();
+	const command = `revdiff${state.args.length > 0 ? ` ${state.args.join(" ")}` : ""}`;
+	const { content: template, warning } = readApplyPromptTemplate();
+
+	if (template) {
+		const prompt = template
+			.replaceAll("{{target}}", state.label)
+			.replaceAll("{{mode}}", state.mode)
+			.replaceAll("{{command}}", command)
+			.replaceAll("{{annotations}}", annotations)
+			.trim();
+		return {
+			prompt: template.includes("{{annotations}}") ? prompt : [prompt, annotations].filter(Boolean).join("\n\n"),
+			warning,
+		};
+	}
+
+	return {
+		prompt: [
+			"Please address the following revdiff annotations.",
+			`Review target: ${state.label}`,
+			`Launch mode: ${state.mode}`,
+			`Original command: ${command}`,
+			"Start with a short plan, then make the necessary changes in the repository.",
+			annotations,
+		]
+			.filter(Boolean)
+			.join("\n\n"),
+		warning,
+	};
+}
+
+function readApplyPromptTemplate(): ApplyPromptTemplateResult {
+	const envFile = process.env.REVDIFF_PI_APPLY_PROMPT_FILE;
+	if (envFile) {
+		return readTemplateFile(envFile, "REVDIFF_PI_APPLY_PROMPT_FILE");
+	}
+	if (!existsSync(DEFAULT_APPLY_PROMPT_FILE)) {
+		return {};
+	}
+	return readTemplateFile(DEFAULT_APPLY_PROMPT_FILE, "default apply prompt template");
+}
+
+function readTemplateFile(file: string, source: string): ApplyPromptTemplateResult {
+	try {
+		return { content: readFileSync(file, "utf8") };
+	} catch (error) {
+		return { warning: `Failed to read ${source} (${file}): ${formatError(error)}` };
+	}
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 function parseAnnotations(output: string): AnnotationItem[] {

--- a/plugins/pi/skills/revdiff/SKILL.md
+++ b/plugins/pi/skills/revdiff/SKILL.md
@@ -59,6 +59,10 @@ Behavior:
 - Optional post-edit reminders can suggest `/revdiff` or `/revdiff-rerun` after the agent uses `edit`/`write`
 - `/revdiff-apply` packages the structured annotations and sends them back to the agent for implementation
 
+## Apply prompt customization
+
+`/revdiff-apply` uses `~/.config/revdiff/pi-apply-prompt.md` when present, or the path in `REVDIFF_PI_APPLY_PROMPT_FILE` when set. Supported placeholders: `{{target}}`, `{{mode}}`, `{{command}}`, and `{{annotations}}`. If the template omits `{{annotations}}`, captured annotations are appended after the template.
+
 ## Notes
 
 - The default mode launches the external `revdiff` binary in the current terminal session, temporarily suspending pi while revdiff is running

--- a/site/docs.html
+++ b/site/docs.html
@@ -143,6 +143,7 @@
 /revdiff-clear                   <span class="code-comment">-- clear stored review state</span>
 /revdiff-reminders on            <span class="code-comment">-- enable post-edit review reminders</span></code></div>
         <p>Requires the <code>revdiff</code> binary on <code>PATH</code>. Set <code>REVDIFF_BIN=/absolute/path/to/revdiff</code> if pi can’t find the binary. Same-terminal mode is the default. Optional overlay mode (<code>--pi-overlay</code> or <code>REVDIFF_PI_MODE=overlay</code>) reuses the existing <code>launch-revdiff.sh</code> script from the Claude plugin integration; pi invokes the bundled script directly and does not honor Claude-plugin overrides (<code>CLAUDE_PLUGIN_DATA</code> is not set in the pi runtime). Optional post-edit reminders (<code>/revdiff-reminders on</code>) suggest running <code>/revdiff</code> or <code>/revdiff-rerun</code> after agent edits.</p>
+        <p><code>/revdiff-apply</code> uses <code>~/.config/revdiff/pi-apply-prompt.md</code> when present, or the path in <code>REVDIFF_PI_APPLY_PROMPT_FILE</code> when set. Templates support <code>{{target}}</code>, <code>{{mode}}</code>, <code>{{command}}</code>, and <code>{{annotations}}</code>; annotations are appended automatically when <code>{{annotations}}</code> is omitted.</p>
 
         <!-- usage -->
         <h2 id="usage">Usage</h2>


### PR DESCRIPTION
## Summary

- Add Pi-only `/revdiff-apply` prompt template support via `~/.config/revdiff/pi-apply-prompt.md`.
- Add `REVDIFF_PI_APPLY_PROMPT_FILE` override for alternate template paths.
- Support `{{target}}`, `{{mode}}`, `{{command}}`, and `{{annotations}}` placeholders.
- Preserve existing hardcoded prompt when no template is configured.
- Append captured annotations automatically when a custom template omits `{{annotations}}`.
- Warn in Pi when a configured template file cannot be read.
- Document the customization in the root README, site docs, Pi README, and Pi skill docs.

Closes #186.

## Checks

- `make test`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run`
- `python3 .github/scripts/validate-frontmatter.py` (with PyYAML in a temp venv)
- `npm exec --yes --package=typescript -- tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --skipLibCheck plugins/pi/extensions/revdiff.ts`
- `git diff --check`

## Notes

I have been running this locally in Pi and the apply flow works for discussion-oriented review notes while keeping the default behavior unchanged.

CI is currently waiting for maintainer approval because this is a fork PR.
