### PR TITLE
fix(ui): Restore mouse after editor return

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -195,6 +195,7 @@ func run(opts options) (int, error) {
 		ReloadApplicable:  reloadApplicable(opts),
 		CompactApplicable: compactApplicable(opts, renderer),
 		NoColors:          opts.NoColors,
+		MouseTracking:     !opts.NoMouse,
 		NoStatusBar:       opts.NoStatusBar,
 		NoConfirmDiscard:  opts.NoConfirmDiscard,
 		Wrap:              opts.Wrap,

--- a/app/ui/editor.go
+++ b/app/ui/editor.go
@@ -34,6 +34,11 @@ type editorFinishedMsg struct {
 	fileLevel  bool
 	line       int
 	changeType string
+
+	// restoreMouse requests mouse tracking after the editor returns.
+	// Bubble Tea disables mouse modes while the child process owns the terminal;
+	// editor setup failures never release the terminal, so they do not need this.
+	restoreMouse bool
 }
 
 // openEditor returns a tea.Cmd that suspends the program, launches the user's
@@ -73,14 +78,18 @@ func (m *Model) openEditor() tea.Cmd {
 	seed := content
 	return tea.ExecProcess(cmd, func(runErr error) tea.Msg {
 		text, finalErr := complete(runErr)
+		// Earlier setup failures return before tea.ExecProcess releases the
+		// terminal, so restoreMouse is set only on this completion path and only
+		// when the session originally enabled mouse tracking.
 		return editorFinishedMsg{
-			content:    text,
-			seed:       seed,
-			err:        finalErr,
-			fileName:   fileName,
-			fileLevel:  fileLevel,
-			line:       line,
-			changeType: changeType,
+			content:      text,
+			seed:         seed,
+			err:          finalErr,
+			restoreMouse: m.cfg.mouseTracking,
+			fileName:     fileName,
+			fileLevel:    fileLevel,
+			line:         line,
+			changeType:   changeType,
 		}
 	})
 }
@@ -99,6 +108,10 @@ func (m *Model) openEditor() tea.Cmd {
 // failure (tty restore error post-save, non-zero exit after save), so the
 // content is saved and the error logged — preserving user work.
 func (m Model) handleEditorFinished(msg editorFinishedMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	if msg.restoreMouse {
+		cmd = tea.EnableMouseCellMotion
+	}
 	if msg.err != nil {
 		// covers editor spawn failure, non-zero exit, tty release/restore errors,
 		// temp-file creation/write failures, and post-exit file read errors.
@@ -112,14 +125,14 @@ func (m Model) handleEditorFinished(msg editorFinishedMsg) (tea.Model, tea.Cmd) 
 			// and drop. trade-off: preserving input state on ambiguous errors lets
 			// users retry. the alternative (save on any non-empty content) caused
 			// the iter-2 regression where launch-time failures silently saved seed.
-			return m, nil
+			return m, cmd
 		}
 		// fall through to save: user wrote content before the error, preserve it
 	}
 	if msg.content == "" {
 		m.cancelAnnotation()
-		return m, nil
+		return m, cmd
 	}
 	m.saveComment(msg.content, msg.fileName, msg.fileLevel, msg.line, msg.changeType)
-	return m, nil
+	return m, cmd
 }

--- a/app/ui/editor_test.go
+++ b/app/ui/editor_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -167,4 +168,52 @@ func TestOpenEditor_CommandErrorProducesEditorFinishedMsg(t *testing.T) {
 	assert.True(t, model.annot.annotating, "annotation mode must stay open after editor error so user can retry")
 	assert.Equal(t, "in-progress note", model.annot.input.Value(), "input value must be preserved after error")
 	assert.Empty(t, model.store.Get("a.go"), "no annotation should be saved when editor errored")
+}
+
+func TestModel_EditorFinishedReenablesMouseTracking(t *testing.T) {
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "added", ChangeType: diff.ChangeAdd},
+	}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.tree = testNewFileTree([]string{"a.go"})
+	m.layout.focus = paneDiff
+	m.file.name = "a.go"
+	m.file.lines = lines
+	m.nav.diffCursor = 1
+	m.startAnnotation()
+
+	result, cmd := m.Update(editorFinishedMsg{content: "review note", restoreMouse: true, fileName: "a.go", line: 2, changeType: "+"})
+	model := result.(Model)
+
+	require.NotNil(t, cmd, "editor completion must re-enable mouse tracking after Bubble Tea restores the terminal")
+	// This intentionally checks the current command shape. The external behavior
+	// is a terminal escape sequence emitted by Bubble Tea after Update returns;
+	// asserting it without a PTY harness requires inspecting the command message.
+	assert.IsType(t, tea.EnableMouseCellMotion(), cmd(), "editor completion must emit Bubble Tea's mouse re-enable message")
+	assert.False(t, model.annot.annotating, "annotation mode should close after successful editor save")
+	require.Len(t, model.store.Get("a.go"), 1)
+	assert.Equal(t, "review note", model.store.Get("a.go")[0].Comment)
+}
+
+func TestModel_EditorFinishedDoesNotEnableMouseWhenTrackingDisabled(t *testing.T) {
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext},
+		{NewNum: 2, Content: "added", ChangeType: diff.ChangeAdd},
+	}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.tree = testNewFileTree([]string{"a.go"})
+	m.layout.focus = paneDiff
+	m.file.name = "a.go"
+	m.file.lines = lines
+	m.nav.diffCursor = 1
+	m.startAnnotation()
+
+	result, cmd := m.Update(editorFinishedMsg{content: "review note", restoreMouse: false, fileName: "a.go", line: 2, changeType: "+"})
+	model := result.(Model)
+
+	assert.Nil(t, cmd, "editor completion must not enable mouse tracking when the session did not enable it")
+	assert.False(t, model.annot.annotating, "annotation mode should close after successful editor save")
+	require.Len(t, model.store.Get("a.go"), 1)
+	assert.Equal(t, "review note", model.store.Get("a.go")[0].Comment)
 }

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -262,6 +262,7 @@ type modelConfigState struct {
 	only             []string // filter to show only matching files
 	workDir          string   // working directory for resolving absolute --only paths
 	noColors         bool     // keep monochrome output when previewing or applying themes
+	mouseTracking    bool     // true when the session enabled mouse tracking
 	noStatusBar      bool     // hide the status bar
 	noConfirmDiscard bool     // skip confirmation prompt on discard quit
 	crossFileHunks   bool     // allow [ and ] to jump across file boundaries
@@ -613,6 +614,7 @@ type ModelConfig struct {
 	TreeWidthRatio   int
 	TabWidth         int      // number of spaces per tab character
 	NoColors         bool     // disable all colors including syntax highlighting
+	MouseTracking    bool     // enable mouse tracking for clicks and wheel events
 	NoStatusBar      bool     // hide the status bar
 	NoConfirmDiscard bool     // skip confirmation prompt when discarding annotations
 	Wrap             bool     // enable line wrapping
@@ -751,6 +753,7 @@ func NewModel(cfg ModelConfig) (Model, error) {
 			only:             cfg.Only,
 			workDir:          cfg.WorkDir,
 			noColors:         cfg.NoColors,
+			mouseTracking:    cfg.MouseTracking,
 			noStatusBar:      cfg.NoStatusBar,
 			noConfirmDiscard: cfg.NoConfirmDiscard,
 			crossFileHunks:   cfg.CrossFileHunks,


### PR DESCRIPTION
Bug:
Ctrl+E annotation editing releases the terminal to the external editor.
Bubble Tea disables mouse tracking during that release,
then restores the terminal without re-emitting the mouse-enable sequence.
After returning from the editor,
events therefore stay with the terminal instead of reaching revdiff.

Fix:
Mark editor sessions that passed through Bubble Tea's process handoff,
and re-enable mouse cell tracking when those sessions complete
for sessions that started with mouse tracking enabled.

Editor setup failures retry without requesting mouse restoration,
and `--no-mouse` sessions do not gain mouse tracking after editor return.
