### PR TITLE
Add automatic light/dark theme selection

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -38,7 +38,9 @@ Then uncomment and edit the values you want to change.
 | `--no-mouse` | `REVDIFF_NO_MOUSE` | Disable mouse support (scroll wheel, click) | `false` |
 | `--vim-motion` | `REVDIFF_VIM_MOTION` | Enable vim-style motion preset (counts, `gg`, `G`, `H`/`M`/`L`, `zz`/`zt`/`zb`, `ZZ`/`ZQ`) | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
-| `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/` | |
+| `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/`; use `auto` to choose by terminal background | |
+| `--auto-theme-dark` | `REVDIFF_AUTO_THEME_DARK` | Theme used by `--theme auto` on dark terminal backgrounds | `revdiff` |
+| `--auto-theme-light` | `REVDIFF_AUTO_THEME_LIGHT` | Theme used by `--theme auto` on light terminal backgrounds | `catppuccin-latte` |
 | `--dump-theme` | | Print currently resolved colors as theme file and exit | |
 | `--list-themes` | | Print available theme names and exit | |
 | `--init-themes` | | Write bundled theme files to themes dir and exit | |
@@ -76,6 +78,7 @@ Press `T` inside revdiff to open the interactive theme selector with live previe
 
 ```bash
 revdiff --theme dracula          # apply a theme
+revdiff --theme auto             # choose by terminal background
 revdiff --list-themes            # list available themes
 revdiff --init-themes            # re-create bundled themes
 revdiff --install-theme nord     # install a specific gallery theme
@@ -83,7 +86,7 @@ revdiff --init-all-themes        # install all gallery themes
 revdiff --dump-theme > ~/.config/revdiff/themes/my-custom  # export current colors
 ```
 
-Set default theme in config: `theme = dracula`. Or env: `REVDIFF_THEME=dracula`.
+Set default theme in config: `theme = dracula`. Or env: `REVDIFF_THEME=dracula`. Use `theme = auto` to query the terminal background and choose `auto-theme-dark` or `auto-theme-light`.
 
 **Custom themes:** customize colors in config or via `--color-*` flags, then `revdiff --dump-theme > ~/.config/revdiff/themes/my-custom`. Or copy a bundled theme file and edit directly — each has all 23 color keys + `chroma-style`.
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,9 @@ Positional arguments support several forms:
 | `--no-mouse` | Disable mouse support (scroll wheel, click), env: `REVDIFF_NO_MOUSE` | `false` |
 | `--vim-motion` | Enable vim-style motion preset (counts, `gg`, `G`, `H`/`M`/`L`, `zz`/`zt`/`zb`, `ZZ`/`ZQ`), env: `REVDIFF_VIM_MOTION` | `false` |
 | `--chroma-style` | Chroma color theme for syntax highlighting, env: `REVDIFF_CHROMA_STYLE` | `catppuccin-macchiato` |
-| `--theme` | Load color theme from `~/.config/revdiff/themes/`, env: `REVDIFF_THEME` | |
+| `--theme` | Load color theme from `~/.config/revdiff/themes/`; use `auto` to choose by terminal background, env: `REVDIFF_THEME` | |
+| `--auto-theme-dark` | Theme used by `--theme auto` on dark terminal backgrounds, env: `REVDIFF_AUTO_THEME_DARK` | `revdiff` |
+| `--auto-theme-light` | Theme used by `--theme auto` on light terminal backgrounds, env: `REVDIFF_AUTO_THEME_LIGHT` | `catppuccin-latte` |
 | `--dump-theme` | Print currently resolved colors as theme file to stdout and exit | |
 | `--list-themes` | Print available theme names to stdout and exit | |
 | `--init-themes` | Write bundled theme files to themes dir and exit | |
@@ -395,6 +397,9 @@ Press `T` inside revdiff to open the interactive theme selector with live previe
 # apply a theme
 revdiff --theme dracula
 
+# choose a theme from the terminal background color
+revdiff --theme auto
+
 # list available themes
 revdiff --list-themes
 
