### PR TITLE
fix: drop redundant cmux close-surface to avoid killing the caller tab

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "revdiff",
       "source": "./",
       "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
-      "version": "0.8.13",
+      "version": "0.8.14",
       "author": {
         "name": "umputun"
       }
@@ -18,7 +18,7 @@
       "name": "revdiff-planning",
       "source": "./plugins/revdiff-planning",
       "description": "Automatic plan review with revdiff",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revdiff",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Review diffs, files, and documents with inline annotations in a TUI overlay",
   "author": {
     "name": "umputun",

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -252,8 +252,9 @@ LAUNCHER
         sleep 0.3
     done
     rc=$(read_rc "$SENTINEL")
-    # close the split pane
-    cmux close-surface --surface "$CMUX_SURF" 2>/dev/null || true
+    # no explicit close: the exec'd launch script exits when revdiff does, so
+    # cmux auto-closes the surface. closing by the short ref (surface:N) here
+    # would risk hitting a recycled ref — another tab or the caller (see #217).
     rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
     print_output_and_exit "${rc:-1}"
 fi

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -253,8 +253,9 @@ LAUNCHER
         sleep 0.3
     done
     rc=$(read_rc "$SENTINEL")
-    # close the split pane
-    cmux close-surface --surface "$CMUX_SURF" 2>/dev/null || true
+    # no explicit close: the exec'd launch script exits when revdiff does, so
+    # cmux auto-closes the surface. closing by the short ref (surface:N) here
+    # would risk hitting a recycled ref — another tab or the caller (see #217).
     rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
     print_output_and_exit "${rc:-1}"
 fi

--- a/plugins/revdiff-planning/.claude-plugin/plugin.json
+++ b/plugins/revdiff-planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "revdiff-planning",
   "description": "Automatic plan review with revdiff",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": {
     "name": "umputun"
   },

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -230,7 +230,9 @@ LAUNCHER
         sleep 0.3
     done
     rc=$(cat "$SENTINEL" 2>/dev/null || echo 1)
-    cmux close-surface --surface "$CMUX_SURF" 2>/dev/null || true
+    # no explicit close: the exec'd launch script exits when the review tool does,
+    # so cmux auto-closes the surface. closing by the short ref (surface:N) here
+    # would risk hitting a recycled ref — another tab or the caller (see #217).
     rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
     cat "$OUTPUT_FILE"
     exit "${rc:-1}"


### PR DESCRIPTION
the cmux branch in the overlay launchers closed the review split by its recyclable short ref (`surface:N`) captured at launch. Because revdiff is started via `exec`, the surface auto-closes when revdiff exits, so the explicit `close-surface` was a redundant double-close. After a long review the short ref can be recycled to a different surface, so the late close could hit the wrong tab - another claude-teams agent or the caller's Claude session.

fix: drop the explicit `close-surface` in all three launchers that carry the cmux branch and rely on exec auto-close. `cmux send` still uses the short ref but fires right after `new-split`, with no recycling window.

distinct from #202 (pressing `q` closed both panes) and #209 (cmux detection wrongly took the ghostty branch) - this is the close-surface logic on the correctly-selected cmux branch.

launchers changed:
- `.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh`
- `plugins/codex/skills/revdiff/scripts/launch-revdiff.sh`
- `plugins/revdiff-planning/scripts/launch-plan-review.sh`

Pi is unaffected (no split launcher). Bumped revdiff 0.8.13 -> 0.8.14 and revdiff-planning 0.3.4 -> 0.3.5.

verified: shellcheck clean on all three, `go test ./app/` launcher suite passes.

Related to #217
