### PR TITLE
fix(zellij): route popups to originating tab via pane tracking

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -136,10 +136,33 @@ $(write_rc_cmd "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    zellij run --floating --close-on-exit \
-        --width "$POPUP_W" --height "$POPUP_H" \
-        --name "$OVERLAY_TITLE" --cwd "$CWD" \
-        -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    # zellij run targets the focused tab; route into our originating tab via
+    # `action new-pane --tab-id` so the popup follows the caller's pane even
+    # when the user has switched tabs. needs ZELLIJ_PANE_ID (zellij 0.40+) + jq;
+    # falls back to the plain `zellij run` path otherwise.
+    #
+    # `list-panes --json` reports `.id` as a bare integer and plugin panes
+    # share id numbers with terminal panes, so filter on is_plugin=false.
+    ZELLIJ_TAB_ID=""
+    if [ -n "${ZELLIJ_PANE_ID:-}" ] && command -v jq >/dev/null 2>&1; then
+        ZELLIJ_TAB_ID=$(zellij action list-panes --json 2>/dev/null \
+            | jq -r --arg p "$ZELLIJ_PANE_ID" \
+                '.[] | select((.is_plugin // false) == false and .id == ($p | tonumber)) | .tab_id' \
+            | head -1)
+    fi
+
+    if [ -n "$ZELLIJ_TAB_ID" ]; then
+        zellij action new-pane --floating --close-on-exit \
+            --tab-id "$ZELLIJ_TAB_ID" \
+            --width "$POPUP_W" --height "$POPUP_H" \
+            --name "$OVERLAY_TITLE" --cwd "$CWD" \
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    else
+        zellij run --floating --close-on-exit \
+            --width "$POPUP_W" --height "$POPUP_H" \
+            --name "$OVERLAY_TITLE" --cwd "$CWD" \
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    fi
 
     while [ ! -f "$SENTINEL" ]; do
         sleep 0.3

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -136,27 +136,19 @@ $(write_rc_cmd "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    # zellij run targets the focused tab; route into our originating tab via
-    # `action new-pane --tab-id` so the popup follows the caller's pane even
-    # when the user has switched tabs. needs ZELLIJ_PANE_ID (zellij 0.40+) + jq;
-    # falls back to the plain `zellij run` path otherwise.
-    #
-    # `list-panes --json` reports `.id` as a bare integer and plugin panes
-    # share id numbers with terminal panes, so filter on is_plugin=false.
-    ZELLIJ_TAB_ID=""
+    ZELLIJ_ORIG_TAB_ID=""
     if [ -n "${ZELLIJ_PANE_ID:-}" ] && command -v jq >/dev/null 2>&1; then
-        ZELLIJ_TAB_ID=$(zellij action list-panes --json 2>/dev/null \
+        ZELLIJ_ORIG_TAB_ID=$(zellij action list-panes --json --tab 2>/dev/null \
             | jq -r --arg p "$ZELLIJ_PANE_ID" \
-                '.[] | select((.is_plugin // false) == false and .id == ($p | tonumber)) | .tab_id' \
-            | head -1)
+                '.[] | select((.is_plugin // false) == false and .tab_id != null and .id == ($p | tonumber)) | .tab_id' 2>/dev/null \
+            | head -1 || true)
     fi
 
-    if [ -n "$ZELLIJ_TAB_ID" ]; then
-        zellij action new-pane --floating --close-on-exit \
-            --tab-id "$ZELLIJ_TAB_ID" \
+    if [ -n "$ZELLIJ_ORIG_TAB_ID" ] && zellij run --floating --close-on-exit --tab-id "$ZELLIJ_ORIG_TAB_ID" \
             --width "$POPUP_W" --height "$POPUP_H" \
             --name "$OVERLAY_TITLE" --cwd "$CWD" \
-            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1; then
+        :
     else
         zellij run --floating --close-on-exit \
             --width "$POPUP_W" --height "$POPUP_H" \

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -137,10 +137,33 @@ $(write_rc_cmd "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    zellij run --floating --close-on-exit \
-        --width "$POPUP_W" --height "$POPUP_H" \
-        --name "$OVERLAY_TITLE" --cwd "$CWD" \
-        -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    # zellij run targets the focused tab; route into our originating tab via
+    # `action new-pane --tab-id` so the popup follows the caller's pane even
+    # when the user has switched tabs. needs ZELLIJ_PANE_ID (zellij 0.40+) + jq;
+    # falls back to the plain `zellij run` path otherwise.
+    #
+    # `list-panes --json` reports `.id` as a bare integer and plugin panes
+    # share id numbers with terminal panes, so filter on is_plugin=false.
+    ZELLIJ_TAB_ID=""
+    if [ -n "${ZELLIJ_PANE_ID:-}" ] && command -v jq >/dev/null 2>&1; then
+        ZELLIJ_TAB_ID=$(zellij action list-panes --json 2>/dev/null \
+            | jq -r --arg p "$ZELLIJ_PANE_ID" \
+                '.[] | select((.is_plugin // false) == false and .id == ($p | tonumber)) | .tab_id' \
+            | head -1)
+    fi
+
+    if [ -n "$ZELLIJ_TAB_ID" ]; then
+        zellij action new-pane --floating --close-on-exit \
+            --tab-id "$ZELLIJ_TAB_ID" \
+            --width "$POPUP_W" --height "$POPUP_H" \
+            --name "$OVERLAY_TITLE" --cwd "$CWD" \
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    else
+        zellij run --floating --close-on-exit \
+            --width "$POPUP_W" --height "$POPUP_H" \
+            --name "$OVERLAY_TITLE" --cwd "$CWD" \
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    fi
 
     while [ ! -f "$SENTINEL" ]; do
         sleep 0.3

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -137,27 +137,19 @@ $(write_rc_cmd "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    # zellij run targets the focused tab; route into our originating tab via
-    # `action new-pane --tab-id` so the popup follows the caller's pane even
-    # when the user has switched tabs. needs ZELLIJ_PANE_ID (zellij 0.40+) + jq;
-    # falls back to the plain `zellij run` path otherwise.
-    #
-    # `list-panes --json` reports `.id` as a bare integer and plugin panes
-    # share id numbers with terminal panes, so filter on is_plugin=false.
-    ZELLIJ_TAB_ID=""
+    ZELLIJ_ORIG_TAB_ID=""
     if [ -n "${ZELLIJ_PANE_ID:-}" ] && command -v jq >/dev/null 2>&1; then
-        ZELLIJ_TAB_ID=$(zellij action list-panes --json 2>/dev/null \
+        ZELLIJ_ORIG_TAB_ID=$(zellij action list-panes --json --tab 2>/dev/null \
             | jq -r --arg p "$ZELLIJ_PANE_ID" \
-                '.[] | select((.is_plugin // false) == false and .id == ($p | tonumber)) | .tab_id' \
-            | head -1)
+                '.[] | select((.is_plugin // false) == false and .tab_id != null and .id == ($p | tonumber)) | .tab_id' 2>/dev/null \
+            | head -1 || true)
     fi
 
-    if [ -n "$ZELLIJ_TAB_ID" ]; then
-        zellij action new-pane --floating --close-on-exit \
-            --tab-id "$ZELLIJ_TAB_ID" \
+    if [ -n "$ZELLIJ_ORIG_TAB_ID" ] && zellij run --floating --close-on-exit --tab-id "$ZELLIJ_ORIG_TAB_ID" \
             --width "$POPUP_W" --height "$POPUP_H" \
             --name "$OVERLAY_TITLE" --cwd "$CWD" \
-            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1; then
+        :
     else
         zellij run --floating --close-on-exit \
             --width "$POPUP_W" --height "$POPUP_H" \

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -114,10 +114,33 @@ $REVDIFF_CMD; rc=\$?; printf "%s" "\$rc" > $(sq "$SENTINEL").tmp && mv -f $(sq "
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    zellij run --floating --close-on-exit \
-        --width 90 --height 90 \
-        --name "$OVERLAY_TITLE" \
-        -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    # zellij run targets the focused tab; route into our originating tab via
+    # `action new-pane --tab-id` so the popup follows the caller's pane even
+    # when the user has switched tabs. needs ZELLIJ_PANE_ID (zellij 0.40+) + jq;
+    # falls back to the plain `zellij run` path otherwise.
+    #
+    # `list-panes --json` reports `.id` as a bare integer and plugin panes
+    # share id numbers with terminal panes, so filter on is_plugin=false.
+    ZELLIJ_TAB_ID=""
+    if [ -n "${ZELLIJ_PANE_ID:-}" ] && command -v jq >/dev/null 2>&1; then
+        ZELLIJ_TAB_ID=$(zellij action list-panes --json 2>/dev/null \
+            | jq -r --arg p "$ZELLIJ_PANE_ID" \
+                '.[] | select((.is_plugin // false) == false and .id == ($p | tonumber)) | .tab_id' \
+            | head -1)
+    fi
+
+    if [ -n "$ZELLIJ_TAB_ID" ]; then
+        zellij action new-pane --floating --close-on-exit \
+            --tab-id "$ZELLIJ_TAB_ID" \
+            --width 90 --height 90 \
+            --name "$OVERLAY_TITLE" \
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    else
+        zellij run --floating --close-on-exit \
+            --width 90 --height 90 \
+            --name "$OVERLAY_TITLE" \
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+    fi
 
     while [ ! -f "$SENTINEL" ]; do
         sleep 0.3

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -114,27 +114,19 @@ $REVDIFF_CMD; rc=\$?; printf "%s" "\$rc" > $(sq "$SENTINEL").tmp && mv -f $(sq "
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    # zellij run targets the focused tab; route into our originating tab via
-    # `action new-pane --tab-id` so the popup follows the caller's pane even
-    # when the user has switched tabs. needs ZELLIJ_PANE_ID (zellij 0.40+) + jq;
-    # falls back to the plain `zellij run` path otherwise.
-    #
-    # `list-panes --json` reports `.id` as a bare integer and plugin panes
-    # share id numbers with terminal panes, so filter on is_plugin=false.
-    ZELLIJ_TAB_ID=""
+    ZELLIJ_ORIG_TAB_ID=""
     if [ -n "${ZELLIJ_PANE_ID:-}" ] && command -v jq >/dev/null 2>&1; then
-        ZELLIJ_TAB_ID=$(zellij action list-panes --json 2>/dev/null \
+        ZELLIJ_ORIG_TAB_ID=$(zellij action list-panes --json --tab 2>/dev/null \
             | jq -r --arg p "$ZELLIJ_PANE_ID" \
-                '.[] | select((.is_plugin // false) == false and .id == ($p | tonumber)) | .tab_id' \
-            | head -1)
+                '.[] | select((.is_plugin // false) == false and .tab_id != null and .id == ($p | tonumber)) | .tab_id' 2>/dev/null \
+            | head -1 || true)
     fi
 
-    if [ -n "$ZELLIJ_TAB_ID" ]; then
-        zellij action new-pane --floating --close-on-exit \
-            --tab-id "$ZELLIJ_TAB_ID" \
+    if [ -n "$ZELLIJ_ORIG_TAB_ID" ] && zellij run --floating --close-on-exit --tab-id "$ZELLIJ_ORIG_TAB_ID" \
             --width 90 --height 90 \
             --name "$OVERLAY_TITLE" \
-            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
+            -- "$LAUNCH_SCRIPT" >/dev/null 2>&1; then
+        :
     else
         zellij run --floating --close-on-exit \
             --width 90 --height 90 \


### PR DESCRIPTION
## Summary

Fixes Zellij popups (revdiff review + plan review) appearing in the *currently focused* tab rather than the tab where the user invoked the command. If the user switched tabs between firing the action and the popup spawning, it would land out of
sight — looking like a silent failure.

  ## Problem

`zellij run --floating` always targets the focused tab at spawn time. When Claude Code (or a hook) takes a few seconds to fire, the user often tabs away — and the popup opens in whichever tab they're now looking at, or worse, in a tab they've
since left, where it sits invisible until they wander back.

  ## Fix

Resolve the originating pane's tab up front and route the popup there explicitly:

1. Read `ZELLIJ_PANE_ID` (exported by zellij 0.40+ into the calling shell).
2. Query `zellij action list-panes --json` and use `jq` to look up the matching `tab_id`, filtering on `is_plugin=false`
(plugin panes share id numbers with terminal panes).
3. Spawn the popup with `zellij action new-pane --floating --tab-id <id>` so it lands in the originating tab regardless of current focus.
4. Fall back to the original `zellij run --floating` path when `ZELLIJ_PANE_ID` or `jq` is missing — no behavior change for older zellij or systems without jq.