@@ -432,6 +437,14 @@ theme = dracula
 ```
 
 Or via environment variable: `REVDIFF_THEME=dracula`.
+
+Set `theme = auto` to query the terminal background and choose a matching theme. By default, auto mode uses `revdiff` for dark backgrounds and `catppuccin-latte` for light backgrounds:
+
+```ini
+theme = auto
+auto-theme-dark = revdiff
+auto-theme-light = catppuccin-latte
+```
 
 **Contributing themes** — community themes live in the `themes/gallery/` directory. See [themes/README.md](themes/README.md) for the contribution guide, format requirements, and validation instructions.
 

--- a/app/config.go
+++ b/app/config.go
@@ -54,6 +54,8 @@ type options struct {
 	Keys                  string   `long:"keys" env:"REVDIFF_KEYS" no-ini:"true" description:"path to keybindings file"`
 	DumpKeys              bool     `long:"dump-keys" no-ini:"true" description:"print effective keybindings to stdout and exit"`
 	Theme                 string   `long:"theme" ini-name:"theme" env:"REVDIFF_THEME" description:"load theme from themes directory"`
+	AutoThemeDark         string   `long:"auto-theme-dark" ini-name:"auto-theme-dark" env:"REVDIFF_AUTO_THEME_DARK" default:"revdiff" description:"theme to use for dark terminal backgrounds when --theme=auto"`
+	AutoThemeLight        string   `long:"auto-theme-light" ini-name:"auto-theme-light" env:"REVDIFF_AUTO_THEME_LIGHT" default:"catppuccin-latte" description:"theme to use for light terminal backgrounds when --theme=auto"`
 	DumpTheme             bool     `long:"dump-theme" no-ini:"true" description:"print currently resolved colors as theme file and exit"`
 	ListThemes            bool     `long:"list-themes" no-ini:"true" description:"print available theme names and exit"`
 	InitThemes            bool     `long:"init-themes" no-ini:"true" description:"write bundled theme files to themes dir and exit"`

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -42,6 +42,8 @@ func TestParseArgs_Defaults(t *testing.T) {
 	assert.Empty(t, opts.StdinName)
 	assert.Empty(t, opts.Refs.Base)
 	assert.Empty(t, opts.Refs.Against)
+	assert.Equal(t, "revdiff", opts.AutoThemeDark)
+	assert.Equal(t, "catppuccin-latte", opts.AutoThemeLight)
 }
 
 func TestParseArgs_NoConfirmDiscard(t *testing.T) {
@@ -987,6 +989,34 @@ func TestParseArgs_ThemeEnv(t *testing.T) {
 	opts, err := parseArgs(noConfigArgs(t))
 	require.NoError(t, err)
 	assert.Equal(t, "nord", opts.Theme)
+}
+
+func TestParseArgs_AutoThemeOptions(t *testing.T) {
+	t.Run("flags", func(t *testing.T) {
+		opts, err := parseArgs(append(noConfigArgs(t), "--auto-theme-dark=dracula", "--auto-theme-light=catppuccin-latte"))
+		require.NoError(t, err)
+		assert.Equal(t, "dracula", opts.AutoThemeDark)
+		assert.Equal(t, "catppuccin-latte", opts.AutoThemeLight)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("REVDIFF_AUTO_THEME_DARK", "nord")
+		t.Setenv("REVDIFF_AUTO_THEME_LIGHT", "basic")
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.Equal(t, "nord", opts.AutoThemeDark)
+		assert.Equal(t, "basic", opts.AutoThemeLight)
+	})
+
+	t.Run("config file", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config")
+		err := os.WriteFile(cfgPath, []byte("[Application Options]\nauto-theme-dark = dracula\nauto-theme-light = basic\n"), 0o600)
+		require.NoError(t, err)
+		opts, err := parseArgs([]string{"--config", cfgPath})
+		require.NoError(t, err)
+		assert.Equal(t, "dracula", opts.AutoThemeDark)
+		assert.Equal(t, "basic", opts.AutoThemeLight)
+	})
 }
 
 func TestParseArgs_DumpThemeFlag(t *testing.T) {

--- a/app/themes.go
+++ b/app/themes.go
@@ -9,11 +9,19 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/muesli/termenv"
+
 	"github.com/umputun/revdiff/app/fsutil"
 	"github.com/umputun/revdiff/app/highlight"
 	"github.com/umputun/revdiff/app/theme"
 	"github.com/umputun/revdiff/app/ui"
 	"github.com/umputun/revdiff/app/ui/style"
+)
+
+const (
+	autoThemeName         = "auto"
+	defaultAutoThemeDark  = "revdiff"
+	defaultAutoThemeLight = "catppuccin-latte"
 )
 
 // defaultThemesDir returns ~/.config/revdiff/themes.
@@ -79,12 +87,28 @@ func handleThemes(opts *options, cat *theme.Catalog, stdout, stderr io.Writer) (
 		_, _ = fmt.Fprintln(stderr, "warning: --no-colors ignored when --theme is set")
 		opts.NoColors = false
 	}
+	if opts.Theme == autoThemeName {
+		opts.Theme = resolveAutoThemeName(*opts, termenv.HasDarkBackground())
+	}
 	th, err := cat.Load(opts.Theme)
 	if err != nil {
 		return false, fmt.Errorf("load theme: %w", err)
 	}
 	applyTheme(opts, th, cat.OptionalColorKeys())
 	return false, nil
+}
+
+func resolveAutoThemeName(opts options, darkBackground bool) string {
+	if darkBackground {
+		if opts.AutoThemeDark != "" {
+			return opts.AutoThemeDark
+		}
+		return defaultAutoThemeDark
+	}
+	if opts.AutoThemeLight != "" {
+		return opts.AutoThemeLight
+	}
+	return defaultAutoThemeLight
 }
 
 // colorFieldPtrs maps color key names (matching ini-name tags) to pointers into opts.Colors fields.

--- a/app/themes.go
+++ b/app/themes.go
@@ -87,15 +87,22 @@ func handleThemes(opts *options, cat *theme.Catalog, stdout, stderr io.Writer) (
 		_, _ = fmt.Fprintln(stderr, "warning: --no-colors ignored when --theme is set")
 		opts.NoColors = false
 	}
-	if opts.Theme == autoThemeName {
-		opts.Theme = resolveAutoThemeName(*opts, termenv.HasDarkBackground())
-	}
+	opts.Theme = resolveThemeName(*opts)
 	th, err := cat.Load(opts.Theme)
 	if err != nil {
 		return false, fmt.Errorf("load theme: %w", err)
 	}
 	applyTheme(opts, th, cat.OptionalColorKeys())
 	return false, nil
+}
+
+// resolveThemeName resolves the "auto" sentinel to a concrete theme via the terminal
+// background; any other theme name is returned unchanged.
+func resolveThemeName(opts options) string {
+	if opts.Theme != autoThemeName {
+		return opts.Theme
+	}
+	return resolveAutoThemeName(opts, termenv.HasDarkBackground())
 }
 
 func resolveAutoThemeName(opts options, darkBackground bool) string {

--- a/app/themes_test.go
+++ b/app/themes_test.go
@@ -331,6 +331,47 @@ func TestHandleThemes_LoadTheme(t *testing.T) {
 	assert.Equal(t, "dracula", opts.ChromaStyle)
 }
 
+func TestResolveAutoThemeName(t *testing.T) {
+	tests := []struct {
+		name           string
+		opts           options
+		darkBackground bool
+		want           string
+	}{
+		{name: "dark terminal uses default dark theme", darkBackground: true, want: "revdiff"},
+		{name: "light terminal uses default light theme", darkBackground: false, want: "catppuccin-latte"},
+		{
+			name:           "custom dark choice is honored",
+			opts:           options{AutoThemeDark: "dracula", AutoThemeLight: "basic"},
+			darkBackground: true,
+			want:           "dracula",
+		},
+		{
+			name:           "custom light choice is honored",
+			opts:           options{AutoThemeDark: "dracula", AutoThemeLight: "basic"},
+			darkBackground: false,
+			want:           "basic",
+		},
+		{
+			name:           "empty custom dark choice falls back to default",
+			opts:           options{AutoThemeDark: "", AutoThemeLight: "basic"},
+			darkBackground: true,
+			want:           "revdiff",
+		},
+		{
+			name:           "empty custom light choice falls back to default",
+			opts:           options{AutoThemeDark: "dracula", AutoThemeLight: ""},
+			darkBackground: false,
+			want:           "catppuccin-latte",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveAutoThemeName(tt.opts, tt.darkBackground))
+		})
+	}
+}
+
 func TestHandleThemes_LoadThemeNotFound(t *testing.T) {
 	themesDir := filepath.Join(t.TempDir(), "themes")
 	cat := theme.NewCatalog(themesDir)

--- a/app/themes_test.go
+++ b/app/themes_test.go
@@ -372,6 +372,15 @@ func TestResolveAutoThemeName(t *testing.T) {
 	}
 }
 
+func TestResolveThemeName(t *testing.T) {
+	t.Run("concrete theme passes through unchanged", func(t *testing.T) {
+		assert.Equal(t, "dracula", resolveThemeName(options{Theme: "dracula"}))
+	})
+	t.Run("empty theme passes through unchanged", func(t *testing.T) {
+		assert.Empty(t, resolveThemeName(options{Theme: ""}))
+	})
+}
+
 func TestHandleThemes_LoadThemeNotFound(t *testing.T) {
 	themesDir := filepath.Join(t.TempDir(), "themes")
 	cat := theme.NewCatalog(themesDir)

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -38,7 +38,9 @@ Then uncomment and edit the values you want to change.
 | `--no-mouse` | `REVDIFF_NO_MOUSE` | Disable mouse support (scroll wheel, click) | `false` |
 | `--vim-motion` | `REVDIFF_VIM_MOTION` | Enable vim-style motion preset (counts, `gg`, `G`, `H`/`M`/`L`, `zz`/`zt`/`zb`, `ZZ`/`ZQ`) | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
-| `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/` | |
+| `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/`; use `auto` to choose by terminal background | |
+| `--auto-theme-dark` | `REVDIFF_AUTO_THEME_DARK` | Theme used by `--theme auto` on dark terminal backgrounds | `revdiff` |
+| `--auto-theme-light` | `REVDIFF_AUTO_THEME_LIGHT` | Theme used by `--theme auto` on light terminal backgrounds | `catppuccin-latte` |
 | `--dump-theme` | | Print currently resolved colors as theme file and exit | |
 | `--list-themes` | | Print available theme names and exit | |
 | `--init-themes` | | Write bundled theme files to themes dir and exit | |
@@ -76,6 +78,7 @@ Press `T` inside revdiff to open the interactive theme selector with live previe
 
 ```bash
 revdiff --theme dracula          # apply a theme
