### PR TITLE
feat(plugins): render revdiff in a tmux window under agent-deck

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/agentdeck-window.sh
+++ b/.claude-plugin/skills/revdiff/scripts/agentdeck-window.sh
@@ -1,0 +1,58 @@
+# shellcheck shell=bash
+# revdiff — agent-deck backend. SOURCED by launch-revdiff.sh (never run standalone).
+#
+# Why this exists: agent-deck (https://github.com/asheshgoplani/agent-deck) renders each of its
+# sessions through a tmux *control-mode* client, which does NOT render `tmux display-popup` at
+# all — the popup is invisible to the user and `display-popup -E` blocks forever (the agent
+# waits on a review the human can never see). agent-deck DOES surface real tmux windows, so
+# under agent-deck revdiff runs in a background tmux window named after the content under
+# review. It appears in the agent-deck session tree for the user to switch to when ready and
+# never pops over whatever other session they are working in.
+#
+# Activation:
+#   REVDIFF_TMUX_WINDOW=1   force window mode (any tmux)
+#   REVDIFF_TMUX_WINDOW=0   force the popup path (skip this backend)
+#   unset                   auto: window mode only when agent-deck is detected
+#
+# Reuses from the caller (launch-revdiff.sh): TMPBASE, OUTPUT_FILE, REVDIFF_CMD, CWD, DIR_NAME,
+# TITLE_REF, and the helpers sq() / write_rc_cmd() / read_rc() / print_output_and_exit().
+# The caller guarantees $TMUX is set and tmux is on PATH before sourcing this.
+
+_rd_winmode="${REVDIFF_TMUX_WINDOW:-}"
+if [ -z "$_rd_winmode" ]; then
+    # agent-deck markers: its env var (also mirrored into the tmux session env), with the
+    # agentdeck_* session-name prefix as a fallback signal.
+    if [ -n "${AGENTDECK_INSTANCE_ID:-}" ] \
+        || tmux show-environment AGENTDECK_INSTANCE_ID >/dev/null 2>&1 \
+        || tmux display-message -p '#{session_name}' 2>/dev/null | grep -q '^agentdeck_'; then
+        _rd_winmode=1
+    else
+        _rd_winmode=0
+    fi
+fi
+# not agent-deck (and not forced) → return to the launcher, which uses the normal popup path
+[ "$_rd_winmode" = 1 ] || return 0
+
+# window name from the content under review: the --only file, else the ref, else the directory
+_rd_winname=""
+for _rd_arg in "$@"; do
+    case "$_rd_arg" in
+        --only=*) _rd_f="${_rd_arg#--only=}"; _rd_winname="review: ${_rd_f##*/}" ;;
+    esac
+done
+[ -z "$_rd_winname" ] && _rd_winname="review: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
+
+SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+rm -f "$SENTINEL"
+trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$SENTINEL.tmp"' EXIT
+
+# -d: create the window in the BACKGROUND so it does not steal the active window — it waits in
+# the agent-deck tree until the user switches to it. -c: start directory.
+tmux new-window -d -c "$CWD" -n "$_rd_winname" -- sh -c "$(write_rc_cmd "$SENTINEL")"
+
+while [ ! -f "$SENTINEL" ]; do
+    sleep 0.3
+done
+rc=$(read_rc "$SENTINEL")
+rm -f "$SENTINEL"
+print_output_and_exit "${rc:-1}"

--- a/.claude-plugin/skills/revdiff/scripts/agentdeck-window.sh
+++ b/.claude-plugin/skills/revdiff/scripts/agentdeck-window.sh
@@ -14,9 +14,11 @@
 #   REVDIFF_TMUX_WINDOW=0   force the popup path (skip this backend)
 #   unset                   auto: window mode only when agent-deck is detected
 #
