### PR TITLE
feat: add --watch flag for automatic reload on file changes

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -37,6 +37,7 @@ type options struct {
 	AnnotationMarker      string   `long:"annotation-marker" ini-name:"annotation-marker" env:"REVDIFF_ANNOTATION_MARKER" default:"💬" description:"prefix shown before annotation lines"`
 	ExitCodeOnAnnotations bool     `long:"exit-code-on-annotations" ini-name:"exit-code-on-annotations" env:"REVDIFF_EXIT_CODE_ON_ANNOTATIONS" description:"exit 10 when annotations are produced"`
 	VimMotion             bool     `long:"vim-motion" ini-name:"vim-motion" env:"REVDIFF_VIM_MOTION" description:"enable vim-style motion preset (counts, gg, G, zz/zt/zb, ZZ/ZQ)"`
+	Watch                 bool     `long:"watch" ini-name:"watch" env:"REVDIFF_WATCH" description:"reload automatically when changes are detected (polls every 2s)"`
 	ChromaStyle           string   `long:"chroma-style" ini-name:"chroma-style" env:"REVDIFF_CHROMA_STYLE" default:"catppuccin-macchiato" description:"chroma style for syntax highlighting"`
 	AllFiles              bool     `long:"all-files" short:"A" no-ini:"true" description:"browse all tracked files, not just diffs (git and jj only)"`
 	CompareOld            string   `long:"compare-old" no-ini:"true" description:"compare mode: old file path (use with --compare-new)"`

--- a/app/main.go
+++ b/app/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -238,6 +241,13 @@ func run(opts options) (int, error) {
 	}
 
 	p := tea.NewProgram(model, programOptions...)
+
+	if opts.Watch && watchApplicable(opts) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		startWatcher(ctx, renderer, opts.ref(), opts.Staged, p)
+	}
+
 	finalModel, err := p.Run()
 	if err != nil {
 		return 0, fmt.Errorf("TUI error: %w", err)
@@ -337,4 +347,51 @@ func compactApplicable(opts options, r ui.Renderer) bool {
 		return false
 	}
 	return true
+}
+
+// watchApplicable returns true when --watch is meaningful: stdin has been
+// consumed and cannot change; compare mode operates on static files.
+func watchApplicable(opts options) bool {
+	return !opts.Stdin && opts.compareAbsOld == ""
+}
+
+// startWatcher polls the renderer's ChangedFiles list every 2 seconds and
+// sends a WatchReloadMsg to the bubbletea program when the list changes.
+// The goroutine exits when ctx is cancelled (triggered when run() returns).
+func startWatcher(ctx context.Context, renderer ui.Renderer, ref string, staged bool, p *tea.Program) {
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		last := fileListHash(renderer, ref, staged)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				h := fileListHash(renderer, ref, staged)
+				if h != last {
+					last = h
+					p.Send(ui.WatchReloadMsg{})
+				}
+			}
+		}
+	}()
+}
+
+// fileListHash returns a string that changes whenever the set of changed files
+// (paths and statuses) changes. Returns empty string on error so the watcher
+// stays quiet rather than spamming reloads on transient VCS failures.
+func fileListHash(r ui.Renderer, ref string, staged bool) string {
+	entries, err := r.ChangedFiles(ref, staged)
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		b.WriteString(e.Path)
+		b.WriteByte('|')
+		b.WriteString(string(e.Status))
+		b.WriteByte('\n')
+	}
+	return b.String()
 }

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -538,6 +538,11 @@ type filesLoadedMsg struct {
 	warnings []string // non-fatal issues (staged/untracked fetch failures)
 }
 
+// WatchReloadMsg is sent by the external file-watcher goroutine (started when
+// --watch is set) when the changed-files list hash differs from the previous
+// poll. Exported so main.go can construct and send it via p.Send().
+type WatchReloadMsg struct{}
+
 // commitsLoadedMsg is sent when the commit log for the current ref range is loaded.
 type commitsLoadedMsg struct {
 	seq       uint64 // matches m.commits.loadSeq at the time the load was issued; mismatched messages are dropped
@@ -833,6 +838,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleFileLoaded(msg)
 	case blameLoadedMsg:
 		return m.handleBlameLoaded(msg)
+	case WatchReloadMsg:
+		return m.handleWatchReload()
 	case editorFinishedMsg:
 		return m.handleEditorFinished(msg)
 	case wheelDebounceMsg:
@@ -1063,6 +1070,21 @@ func (m Model) handleChordSecond(keyStr string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m.dispatchAction(action)
+}
+
+// handleWatchReload is called when the external watcher detects a file-list
+// change. Unlike handleReload (R key), there is no confirmation prompt and no
+// hint — watch mode is unattended. If annotations exist, the reload is skipped
+// silently to avoid dropping user work.
+func (m Model) handleWatchReload() (tea.Model, tea.Cmd) {
+	if !m.reload.applicable || m.reload.pending || m.annot.annotating || m.search.active {
+		return m, nil
+	}
+	if m.store.Count() > 0 {
+		return m, nil
+	}
+	cmd := m.triggerReload()
+	return m, cmd
 }
 
 // handleReload handles the ActionReload key. In stdin mode the feature is


### PR DESCRIPTION
Polls ChangedFiles() every 2s; reloads silently when the file list hash changes. Skips reload when annotations exist to avoid data loss. Disabled in --stdin and --compare modes.