### PR TITLE
feat: add shell completions (bash, zsh, fish)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,8 @@ archives:
       - revdiff
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - completions/*
 
 nfpms:
   - id: revdiff
@@ -35,6 +37,13 @@ nfpms:
     formats:
       - deb
       - rpm
+    contents:
+      - src: completions/revdiff.bash
+        dst: /usr/share/bash-completion/completions/revdiff
+      - src: completions/revdiff.zsh
+        dst: /usr/share/zsh/vendor-completions/_revdiff
+      - src: completions/revdiff.fish
+        dst: /usr/share/fish/vendor_completions.d/revdiff.fish
 
 brews:
   - repository:
@@ -44,3 +53,7 @@ brews:
     homepage: https://github.com/umputun/revdiff
     description: TUI for reviewing diffs, files, and documents with inline annotations
     license: MIT
+    extra_install: |
+      bash_completion.install "completions/revdiff.bash" => "revdiff"
+      zsh_completion.install "completions/revdiff.zsh" => "_revdiff"
+      fish_completion.install "completions/revdiff.fish" => "revdiff.fish"

--- a/completions/revdiff.bash
+++ b/completions/revdiff.bash
@@ -1,0 +1,7 @@
+# bash completion for revdiff (generated via go-flags)
+_revdiff() {
+    local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    mapfile -t COMPREPLY < <(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null)
+    return 0
+}
+complete -o default -F _revdiff revdiff

--- a/completions/revdiff.fish
+++ b/completions/revdiff.fish
@@ -1,0 +1,2 @@
+# fish completion for revdiff (generated via go-flags)
+complete -c revdiff -a '(GO_FLAGS_COMPLETION=verbose revdiff (commandline -cop) 2>/dev/null | string replace -r "\\s+# " "\t")'

--- a/completions/revdiff.zsh
+++ b/completions/revdiff.zsh
@@ -1,0 +1,28 @@
+#compdef revdiff
+
+# zsh completion for revdiff (generated via go-flags)
+_revdiff() {
+    local -a lines
+    lines=(${(f)"$(GO_FLAGS_COMPLETION=verbose "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null)"})
+    if (( ${#lines} )); then
+        local -a descr
+        local line item desc
+        for line in "${lines[@]}"; do
+            if [[ "$line" = *'  # '* ]]; then
+                item="${line%%  *}"
+                desc="${line#*  \# }"
+                descr+=("${item//:/\\:}:${desc}")
+            else
+                item="${line%%  *}"
+                [[ -z "$item" ]] && item="$line"
+                [[ "$item" = *" "* ]] && continue
+                descr+=("${item//:/\\:}")
+            fi
+        done
+        _describe 'command' descr
+    else
+        _files
+    fi
+}
+
+_revdiff "$@"


### PR DESCRIPTION
adds shell completions for bash, zsh, and fish via go-flags' built-in `GO_FLAGS_COMPLETION` mechanism, the same pattern used across the other projects (ralphex #120 is the reference).

three static scripts in `completions/` (~30 lines total) and no Go code, since go-flags prints completions and exits during arg parsing before the TUI launches. Bare TAB falls back to file completion (`-o default` / `_files` / fish default), `-<TAB>` shows flags, and zsh/fish render flag descriptions via verbose mode.

`.goreleaser.yml` ships the scripts in release archives, installs them to system paths for deb/rpm, and into the homebrew formula (auto-installed on `brew install`).

supersedes #200, which hand-rolled the same feature with Go templates. Credit to @kunzaatko for surfacing it; I'll close that PR in favor of this one.