-# Reuses from the caller (launch-revdiff.sh): TMPBASE, OUTPUT_FILE, REVDIFF_CMD, CWD, DIR_NAME,
-# TITLE_REF, and the helpers sq() / write_rc_cmd() / read_rc() / print_output_and_exit().
-# The caller guarantees $TMUX is set and tmux is on PATH before sourcing this.
+# Reuses from the caller (launch-revdiff.sh): TMPBASE, CWD, DIR_NAME, TITLE_REF and the helpers
+# sq() / write_rc_cmd() / read_rc() / print_output_and_exit(). The caller guarantees $TMUX is
+# set and tmux is on PATH before sourcing this. This file is SOURCED, so it must not install an
+# EXIT trap (that would clobber the caller's cleanup trap); it cleans up explicitly instead and
+# either returns (non-agent-deck → caller falls through to the popup) or exits the process.
 
 _rd_winmode="${REVDIFF_TMUX_WINDOW:-}"
 if [ -z "$_rd_winmode" ]; then
@@ -30,7 +32,8 @@ if [ -z "$_rd_winmode" ]; then
         _rd_winmode=0
     fi
 fi
-# not agent-deck (and not forced) → return to the launcher, which uses the normal popup path
+# not agent-deck (and not forced) → return to the launcher, which uses the normal popup path.
+# returning here (before any trap/sentinel work) leaves the caller's environment untouched.
 [ "$_rd_winmode" = 1 ] || return 0
 
 # window name from the content under review: the --only file, else the ref, else the directory
@@ -42,17 +45,31 @@ for _rd_arg in "$@"; do
 done
 [ -z "$_rd_winname" ] && _rd_winname="review: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 
-SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
-rm -f "$SENTINEL"
-trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$SENTINEL.tmp"' EXIT
+_rd_sentinel=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+rm -f "$_rd_sentinel"
 
-# -d: create the window in the BACKGROUND so it does not steal the active window — it waits in
-# the agent-deck tree until the user switches to it. -c: start directory.
-tmux new-window -d -c "$CWD" -n "$_rd_winname" -- sh -c "$(write_rc_cmd "$SENTINEL")"
+# Open the review in a background window (-d: don't steal the active window; -c: start dir).
+# -P -F prints the new window id so we can watch it; mirror the popup path's `sh -c "$REVDIFF_CMD"`
+# invocation (every backend runs the command through sh, and REVDIFF_CMD is built sh-compatible).
+# If tmux can't create the window, fail loudly instead of busy-waiting on a sentinel that will
+# never appear.
+if ! _rd_winid=$(tmux new-window -d -P -F '#{window_id}' -c "$CWD" -n "$_rd_winname" \
+        -- sh -c "$(write_rc_cmd "$_rd_sentinel")"); then
+    rm -f "$_rd_sentinel" "$_rd_sentinel".tmp
+    echo "revdiff: failed to open tmux review window" >&2
+    exit 1
+fi
 
-while [ ! -f "$SENTINEL" ]; do
+# Wait for the review to finish. The sentinel carries revdiff's exit code (written before the
+# inner shell exits, so it exists by the time the window closes on a normal finish). Bound the
+# wait on the window still existing rather than a timer: a real review may take a long time, but
+# if the window disappears without a sentinel (killed / tmux died) we stop instead of hanging.
+while [ ! -f "$_rd_sentinel" ]; do
+    tmux list-windows -F '#{window_id}' 2>/dev/null | grep -qxF "$_rd_winid" || break
     sleep 0.3
 done
