### PR TITLE
fix: detect cmux sessions with ghostty env

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "revdiff",
       "source": "./",
       "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "author": {
         "name": "umputun"
       }
@@ -18,7 +18,7 @@
       "name": "revdiff-planning",
       "source": "./plugins/revdiff-planning",
       "description": "Automatic plan review with revdiff",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
   "author": {
     "name": "umputun",

--- a/.claude-plugin/skills/revdiff/references/install.md
+++ b/.claude-plugin/skills/revdiff/references/install.md
@@ -16,6 +16,8 @@ brew install umputun/apps/revdiff
 
 Use: `/revdiff [base] [against]` — opens review session in a terminal overlay (tmux, Zellij, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm).
 
+cmux is detected before ghostty when `$CMUX_SURFACE_ID` is set, `__CFBundleIdentifier=com.cmuxterm.app`, or `GHOSTTY_RESOURCES_DIR` / `GHOSTTY_BIN_DIR` contains `cmux.app`, so cmux uses the cmux CLI instead of Ghostty AppleScript.
+
 **Sandbox note:** Ghostty and iTerm2 launchers use `osascript` (Apple Events), which is blocked by Claude Code's sandbox. If you use these terminals with sandbox enabled, add to your Claude Code `settings.json`:
 
 ```json

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -58,6 +58,19 @@ print_output_and_exit() {
     exit "$rc"
 }
 
+is_cmux_session() {
+    if [ -n "${CMUX_SURFACE_ID:-}" ]; then
+        return 0
+    fi
+    if [ "${__CFBundleIdentifier:-}" = "com.cmuxterm.app" ]; then
+        return 0
+    fi
+    case "${GHOSTTY_RESOURCES_DIR:-}:${GHOSTTY_BIN_DIR:-}" in
+        *cmux.app*) return 0 ;;
+    esac
+    return 1
+}
+
 # overlay backends (kitty @ launch, tmux display-popup, zellij run, etc.) spawn
 # children from a server/app process whose env predates user shell rc files,
 # so EDITOR/VISUAL exports from .zshrc/.bashrc are otherwise lost. prepend
@@ -187,8 +200,12 @@ if [ -n "${WEZTERM_PANE:-}" ]; then
     fi
 fi
 
-# cmux: split pane via cmux CLI (must precede ghostty — cmux also sets TERM_PROGRAM=ghostty)
-if [ -n "${CMUX_SURFACE_ID:-}" ] && command -v cmux >/dev/null 2>&1; then
+# cmux: split pane via cmux CLI (must precede ghostty because cmux may expose Ghostty env vars)
+if is_cmux_session; then
+    if ! command -v cmux >/dev/null 2>&1; then
+        echo "error: cmux session detected but cmux CLI not found" >&2
+        exit 1
+    fi
     SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
     rm -f "$SENTINEL"
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ The plugin requires one of the following terminals since Claude Code itself cann
 | **kitty** | `kitty @ launch --type=overlay` | `$KITTY_LISTEN_ON` env var |
 | **wezterm** | `wezterm cli split-pane` | `$WEZTERM_PANE` env var |
 | **Kaku** | `kaku cli split-pane` (same API as wezterm) | `$WEZTERM_PANE` env var |
-| **cmux** | `cmux new-split` + `cmux send` | `$CMUX_SURFACE_ID` env var |
+| **cmux** | `cmux new-split` + `cmux send` | `$CMUX_SURFACE_ID`, `__CFBundleIdentifier=com.cmuxterm.app`, or `GHOSTTY_RESOURCES_DIR` / `GHOSTTY_BIN_DIR` containing `cmux.app` |
 | **ghostty** | AppleScript split + zoom (macOS only) | `$TERM_PROGRAM` + AppleScript probe |
 | **iTerm2** | `osascript` split pane (macOS only) | `$ITERM_SESSION_ID` env var |
 | **Emacs vterm** | New frame via `emacsclient` | `$INSIDE_EMACS` env var |
 
 Priority: tmux → Zellij → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm (first detected wins). If none are available, the plugin exits with an error.
 
-> **Note:** cmux is detected before ghostty because cmux also sets `$TERM_PROGRAM=ghostty`. The cmux block uses the cmux CLI (`new-split` + `send --surface`) instead of Ghostty's AppleScript API.
+> **Note:** cmux is detected before ghostty when `$CMUX_SURFACE_ID` is set, `__CFBundleIdentifier=com.cmuxterm.app`, or `GHOSTTY_RESOURCES_DIR` / `GHOSTTY_BIN_DIR` contains `cmux.app`. The cmux block uses the cmux CLI (`new-split` + `send --surface`) instead of Ghostty's AppleScript API.
 
 > **Note:** iTerm2 uses a split pane (vertical or horizontal, auto-detected from terminal dimensions) rather than a full-screen overlay. The iTerm2 AppleScript API does not expose a zoom command, so the split view shares screen space with the invoking session.
 
@@ -100,7 +100,7 @@ Priority: tmux → Zellij → kitty → wezterm/Kaku → cmux → ghostty → iT
 >
 > ```json
 > {
->   "sandbox": {
+>   "permissions": {
 >     "excludedCommands": ["*/launch-revdiff.sh*"]
 >   }
 > }

--- a/app/plugin_exit_code_test.go
+++ b/app/plugin_exit_code_test.go
@@ -286,6 +286,12 @@ func launcherBackends() []launcherBackend {
 		{name: "kitty", command: "kitty", env: map[string]string{"KITTY_LISTEN_ON": "unix:/tmp/kitty"}},
 		{name: "wezterm", command: "wezterm", env: map[string]string{"WEZTERM_PANE": "1"}},
 		{name: "cmux", command: "cmux", env: map[string]string{"CMUX_SURFACE_ID": "1"}},
+		{name: "cmux ghostty env", command: "cmux", env: map[string]string{
+			"TERM_PROGRAM":          "ghostty",
+			"__CFBundleIdentifier":  "com.cmuxterm.app",
+			"GHOSTTY_RESOURCES_DIR": "/Applications/cmux.app/Contents/Resources/ghostty",
+			"GHOSTTY_BIN_DIR":       "/Applications/cmux.app/Contents/MacOS",
+		}},
 		{name: "ghostty", command: "osascript", env: map[string]string{"TERM_PROGRAM": "ghostty"}},
 		{name: "iterm2", command: "osascript", env: map[string]string{"ITERM_SESSION_ID": "w0t0p0:ABC"}},
 		{name: "emacs", command: "emacsclient", env: map[string]string{"INSIDE_EMACS": "vterm"}},
@@ -310,16 +316,20 @@ func fakeLauncherEnv(t *testing.T, r launcherRun) map[string]string {
 
 func cleanOverlayEnv() map[string]string {
 	return map[string]string{
-		"TMUX":             "",
-		"ZELLIJ":           "",
-		"KITTY_LISTEN_ON":  "",
-		"KITTY_WINDOW_ID":  "",
-		"WEZTERM_PANE":     "",
-		"CMUX_SURFACE_ID":  "",
-		"TERM_PROGRAM":     "",
-		"ITERM_SESSION_ID": "",
-		"INSIDE_EMACS":     "",
-		"REVDIFF_CONFIG":   "",
+		"TMUX":                  "",
+		"ZELLIJ":                "",
+		"KITTY_LISTEN_ON":       "",
+		"KITTY_WINDOW_ID":       "",
+		"WEZTERM_PANE":          "",
+		"CMUX_SURFACE_ID":       "",
+		"TERM_PROGRAM":          "",
+		"GHOSTTY_SURFACE_ID":    "",
+		"GHOSTTY_RESOURCES_DIR": "",
+		"GHOSTTY_BIN_DIR":       "",
+		"__CFBundleIdentifier":  "",
+		"ITERM_SESSION_ID":      "",
+		"INSIDE_EMACS":          "",
+		"REVDIFF_CONFIG":        "",
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff-pi",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Pi package for revdiff interactive diff review",
   "license": "MIT",
   "repository": {

--- a/plugins/codex/skills/revdiff/references/install.md
+++ b/plugins/codex/skills/revdiff/references/install.md
@@ -13,6 +13,8 @@ Install the revdiff Codex plugin from the marketplace or manually copy the `plug
 
 Use: `/revdiff [base] [against]` — opens review session in a terminal overlay (tmux, Zellij, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm). The bundled launcher sets `REVDIFF_EXIT_CODE_ON_ANNOTATIONS`; exit `10` is success-with-annotations, not launcher failure.
 
+cmux is detected before ghostty when `$CMUX_SURFACE_ID` is set, `__CFBundleIdentifier=com.cmuxterm.app`, or `GHOSTTY_RESOURCES_DIR` / `GHOSTTY_BIN_DIR` contains `cmux.app`, so cmux uses the cmux CLI instead of Ghostty AppleScript.
+
 ### Plan Review
 
 Use `/revdiff-plan` to extract the last Codex assistant message and open it in revdiff for annotation review.

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -59,6 +59,19 @@ print_output_and_exit() {
     exit "$rc"
 }
 
+is_cmux_session() {
+    if [ -n "${CMUX_SURFACE_ID:-}" ]; then
+        return 0
+    fi
+    if [ "${__CFBundleIdentifier:-}" = "com.cmuxterm.app" ]; then
+        return 0
+    fi
+    case "${GHOSTTY_RESOURCES_DIR:-}:${GHOSTTY_BIN_DIR:-}" in
+        *cmux.app*) return 0 ;;
+    esac
+    return 1
+}
+
 # overlay backends (kitty @ launch, tmux display-popup, zellij run, etc.) spawn
 # children from a server/app process whose env predates user shell rc files,
 # so EDITOR/VISUAL exports from .zshrc/.bashrc are otherwise lost. prepend
@@ -188,8 +201,12 @@ if [ -n "${WEZTERM_PANE:-}" ]; then
     fi
 fi
 
-# cmux: split pane via cmux CLI (must precede ghostty — cmux also sets TERM_PROGRAM=ghostty)
-if [ -n "${CMUX_SURFACE_ID:-}" ] && command -v cmux >/dev/null 2>&1; then
+# cmux: split pane via cmux CLI (must precede ghostty because cmux may expose Ghostty env vars)
+if is_cmux_session; then
+    if ! command -v cmux >/dev/null 2>&1; then
+        echo "error: cmux session detected but cmux CLI not found" >&2
+        exit 1
+    fi
     SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
     rm -f "$SENTINEL"
 

--- a/plugins/revdiff-planning/.claude-plugin/plugin.json
+++ b/plugins/revdiff-planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "revdiff-planning",
   "description": "Automatic plan review with revdiff",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": {
     "name": "umputun"
   },

--- a/plugins/revdiff-planning/README.md
+++ b/plugins/revdiff-planning/README.md
@@ -11,6 +11,8 @@ Claude Code plugin that intercepts `ExitPlanMode` and opens the proposed plan in
 
 Requires the `revdiff` binary in `PATH` and one of: tmux, Zellij, kitty, wezterm, cmux, ghostty (macOS), iTerm2 (macOS), or Emacs vterm.
 
+cmux is detected before ghostty when `$CMUX_SURFACE_ID` is set, `__CFBundleIdentifier=com.cmuxterm.app`, or `GHOSTTY_RESOURCES_DIR` / `GHOSTTY_BIN_DIR` contains `cmux.app`, so cmux uses the cmux CLI instead of Ghostty AppleScript.
+
 ## How It Works
 
 The plugin registers a `PreToolUse` hook on `ExitPlanMode` that:

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -72,6 +72,19 @@ if [ "$COMPARE_MODE" = "1" ]; then
 fi
 OVERLAY_TITLE="plan: $(basename "$PLAN_FILE")"
 
+is_cmux_session() {
+    if [ -n "${CMUX_SURFACE_ID:-}" ]; then
+        return 0
+    fi
+    if [ "${__CFBundleIdentifier:-}" = "com.cmuxterm.app" ]; then
+        return 0
+    fi
+    case "${GHOSTTY_RESOURCES_DIR:-}:${GHOSTTY_BIN_DIR:-}" in
+        *cmux.app*) return 0 ;;
+    esac
+    return 1
+}
+
 # tmux: display-popup -E blocks until command exits
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     # -T (title) requires tmux 3.3+; skip on older versions
@@ -166,8 +179,12 @@ if [ -n "${WEZTERM_PANE:-}" ]; then
     fi
 fi
 
-# cmux: split pane via cmux CLI (must precede ghostty — cmux also sets TERM_PROGRAM=ghostty)
-if [ -n "${CMUX_SURFACE_ID:-}" ] && command -v cmux >/dev/null 2>&1; then
+# cmux: split pane via cmux CLI (must precede ghostty because cmux may expose Ghostty env vars)
+if is_cmux_session; then
+    if ! command -v cmux >/dev/null 2>&1; then
+        echo "error: cmux session detected but cmux CLI not found" >&2
+        exit 1
+    fi
     SENTINEL=$(mktemp "$TMPBASE/plan-review-done-XXXXXX")
     rm -f "$SENTINEL"
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -639,13 +639,13 @@ map alt+t&gt;n theme_select</code></div>
                 <tr><td><strong>kitty</strong></td><td><code>kitty @ launch --type=overlay</code></td><td><code>$KITTY_LISTEN_ON</code></td></tr>
                 <tr><td><strong>wezterm</strong></td><td><code>wezterm cli split-pane</code></td><td><code>$WEZTERM_PANE</code></td></tr>
                 <tr><td><strong>kaku</strong></td><td><code>kaku cli split-pane</code> (same API as wezterm)</td><td><code>$WEZTERM_PANE</code></td></tr>
-                <tr><td><strong>cmux</strong></td><td><code>cmux new-split</code> + <code>cmux send</code></td><td><code>$CMUX_SURFACE_ID</code></td></tr>
-                <tr><td><strong>ghostty</strong></td><td>AppleScript split + zoom (macOS only)</td><td><code>$TERM_PROGRAM</code></td></tr>
+                <tr><td><strong>cmux</strong></td><td><code>cmux new-split</code> + <code>cmux send</code></td><td><code>$CMUX_SURFACE_ID</code>, <code>__CFBundleIdentifier=com.cmuxterm.app</code>, or <code>GHOSTTY_RESOURCES_DIR</code> / <code>GHOSTTY_BIN_DIR</code> containing <code>cmux.app</code></td></tr>
+                <tr><td><strong>ghostty</strong></td><td>AppleScript split + zoom (macOS only)</td><td><code>$TERM_PROGRAM</code> + AppleScript probe</td></tr>
                 <tr><td><strong>iTerm2</strong></td><td>AppleScript split pane (macOS only)</td><td><code>$ITERM_SESSION_ID</code></td></tr>
                 <tr><td><strong>Emacs vterm</strong></td><td>New frame via <code>emacsclient</code></td><td><code>$INSIDE_EMACS</code></td></tr>
             </tbody>
         </table>
-        <p>Priority: tmux &rarr; zellij &rarr; kitty &rarr; wezterm/kaku &rarr; cmux &rarr; ghostty &rarr; iTerm2 &rarr; Emacs vterm (first detected wins). cmux is checked before ghostty because it also sets <code>$TERM_PROGRAM=ghostty</code>. iTerm2 uses a split pane rather than a full-screen overlay.</p>
+        <p>Priority: tmux &rarr; zellij &rarr; kitty &rarr; wezterm/kaku &rarr; cmux &rarr; ghostty &rarr; iTerm2 &rarr; Emacs vterm (first detected wins). cmux is checked before ghostty when <code>$CMUX_SURFACE_ID</code> is set, <code>__CFBundleIdentifier=com.cmuxterm.app</code>, or <code>GHOSTTY_RESOURCES_DIR</code> / <code>GHOSTTY_BIN_DIR</code> contains <code>cmux.app</code>. iTerm2 uses a split pane rather than a full-screen overlay.</p>
         <p><strong>Sandbox note:</strong> Ghostty and iTerm2 launchers use <code>osascript</code> (Apple Events), which is blocked by Claude Code's sandbox. If you use these terminals with sandbox enabled, add the launcher to <code>excludedCommands</code> in your Claude Code <code>settings.json</code>:</p>
         <div class="code-block"><code>{ "permissions": { "excludedCommands": ["*/launch-revdiff.sh*"] } }</code></div>
         <p>Terminals that use CLI tools instead of AppleScript (tmux, Zellij, kitty, wezterm, cmux) are not affected.</p>

--- a/site/index.html
+++ b/site/index.html
@@ -326,12 +326,12 @@
             <div class="terminal-card">
                 <div class="terminal-name">cmux</div>
                 <div class="terminal-method"><code>cmux new-split</code> + <code>cmux send</code></div>
-                <div class="terminal-detect"><code>$CMUX_SURFACE_ID</code></div>
+                <div class="terminal-detect"><code>$CMUX_SURFACE_ID</code>, <code>__CFBundleIdentifier=com.cmuxterm.app</code>, or <code>GHOSTTY_RESOURCES_DIR</code>/<code>GHOSTTY_BIN_DIR</code> containing <code>cmux.app</code></div>
             </div>
             <div class="terminal-card">
                 <div class="terminal-name">ghostty</div>
                 <div class="terminal-method">AppleScript split + zoom</div>
-                <div class="terminal-detect"><code>$TERM_PROGRAM</code></div>
+                <div class="terminal-detect"><code>$TERM_PROGRAM</code> + AppleScript probe</div>
             </div>
             <div class="terminal-card">
                 <div class="terminal-name">iTerm2</div>


### PR DESCRIPTION
Detect cmux sessions that expose Ghostty environment variables but no `CMUX_SURFACE_ID`, and route them through the cmux CLI launcher instead of the Ghostty AppleScript branch.

This updates the Claude, Codex, and plan-review launcher copies, adds focused launcher coverage for the cmux/Ghostty-env case, refreshes README/site/plugin docs, and bumps affected plugin/package versions.

Related to #202