+revdiff --theme auto             # choose by terminal background
 revdiff --list-themes            # list available themes
 revdiff --init-themes            # re-create bundled themes
 revdiff --install-theme nord     # install a specific gallery theme
@@ -83,7 +86,7 @@ revdiff --init-all-themes        # install all gallery themes
 revdiff --dump-theme > ~/.config/revdiff/themes/my-custom  # export current colors
 ```
 
-Set default theme in config: `theme = dracula`. Or env: `REVDIFF_THEME=dracula`.
+Set default theme in config: `theme = dracula`. Or env: `REVDIFF_THEME=dracula`. Use `theme = auto` to query the terminal background and choose `auto-theme-dark` or `auto-theme-light`.
 
 **Custom themes:** customize colors in config or via `--color-*` flags, then `revdiff --dump-theme > ~/.config/revdiff/themes/my-custom`. Or copy a bundled theme file and edit directly — each has all 23 color keys + `chroma-style`.
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -412,7 +412,9 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>--no-mouse</code></td><td>Disable mouse support (scroll wheel, click)</td><td><code>false</code></td></tr>
                 <tr><td><code>--vim-motion</code></td><td>Enable vim-style motion preset (counts, <code>gg</code>, <code>G</code>, <code>H</code>/<code>M</code>/<code>L</code>, <code>zz</code>/<code>zt</code>/<code>zb</code>, <code>ZZ</code>/<code>ZQ</code>)</td><td><code>false</code></td></tr>
                 <tr><td><code>--chroma-style</code></td><td>Syntax highlighting theme</td><td><code>catppuccin-macchiato</code></td></tr>
-                <tr><td><code>--theme</code></td><td>Load color theme from <code>~/.config/revdiff/themes/</code></td><td></td></tr>
+                <tr><td><code>--theme</code></td><td>Load color theme from <code>~/.config/revdiff/themes/</code>; use <code>auto</code> to choose by terminal background</td><td></td></tr>
+                <tr><td><code>--auto-theme-dark</code></td><td>Theme used by <code>--theme auto</code> on dark terminal backgrounds</td><td><code>revdiff</code></td></tr>
+                <tr><td><code>--auto-theme-light</code></td><td>Theme used by <code>--theme auto</code> on light terminal backgrounds</td><td><code>catppuccin-latte</code></td></tr>
                 <tr><td><code>--dump-theme</code></td><td>Print resolved colors as theme file and exit</td><td></td></tr>
                 <tr><td><code>--list-themes</code></td><td>Print available theme names and exit</td><td></td></tr>
                 <tr><td><code>--init-themes</code></td><td>Write bundled theme files to themes dir and exit</td><td></td></tr>
@@ -443,12 +445,13 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
         <p>Eight bundled color themes: <strong>basic</strong>, <strong>catppuccin-latte</strong>, <strong>catppuccin-mocha</strong>, <strong>dracula</strong>, <strong>gruvbox</strong>, <strong>nord</strong>, <strong>revdiff</strong>, and <strong>solarized-dark</strong>. Stored in <code>~/.config/revdiff/themes/</code>, auto-created on first run.</p>
         <p>Press <code>T</code> inside revdiff to open the interactive theme selector with live preview &mdash; browse themes, see colors applied instantly, and persist your choice on confirm.</p>
         <div class="code-block"><code>revdiff --theme dracula          <span class="code-comment"># apply a theme</span>
+revdiff --theme auto             <span class="code-comment"># choose by terminal background</span>
 revdiff --list-themes            <span class="code-comment"># list available</span>
 revdiff --init-themes            <span class="code-comment"># re-create bundled themes</span>
 revdiff --install-theme nord     <span class="code-comment"># install a specific gallery theme</span>
 revdiff --init-all-themes        <span class="code-comment"># install all gallery themes</span>
 revdiff --dump-theme > ~/.config/revdiff/themes/my-custom</code></div>
-        <p>Set default in config: <code>theme = dracula</code>. Or env: <code>REVDIFF_THEME=dracula</code>.</p>
+        <p>Set default in config: <code>theme = dracula</code>. Or env: <code>REVDIFF_THEME=dracula</code>. Use <code>theme = auto</code> to choose by terminal background &mdash; <code>auto-theme-dark</code> / <code>auto-theme-light</code> (defaults <code>revdiff</code> / <code>catppuccin-latte</code>).</p>
         <h3>Creating custom themes</h3>
         <p>Two approaches:</p>
         <ol>


### PR DESCRIPTION
## Problem

Many users alternate between light and dark environments and use dark backgrounds sometimes and light backgrounds sometimes. Frequently the OS is set up to automatically switch between the two.

Revdiff currently only has a way to configure a single theme which means revdiff startup can often be jarring, especially if system is dark and revdiff is light.

I am one of these users and frequently do a "gah my eyes!" the first time I run revdiff after my system switches to dark mode.


## Solution

This adds a new special theme called `auto` and 2 new config flags `auto-theme-light` and `auto-theme-dark`. If `theme = auto`, we automatically resolve to either the light or dark theme depending on the terminal background color.

This is analogous to a similar feature in [hunk](https://github.com/modem-dev/hunk#config).


## ps

💛 revdiff is fantastic. Thanks for it!