-rc=$(read_rc "$SENTINEL")
-rm -f "$SENTINEL"
-print_output_and_exit "${rc:-1}"
+
+_rd_rc=1
+[ -f "$_rd_sentinel" ] && _rd_rc=$(read_rc "$_rd_sentinel")
+rm -f "$_rd_sentinel" "$_rd_sentinel".tmp
+print_output_and_exit "${_rd_rc:-1}"

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -108,6 +108,14 @@ OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 
+# agent-deck: its control-mode tmux UI cannot render display-popup, so when detected this sourced
+# backend runs revdiff in a tmux window instead and exits. It returns here (no-op) for every
+# non-agent-deck tmux, leaving the popup path below unchanged.
+if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+    _RD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+    [ -f "$_RD_SCRIPT_DIR/agentdeck-window.sh" ] && . "$_RD_SCRIPT_DIR/agentdeck-window.sh"
+fi
+
 # tmux: display-popup -E blocks until command exits
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     # -T (title) requires tmux 3.3+; skip on older versions

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -113,6 +113,8 @@ POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 # non-agent-deck tmux, leaving the popup path below unchanged.
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     _RD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+    # shellcheck source=/dev/null  # sibling backend resolved at runtime; not followed at lint time
+    # shellcheck disable=SC1091
     [ -f "$_RD_SCRIPT_DIR/agentdeck-window.sh" ] && . "$_RD_SCRIPT_DIR/agentdeck-window.sh"
 fi
 

--- a/plugins/codex/skills/revdiff/scripts/agentdeck-window.sh
+++ b/plugins/codex/skills/revdiff/scripts/agentdeck-window.sh
@@ -1,0 +1,58 @@
+# shellcheck shell=bash
+# revdiff — agent-deck backend. SOURCED by launch-revdiff.sh (never run standalone).
+#
+# Why this exists: agent-deck (https://github.com/asheshgoplani/agent-deck) renders each of its
+# sessions through a tmux *control-mode* client, which does NOT render `tmux display-popup` at
+# all — the popup is invisible to the user and `display-popup -E` blocks forever (the agent
+# waits on a review the human can never see). agent-deck DOES surface real tmux windows, so
+# under agent-deck revdiff runs in a background tmux window named after the content under
+# review. It appears in the agent-deck session tree for the user to switch to when ready and
+# never pops over whatever other session they are working in.
+#
+# Activation:
+#   REVDIFF_TMUX_WINDOW=1   force window mode (any tmux)
+#   REVDIFF_TMUX_WINDOW=0   force the popup path (skip this backend)
+#   unset                   auto: window mode only when agent-deck is detected
+#
+# Reuses from the caller (launch-revdiff.sh): TMPBASE, OUTPUT_FILE, REVDIFF_CMD, CWD, DIR_NAME,
+# TITLE_REF, and the helpers sq() / write_rc_cmd() / read_rc() / print_output_and_exit().
+# The caller guarantees $TMUX is set and tmux is on PATH before sourcing this.
+
+_rd_winmode="${REVDIFF_TMUX_WINDOW:-}"
+if [ -z "$_rd_winmode" ]; then
+    # agent-deck markers: its env var (also mirrored into the tmux session env), with the
+    # agentdeck_* session-name prefix as a fallback signal.
+    if [ -n "${AGENTDECK_INSTANCE_ID:-}" ] \
+        || tmux show-environment AGENTDECK_INSTANCE_ID >/dev/null 2>&1 \
+        || tmux display-message -p '#{session_name}' 2>/dev/null | grep -q '^agentdeck_'; then
+        _rd_winmode=1
+    else
+        _rd_winmode=0
+    fi
+fi
+# not agent-deck (and not forced) → return to the launcher, which uses the normal popup path
+[ "$_rd_winmode" = 1 ] || return 0
+
+# window name from the content under review: the --only file, else the ref, else the directory
+_rd_winname=""
+for _rd_arg in "$@"; do
+    case "$_rd_arg" in
+        --only=*) _rd_f="${_rd_arg#--only=}"; _rd_winname="review: ${_rd_f##*/}" ;;
+    esac
+done
+[ -z "$_rd_winname" ] && _rd_winname="review: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
+
+SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+rm -f "$SENTINEL"
+trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$SENTINEL.tmp"' EXIT
+
+# -d: create the window in the BACKGROUND so it does not steal the active window — it waits in
+# the agent-deck tree until the user switches to it. -c: start directory.
+tmux new-window -d -c "$CWD" -n "$_rd_winname" -- sh -c "$(write_rc_cmd "$SENTINEL")"
+
+while [ ! -f "$SENTINEL" ]; do
+    sleep 0.3
+done
+rc=$(read_rc "$SENTINEL")
+rm -f "$SENTINEL"
+print_output_and_exit "${rc:-1}"

