### PR TITLE
fix(plugins): open herd review tab in the agent's (caller's) workspace

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -189,9 +189,13 @@ $(write_rc_cmd "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    # create a focused tab (cwd set so revdiff runs in the caller's directory);
-    # parse the new tab + root pane ids from the JSON reply
-    HERDR_NEW=$(herdr tab create --cwd "$CWD" --label "$OVERLAY_TITLE" --focus 2>&1) || {
+    # pin the tab to the caller's workspace: without --workspace, herdr tab create
+    # targets the server's focused workspace (what the user is currently viewing),
+    # not the caller's workspace
+    HERDR_TAB_ARGS=(tab create --cwd "$CWD" --label "$OVERLAY_TITLE")
+    [ -n "${HERDR_WORKSPACE_ID:-}" ] && HERDR_TAB_ARGS+=(--workspace "$HERDR_WORKSPACE_ID")
+    HERDR_TAB_ARGS+=(--focus)
+    HERDR_NEW=$(herdr "${HERDR_TAB_ARGS[@]}" 2>&1) || {
         echo "error: herdr tab create failed: $HERDR_NEW" >&2
         exit 1
     }

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -190,9 +190,13 @@ $(write_rc_cmd "$SENTINEL")
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    # create a focused tab (cwd set so revdiff runs in the caller's directory);
-    # parse the new tab + root pane ids from the JSON reply
-    HERDR_NEW=$(herdr tab create --cwd "$CWD" --label "$OVERLAY_TITLE" --focus 2>&1) || {
+    # pin the tab to the caller's workspace: without --workspace, herdr tab create
+    # targets the server's focused workspace (what the user is currently viewing),
+    # not the caller's workspace
+    HERDR_TAB_ARGS=(tab create --cwd "$CWD" --label "$OVERLAY_TITLE")
+    [ -n "${HERDR_WORKSPACE_ID:-}" ] && HERDR_TAB_ARGS+=(--workspace "$HERDR_WORKSPACE_ID")
+    HERDR_TAB_ARGS+=(--focus)
+    HERDR_NEW=$(herdr "${HERDR_TAB_ARGS[@]}" 2>&1) || {
         echo "error: herdr tab create failed: $HERDR_NEW" >&2
         exit 1
     }

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -158,7 +158,13 @@ $REVDIFF_CMD; rc=\$?; printf "%s" "\$rc" > $(sq "$SENTINEL").tmp && mv -f $(sq "
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    HERDR_NEW=$(herdr tab create --cwd "$CWD" --label "$OVERLAY_TITLE" --focus 2>&1) || {
+    # pin the tab to the caller's workspace: without --workspace, herdr tab create
+    # targets the server's focused workspace (what the user is currently viewing),
+    # not the caller's workspace
+    HERDR_TAB_ARGS=(tab create --cwd "$CWD" --label "$OVERLAY_TITLE")
+    [ -n "${HERDR_WORKSPACE_ID:-}" ] && HERDR_TAB_ARGS+=(--workspace "$HERDR_WORKSPACE_ID")
+    HERDR_TAB_ARGS+=(--focus)
+    HERDR_NEW=$(herdr "${HERDR_TAB_ARGS[@]}" 2>&1) || {
         echo "error: herdr tab create failed: $HERDR_NEW" >&2
         exit 1
     }


### PR DESCRIPTION
when an agent launches revdiff inside herdr, the review tab opens in the workspace the user is currently viewing, not the one the agent runs in. with several agents across workspaces, it lands in the wrong place.

cause: the launcher runs `herdr tab create` with no `--workspace`, and herdr's `tab.create` defaults to the active workspace (its `handle_tab_create` falls back to `self.state.active` when `workspace_id` is absent). the socket call carries no caller-pane id, so `--workspace` is the only way to target one.

fix: pass `--workspace "$HERDR_WORKSPACE_ID"`. herdr injects that var into every managed pane, so the tab opens in the caller's own workspace. degrades to the old behavior if the var is unset; `--focus` is unchanged. applied to all three launchers (both revdiff copies + plan-review).

shellcheck and `bash -n` clean.

refs (herdr source, defaults to the active workspace when `--workspace` is omitted):
- [`handle_tab_create`](https://github.com/ogulcancelik/herdr/blob/26c5f97a908c1ebe4228302d1b9e8c5423b2ab75/src/app/api/tabs.rs#L49-L66)
- [`TabCreateParams`](https://github.com/ogulcancelik/herdr/blob/26c5f97a908c1ebe4228302d1b9e8c5423b2ab75/src/api/schema/tabs.rs#L8-L19)