### PR TITLE
feat(launch): add agterm overlay backend

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# launch revdiff in a terminal overlay (tmux/zellij/herdr/kitty/wezterm/cmux/ghostty/iterm2) and capture annotations.
+# launch revdiff in a terminal overlay (agterm/tmux/zellij/herdr/kitty/wezterm/cmux/ghostty/iterm2) and capture annotations.
 # usage: launch-revdiff.sh [ref] [--staged] [--untracked] [--only=file1 ...]
 # output: annotation text from revdiff stdout (empty if no annotations)
 # exit: 0 clean, 10 annotations captured, other nonzero failure
@@ -107,6 +107,20 @@ OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 # popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux, zellij, and wezterm)
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
+
+# agterm: `agtermctl session overlay open <cmd> --block` opens revdiff in a FULL-pane overlay (no
+# --size-percent) over the agent's own session and blocks until it exits, returning revdiff's exit
+# code directly — so, unlike the sentinel-polling backends below, no sentinel is needed. Checked
+# first so an agterm session always uses its native overlay even when a multiplexer is also present.
+# Needs $AGTERM_SESSION_ID (set in every agterm session) and agtermctl on PATH; passes the bound
+# $AGTERM_SOCKET so it reaches the agterm instance hosting this session.
+if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
+    AGTERM_ARGS=(agtermctl session overlay open "$REVDIFF_CMD" --target "$AGTERM_SESSION_ID" --block)
+    [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_ARGS+=(--socket "$AGTERM_SOCKET")
+    rc=0
+    "${AGTERM_ARGS[@]}" || rc=$?
+    print_output_and_exit "$rc"
+fi
 
 # agent-deck: its control-mode tmux UI cannot render display-popup, so when detected this sourced
 # backend runs revdiff in a tmux window instead and exits. It returns here (no-op) for every

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Priority: agterm → tmux → Zellij → herdr → kitty → wezterm/Kaku → cm
 > }
 > ```
 >
-> Terminals that use CLI tools instead of AppleScript (tmux, Zellij, herdr, kitty, wezterm, cmux) are not affected.
+> Terminals that use CLI tools instead of AppleScript (agterm, tmux, Zellij, herdr, kitty, wezterm, Kaku, cmux) are not affected.
 
 **Install:**
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The plugin requires one of the following terminals since Claude Code itself cann
 
 | Terminal | Overlay method | Detection |
 |----------|---------------|-----------|
+| **agterm** | `agtermctl session overlay open … --block` (full-pane overlay, blocks until quit) | `$AGTERM_SESSION_ID` env var |
 | **tmux** | `display-popup` (blocks until quit) | `$TMUX` env var |
 | **Zellij** | `zellij run --floating` | `$ZELLIJ` env var |
 | **herdr** | `herdr tab create` + `herdr pane run` (new tab) | `$HERDR_ENV` env var |
@@ -92,7 +93,7 @@ The plugin requires one of the following terminals since Claude Code itself cann
 | **iTerm2** | `osascript` split pane (macOS only) | `$ITERM_SESSION_ID` env var |
 | **Emacs vterm** | New frame via `emacsclient` | `$INSIDE_EMACS` env var |
 
-Priority: tmux → Zellij → herdr → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm (first detected wins). If none are available, the plugin exits with an error.
+Priority: agterm → tmux → Zellij → herdr → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm (first detected wins). If none are available, the plugin exits with an error.
 
 > **Note:** cmux is detected before ghostty when `$CMUX_SURFACE_ID` is set, `__CFBundleIdentifier=com.cmuxterm.app`, or `GHOSTTY_RESOURCES_DIR` / `GHOSTTY_BIN_DIR` contains `cmux.app`. The cmux block uses the cmux CLI (`new-split` + `send --surface`) instead of Ghostty's AppleScript API.
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -14,7 +14,7 @@ This directory contains the **Codex CLI** skills for revdiff.
 
 - `revdiff` binary — `brew install umputun/apps/revdiff` or download from [releases](https://github.com/umputun/revdiff/releases)
 - `jq` — required by the `revdiff-plan` skill for extracting messages from Codex rollout files
-- A supported terminal: tmux, Zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm
+- A supported terminal: agterm, tmux, Zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or Emacs vterm
 
 ## Install
 

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# launch revdiff in a terminal overlay (tmux/zellij/herdr/kitty/wezterm/cmux/ghostty/iterm2) and capture annotations.
+# launch revdiff in a terminal overlay (agterm/tmux/zellij/herdr/kitty/wezterm/cmux/ghostty/iterm2) and capture annotations.
 # source: .claude-plugin/skills/revdiff/scripts/launch-revdiff.sh (keep in sync)
 # usage: launch-revdiff.sh [ref] [--staged] [--untracked] [--only=file1 ...]
 # output: annotation text from revdiff stdout (empty if no annotations)
@@ -108,6 +108,20 @@ OVERLAY_TITLE="rd: ${DIR_NAME}${TITLE_REF:+ [$TITLE_REF]}"
 # popup size: override via REVDIFF_POPUP_WIDTH / REVDIFF_POPUP_HEIGHT env vars (tmux, zellij, and wezterm)
 POPUP_W="${REVDIFF_POPUP_WIDTH:-90%}"
 POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
+
+# agterm: `agtermctl session overlay open <cmd> --block` opens revdiff in a FULL-pane overlay (no
+# --size-percent) over the agent's own session and blocks until it exits, returning revdiff's exit
+# code directly — so, unlike the sentinel-polling backends below, no sentinel is needed. Checked
+# first so an agterm session always uses its native overlay even when a multiplexer is also present.
+# Needs $AGTERM_SESSION_ID (set in every agterm session) and agtermctl on PATH; passes the bound
+# $AGTERM_SOCKET so it reaches the agterm instance hosting this session.
+if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
+    AGTERM_ARGS=(agtermctl session overlay open "$REVDIFF_CMD" --target "$AGTERM_SESSION_ID" --block)
+    [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_ARGS+=(--socket "$AGTERM_SOCKET")
+    rc=0
+    "${AGTERM_ARGS[@]}" || rc=$?
+    print_output_and_exit "$rc"
+fi
 
 # agent-deck: its control-mode tmux UI cannot render display-popup, so when detected this sourced
 # backend runs revdiff in a tmux window instead and exits. It returns here (no-op) for every

--- a/site/docs.html
+++ b/site/docs.html
@@ -671,6 +671,7 @@ map alt+t&gt;n theme_select</code></div>
         <table>
             <thead><tr><th>Terminal</th><th>Overlay method</th><th>Detection</th></tr></thead>
             <tbody>
+                <tr><td><strong>agterm</strong></td><td><code>agtermctl session overlay open … --block</code> (full-pane overlay, blocks until quit)</td><td><code>$AGTERM_SESSION_ID</code></td></tr>
                 <tr><td><strong>tmux</strong></td><td><code>display-popup</code> (blocks until quit)</td><td><code>$TMUX</code></td></tr>
                 <tr><td><strong>zellij</strong></td><td><code>zellij run --floating</code></td><td><code>$ZELLIJ</code> env var</td></tr>
                 <tr><td><strong>herdr</strong></td><td><code>herdr tab create</code> + <code>herdr pane run</code> (new tab)</td><td><code>$HERDR_ENV</code></td></tr>
@@ -683,7 +684,7 @@ map alt+t&gt;n theme_select</code></div>
                 <tr><td><strong>Emacs vterm</strong></td><td>New frame via <code>emacsclient</code></td><td><code>$INSIDE_EMACS</code></td></tr>
             </tbody>
         </table>
-        <p>Priority: tmux &rarr; zellij &rarr; herdr &rarr; kitty &rarr; wezterm/kaku &rarr; cmux &rarr; ghostty &rarr; iTerm2 &rarr; Emacs vterm (first detected wins). cmux is checked before ghostty when <code>$CMUX_SURFACE_ID</code> is set, <code>__CFBundleIdentifier=com.cmuxterm.app</code>, or <code>GHOSTTY_RESOURCES_DIR</code> / <code>GHOSTTY_BIN_DIR</code> contains <code>cmux.app</code>. iTerm2 uses a split pane rather than a full-screen overlay.</p>
+        <p>Priority: agterm &rarr; tmux &rarr; zellij &rarr; herdr &rarr; kitty &rarr; wezterm/kaku &rarr; cmux &rarr; ghostty &rarr; iTerm2 &rarr; Emacs vterm (first detected wins). cmux is checked before ghostty when <code>$CMUX_SURFACE_ID</code> is set, <code>__CFBundleIdentifier=com.cmuxterm.app</code>, or <code>GHOSTTY_RESOURCES_DIR</code> / <code>GHOSTTY_BIN_DIR</code> contains <code>cmux.app</code>. iTerm2 uses a split pane rather than a full-screen overlay.</p>
         <p><strong>Sandbox note:</strong> Ghostty and iTerm2 launchers use <code>osascript</code> (Apple Events), which is blocked by Claude Code's sandbox. If you use these terminals with sandbox enabled, add the launcher to <code>excludedCommands</code> in your Claude Code <code>settings.json</code>:</p>
         <div class="code-block"><code>{ "permissions": { "excludedCommands": ["*/launch-revdiff.sh*"] } }</code></div>
         <p>Terminals that use CLI tools instead of AppleScript (tmux, Zellij, herdr, kitty, wezterm, cmux) are not affected.</p>

--- a/site/docs.html
+++ b/site/docs.html
@@ -687,7 +687,7 @@ map alt+t&gt;n theme_select</code></div>
         <p>Priority: agterm &rarr; tmux &rarr; zellij &rarr; herdr &rarr; kitty &rarr; wezterm/kaku &rarr; cmux &rarr; ghostty &rarr; iTerm2 &rarr; Emacs vterm (first detected wins). cmux is checked before ghostty when <code>$CMUX_SURFACE_ID</code> is set, <code>__CFBundleIdentifier=com.cmuxterm.app</code>, or <code>GHOSTTY_RESOURCES_DIR</code> / <code>GHOSTTY_BIN_DIR</code> contains <code>cmux.app</code>. iTerm2 uses a split pane rather than a full-screen overlay.</p>
         <p><strong>Sandbox note:</strong> Ghostty and iTerm2 launchers use <code>osascript</code> (Apple Events), which is blocked by Claude Code's sandbox. If you use these terminals with sandbox enabled, add the launcher to <code>excludedCommands</code> in your Claude Code <code>settings.json</code>:</p>
         <div class="code-block"><code>{ "permissions": { "excludedCommands": ["*/launch-revdiff.sh*"] } }</code></div>
-        <p>Terminals that use CLI tools instead of AppleScript (tmux, Zellij, herdr, kitty, wezterm, cmux) are not affected.</p>
+        <p>Terminals that use CLI tools instead of AppleScript (agterm, tmux, Zellij, herdr, kitty, wezterm, Kaku, cmux) are not affected.</p>
 
         <h2 id="plugin-usage">Plugin usage</h2>
         <h3>Slash commands</h3>


### PR DESCRIPTION
Adds agterm to the terminal overlay backends in `launch-revdiff.sh`, so a coding agent running inside an [agterm](https://github.com/umputun/agterm) session opens revdiff in a full-pane agterm overlay instead of falling through to a non-agterm backend.

**How it works.** When `$AGTERM_SESSION_ID` is set and `agtermctl` is on PATH, the launcher runs `agtermctl session overlay open "<revdiff cmd>" --target $AGTERM_SESSION_ID --block --socket $AGTERM_SOCKET`. The `--block` flag opens the overlay, blocks until revdiff exits, and returns revdiff's exit code directly, so unlike the kitty/zellij/herdr backends there is no sentinel file to poll. Full-pane mode is just omitting `--size-percent`. It is checked first in the priority chain, so an agterm session always uses its native overlay even when a multiplexer is also present.

**Docs and sync.** Backend table and priority updated in `README.md`, `site/docs.html`, and `plugins/codex/README.md`. Both `launch-revdiff.sh` copies (`.claude-plugin` and `plugins/codex`) stay byte-identical except the sync comment, and both pass shellcheck.

Verified by mocking `agtermctl`/`revdiff` on PATH: an agterm session builds the overlay command correctly (env prefix, `--output`, `--target`, `--block`, `--socket`), and a non-agterm session falls through unchanged.