--- a/plugins/codex/skills/revdiff/scripts/agentdeck-window.sh
+++ b/plugins/codex/skills/revdiff/scripts/agentdeck-window.sh
@@ -14,9 +14,11 @@
 #   REVDIFF_TMUX_WINDOW=0   force the popup path (skip this backend)
 #   unset                   auto: window mode only when agent-deck is detected
 #
-# Reuses from the caller (launch-revdiff.sh): TMPBASE, OUTPUT_FILE, REVDIFF_CMD, CWD, DIR_NAME,
-# TITLE_REF, and the helpers sq() / write_rc_cmd() / read_rc() / print_output_and_exit().
-# The caller guarantees $TMUX is set and tmux is on PATH before sourcing this.
+# Reuses from the caller (launch-revdiff.sh): TMPBASE, CWD, DIR_NAME, TITLE_REF and the helpers
+# sq() / write_rc_cmd() / read_rc() / print_output_and_exit(). The caller guarantees $TMUX is
+# set and tmux is on PATH before sourcing this. This file is SOURCED, so it must not install an
+# EXIT trap (that would clobber the caller's cleanup trap); it cleans up explicitly instead and
+# either returns (non-agent-deck → caller falls through to the popup) or exits the process.
 
 _rd_winmode="${REVDIFF_TMUX_WINDOW:-}"
 if [ -z "$_rd_winmode" ]; then
@@ -30,7 +32,8 @@ if [ -z "$_rd_winmode" ]; then
         _rd_winmode=0
     fi
 fi
-# not agent-deck (and not forced) → return to the launcher, which uses the normal popup path
+# not agent-deck (and not forced) → return to the launcher, which uses the normal popup path.
+# returning here (before any trap/sentinel work) leaves the caller's environment untouched.
 [ "$_rd_winmode" = 1 ] || return 0
 
 # window name from the content under review: the --only file, else the ref, else the directory
@@ -42,17 +45,31 @@ for _rd_arg in "$@"; do
 done
 [ -z "$_rd_winname" ] && _rd_winname="review: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 
-SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
-rm -f "$SENTINEL"
-trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$SENTINEL.tmp"' EXIT
+_rd_sentinel=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")
+rm -f "$_rd_sentinel"
 
-# -d: create the window in the BACKGROUND so it does not steal the active window — it waits in
-# the agent-deck tree until the user switches to it. -c: start directory.
-tmux new-window -d -c "$CWD" -n "$_rd_winname" -- sh -c "$(write_rc_cmd "$SENTINEL")"
+# Open the review in a background window (-d: don't steal the active window; -c: start dir).
+# -P -F prints the new window id so we can watch it; mirror the popup path's `sh -c "$REVDIFF_CMD"`
+# invocation (every backend runs the command through sh, and REVDIFF_CMD is built sh-compatible).
+# If tmux can't create the window, fail loudly instead of busy-waiting on a sentinel that will
+# never appear.
+if ! _rd_winid=$(tmux new-window -d -P -F '#{window_id}' -c "$CWD" -n "$_rd_winname" \
+        -- sh -c "$(write_rc_cmd "$_rd_sentinel")"); then
+    rm -f "$_rd_sentinel" "$_rd_sentinel".tmp
+    echo "revdiff: failed to open tmux review window" >&2
+    exit 1
+fi
 
-while [ ! -f "$SENTINEL" ]; do
+# Wait for the review to finish. The sentinel carries revdiff's exit code (written before the
+# inner shell exits, so it exists by the time the window closes on a normal finish). Bound the
+# wait on the window still existing rather than a timer: a real review may take a long time, but
+# if the window disappears without a sentinel (killed / tmux died) we stop instead of hanging.
+while [ ! -f "$_rd_sentinel" ]; do
+    tmux list-windows -F '#{window_id}' 2>/dev/null | grep -qxF "$_rd_winid" || break
     sleep 0.3
 done
-rc=$(read_rc "$SENTINEL")
-rm -f "$SENTINEL"
-print_output_and_exit "${rc:-1}"
+
+_rd_rc=1
+[ -f "$_rd_sentinel" ] && _rd_rc=$(read_rc "$_rd_sentinel")
+rm -f "$_rd_sentinel" "$_rd_sentinel".tmp
+print_output_and_exit "${_rd_rc:-1}"

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -109,6 +109,14 @@ OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 
+# agent-deck: its control-mode tmux UI cannot render display-popup, so when detected this sourced
+# backend runs revdiff in a tmux window instead and exits. It returns here (no-op) for every
+# non-agent-deck tmux, leaving the popup path below unchanged.
+if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+    _RD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+    [ -f "$_RD_SCRIPT_DIR/agentdeck-window.sh" ] && . "$_RD_SCRIPT_DIR/agentdeck-window.sh"
+fi
+
 # tmux: display-popup -E blocks until command exits
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     # -T (title) requires tmux 3.3+; skip on older versions

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -114,6 +114,8 @@ POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 # non-agent-deck tmux, leaving the popup path below unchanged.
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     _RD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+    # shellcheck source=/dev/null  # sibling backend resolved at runtime; not followed at lint time
+    # shellcheck disable=SC1091
     [ -f "$_RD_SCRIPT_DIR/agentdeck-window.sh" ] && . "$_RD_SCRIPT_DIR/agentdeck-window.sh"
 fi
 


### PR DESCRIPTION
## What

Under [agent-deck](https://github.com/asheshgoplani/agent-deck), revdiff's review overlay never appears if I'm in another session when revdiff is spawned.

agent-deck *does* surface real tmux **windows**. This PR adds a small backend that, when agent-deck is detected, runs revdiff in a background tmux window (named after the content under review) instead of a popup. It shows up in the agent-deck session tree for the user to switch to, and never pops over whatever other session they're working in.

## How

- New `agentdeck-window.sh`, **sourced** by `launch-revdiff.sh` — it reuses the existing `REVDIFF_CMD` / `OUTPUT_FILE` / `sq` / `write_rc_cmd` / `read_rc` / `print_output_and_exit` plumbing and the sentinel/rc protocol, so the exit-code-on-annotations behaviour is preserved.
- `launch-revdiff.sh` gains only a 4-line guarded `source` hook before the tmux popup path. Every non-agent-deck tmux returns immediately and uses the popup **unchanged** — no behaviour change and no added cost for existing users.
- Detection: `AGENTDECK_INSTANCE_ID` (also mirrored into the tmux session env) with the `agentdeck_*` session-name prefix as a fallback.
- Window created with `new-window -d` so it never steals the active window.
- Applied to both the main (`.claude-plugin/…`) and codex (`plugins/codex/…`) plugin script sets.

## Opt in / out

- `REVDIFF_TMUX_WINDOW=1` — force window mode (any tmux)
- `REVDIFF_TMUX_WINDOW=0` — force the popup path
- unset — auto: window mode only when agent-deck is detected

## Testing

- `bash -n` + `shellcheck -x` clean on all four changed files.
- Verified end-to-end inside agent-deck: the review window opens in the background (active window not stolen), annotations are captured on close via the existing sentinel/rc flow, and exit-code-on-annotations is preserved.

How it looks like:

<img width="447" height="89" alt="Screenshot 2026-06-15 at 00 02 53" src="https://github.com/user-attachments/assets/a9714490-58d4-4e5c-8262-23a23309eb01" />

