### PR TITLE
pi: add cwd support to revdiff_review

### DIFF
--- a/app/plugin_exit_code_test.go
+++ b/app/plugin_exit_code_test.go
@@ -376,6 +376,12 @@ async function testToolReturnsAnnotations(): Promise<void> {
 	}
 }
 
+function testReviewCwdExpansion(): void {
+	const base = process.cwd();
+	const resolvedHome = resolveReviewCwd("~/", base);
+	testAssert(resolvedHome === homedir(), "~/ should expand to the home directory");
+}
+
 async function testToolCwdParameter(): Promise<void> {
 	const tempDir = mkdtempSync(path.join(tmpdir(), "pi-revdiff-cwd-"));
 	const fakeBin = path.join(tempDir, "revdiff");
@@ -569,6 +575,7 @@ async function testStagedSmartDetection(): Promise<void> {
 
 await testCommandRoutesToSkill();
 await testToolReturnsAnnotations();
+testReviewCwdExpansion();
 await testToolCwdParameter();
 await testSignalTerminatedReviewFails();
 await testArgumentResolution();

--- a/app/plugin_exit_code_test.go
+++ b/app/plugin_exit_code_test.go
@@ -257,6 +257,7 @@ function assertArray(actual: string[], expected: string[], message: string): voi
 function fakeCtx(choice?: "uncommitted" | "branch") {
 	return {
 		hasUI: true,
+		cwd: process.cwd(),
 		isIdle: () => true,
 		ui: {
 			notifications: [] as string[],
@@ -319,6 +320,7 @@ function fakeRevdiffScript(): string {
 		"test -n \"$out\" || exit 22",
 		"printf '## src/app.go:12-14 (+)\\nfix it\\n' > \"$out\"",
 		"printf '%s\\n' \"$@\" > \"$FAKE_ARG_FILE\"",
+		"[ -z \"${FAKE_CWD_FILE:-}\" ] || pwd > \"$FAKE_CWD_FILE\"",
 		"exit 10",
 		"",
 	].join("\n");
@@ -374,6 +376,52 @@ async function testToolReturnsAnnotations(): Promise<void> {
 	}
 }
 
+async function testToolCwdParameter(): Promise<void> {
+	const tempDir = mkdtempSync(path.join(tmpdir(), "pi-revdiff-cwd-"));
+	const fakeBin = path.join(tempDir, "revdiff");
+	const targetRepo = path.join(tempDir, "repo with spaces");
+	const argFile = path.join(tempDir, "args.txt");
+	const cwdFile = path.join(tempDir, "cwd.txt");
+	writeExecutable(fakeBin, fakeRevdiffScript());
+	testMkdirSync(targetRepo, { recursive: true });
+	testWriteFileSync(path.join(targetRepo, "README.md"), "hello\n");
+
+	const oldBin = process.env.REVDIFF_BIN;
+	const oldArgFile = process.env.FAKE_ARG_FILE;
+	const oldCwdFile = process.env.FAKE_CWD_FILE;
+	process.env.REVDIFF_BIN = fakeBin;
+	process.env.FAKE_ARG_FILE = argFile;
+	process.env.FAKE_CWD_FILE = cwdFile;
+	try {
+		const pi = fakePi();
+		revdiffExtension(pi);
+		const result = await pi.tools.get("revdiff_review").execute("call-1", { args: "README.md", cwd: targetRepo }, undefined, undefined, fakeCtx());
+		const text = result.content[0].text;
+		testAssert(text.includes("Captured 1 annotation for README.md."), "cwd parameter should still review target file");
+		testAssert(readFileSync(cwdFile, "utf8").trim() === targetRepo, "revdiff should launch in requested directory");
+		const argText = readFileSync(argFile, "utf8");
+		testAssert(argText.includes("--only\nREADME.md\n"), "file target in requested directory should resolve to --only README.md");
+		testAssert(!argText.includes(targetRepo), "cwd parameter should not be passed as a revdiff argument");
+	} finally {
+		if (oldBin === undefined) {
+			delete process.env.REVDIFF_BIN;
+		} else {
+			process.env.REVDIFF_BIN = oldBin;
+		}
+		if (oldArgFile === undefined) {
+			delete process.env.FAKE_ARG_FILE;
+		} else {
+			process.env.FAKE_ARG_FILE = oldArgFile;
+		}
+		if (oldCwdFile === undefined) {
+			delete process.env.FAKE_CWD_FILE;
+		} else {
+			process.env.FAKE_CWD_FILE = oldCwdFile;
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
 async function testSignalTerminatedReviewFails(): Promise<void> {
 	const tempDir = mkdtempSync(path.join(tmpdir(), "pi-revdiff-signal-"));
 	const fakeBin = path.join(tempDir, "revdiff");
@@ -403,20 +451,21 @@ async function testSignalTerminatedReviewFails(): Promise<void> {
 }
 
 async function testArgumentResolution(): Promise<void> {
-	let launch = await resolveLaunchSpec("--output ignored --only 'docs/my plan.md'", fakeCtx());
+	const cwd = process.cwd();
+	let launch = await resolveLaunchSpec("--output ignored --only 'docs/my plan.md'", fakeCtx(), cwd);
 	testAssert(Boolean(launch), "expected launch after stripping --output");
 	assertArray(launch!.args, ["--only", "docs/my plan.md"], "--output stripping should preserve remaining args");
 	testAssert(launch!.label === "docs/my plan.md", "--only label should use target path");
 
-	launch = await resolveLaunchSpec("all-files exclude vendor and dist", fakeCtx());
+	launch = await resolveLaunchSpec("all-files exclude vendor and dist", fakeCtx(), cwd);
 	testAssert(Boolean(launch), "expected all-files shortcut launch");
 	assertArray(launch!.args, ["--all-files", "--exclude=vendor", "--exclude=dist"], "all-files shortcut should expand excludes");
 
-	launch = await resolveLaunchSpec("./docs/new-file.md", fakeCtx());
+	launch = await resolveLaunchSpec("./docs/new-file.md", fakeCtx(), cwd);
 	testAssert(Boolean(launch), "expected explicit path file launch");
 	assertArray(launch!.args, ["--only", "./docs/new-file.md"], "explicit path arg should map to --only");
 
-	launch = await resolveLaunchSpec("release/v1.2.3", fakeCtx());
+	launch = await resolveLaunchSpec("release/v1.2.3", fakeCtx(), cwd);
 	testAssert(Boolean(launch), "expected slash-dot token launch");
 	assertArray(launch!.args, ["release/v1.2.3"], "slash-dot token should stay a ref-like arg when path does not exist");
 
@@ -430,7 +479,7 @@ async function testRefLikePathArgKeepsRef(): Promise<void> {
 	try {
 		runGit(repo, ["checkout", "-b", "release/v1.2.3"]);
 		process.chdir(repo);
-		const launch = await resolveLaunchSpec("release/v1.2.3", fakeCtx());
+		const launch = await resolveLaunchSpec("release/v1.2.3", fakeCtx(), repo);
 		testAssert(Boolean(launch), "expected ref-like launch");
 		assertArray(launch!.args, ["release/v1.2.3"], "ref-like path arg should stay a ref when the git ref exists");
 		testAssert(launch!.label === "release/v1.2.3", "ref-like path label should stay the ref");
@@ -477,7 +526,7 @@ async function testNeedsAskWithoutMainStops(): Promise<void> {
 
 	try {
 		const ctx = fakeCtx();
-		const launch = await detectSmartLaunch(ctx);
+		const launch = await detectSmartLaunch(ctx, process.cwd());
 		testAssert(launch === undefined, "needsAsk without a main branch should not launch uncommitted review");
 		testAssert(
 			ctx.ui.notifications.some((message: string) => message.includes("Could not determine a revdiff target")),
@@ -495,8 +544,7 @@ async function testStagedSmartDetection(): Promise<void> {
 	try {
 		testWriteFileSync(path.join(mainRepo, "file.txt"), "main staged\n");
 		runGit(mainRepo, ["add", "file.txt"]);
-		process.chdir(mainRepo);
-		let launch = await detectSmartLaunch(fakeCtx());
+		let launch = await detectSmartLaunch(fakeCtx(), mainRepo);
 		testAssert(Boolean(launch), "expected staged launch on main");
 		assertArray(launch!.args, ["--staged"], "main staged-only should launch --staged");
 		testAssert(launch!.label === "staged changes", "main staged-only label should be staged changes");
@@ -504,12 +552,11 @@ async function testStagedSmartDetection(): Promise<void> {
 		runGit(featureRepo, ["checkout", "-b", "feature"]);
 		testWriteFileSync(path.join(featureRepo, "file.txt"), "feature staged\n");
 		runGit(featureRepo, ["add", "file.txt"]);
-		process.chdir(featureRepo);
-		launch = await detectSmartLaunch(fakeCtx("uncommitted"));
+		launch = await detectSmartLaunch(fakeCtx("uncommitted"), featureRepo);
 		testAssert(Boolean(launch), "expected dirty feature uncommitted launch");
 		assertArray(launch!.args, ["--staged"], "dirty feature uncommitted choice should launch --staged");
 
-		launch = await detectSmartLaunch(fakeCtx("branch"));
+		launch = await detectSmartLaunch(fakeCtx("branch"), featureRepo);
 		testAssert(Boolean(launch), "expected dirty feature branch launch");
 		assertArray(launch!.args, ["main"], "dirty feature branch choice should preserve branch diff");
 		testAssert(launch!.label === "feature vs main", "dirty feature branch label should identify main branch");
@@ -522,6 +569,7 @@ async function testStagedSmartDetection(): Promise<void> {
 
 await testCommandRoutesToSkill();
 await testToolReturnsAnnotations();
+await testToolCwdParameter();
 await testSignalTerminatedReviewFails();
 await testArgumentResolution();
 await testRefLikePathArgKeepsRef();

--- a/app/plugin_exit_code_test.go
+++ b/app/plugin_exit_code_test.go
@@ -198,7 +198,7 @@ func TestPiCallerPreservesAnnotationExitCode(t *testing.T) {
 	assert.Contains(t, src, "if (result.signal)")
 	assert.Contains(t, src, "done(result.status ?? 1)")
 	assert.Contains(t, src, "revdiff terminated by signal")
-	assert.Contains(t, src, "return buildResult(launch, rawOutput);")
+	assert.Contains(t, src, "return buildResult(launch, rawOutput, cwd);")
 }
 
 func TestPiExecutableRegressionHasCIBunSetup(t *testing.T) {
@@ -240,7 +240,7 @@ func piTypeboxStub() string {
 
 func piExtensionHarness() string {
 	return `
-import { chmodSync as testChmodSync, mkdirSync as testMkdirSync, writeFileSync as testWriteFileSync } from "node:fs";
+import { chmodSync as testChmodSync, mkdirSync as testMkdirSync, realpathSync as testRealpathSync, writeFileSync as testWriteFileSync } from "node:fs";
 
 function testAssert(condition: unknown, message: string): asserts condition {
 	if (!condition) {
@@ -376,10 +376,35 @@ async function testToolReturnsAnnotations(): Promise<void> {
 	}
 }
 
-function testReviewCwdExpansion(): void {
-	const base = process.cwd();
-	const resolvedHome = resolveReviewCwd("~/", base);
-	testAssert(resolvedHome === homedir(), "~/ should expand to the home directory");
+function testReviewCwdResolution(): void {
+	const base = mkdtempSync(path.join(tmpdir(), "pi-revdiff-cwd-base-"));
+	const child = path.join(base, "child");
+	testMkdirSync(child, { recursive: true });
+	try {
+		const resolvedHome = resolveReviewCwd("~/", base);
+		testAssert(resolvedHome === homedir(), "~/ should expand to the home directory");
+		testAssert(resolveReviewCwd("child", base) === child, "relative cwd should resolve against ctx cwd");
+	} finally {
+		rmSync(base, { recursive: true, force: true });
+	}
+}
+
+async function testToolRejectsInvalidCwd(): Promise<void> {
+	const tempDir = mkdtempSync(path.join(tmpdir(), "pi-revdiff-invalid-cwd-"));
+	const file = path.join(tempDir, "not-a-dir.txt");
+	testWriteFileSync(file, "not a directory\n");
+	try {
+		const pi = fakePi();
+		revdiffExtension(pi);
+		const fileResult = await pi.tools.get("revdiff_review").execute("call-1", { cwd: file }, undefined, undefined, fakeCtx());
+		testAssert(fileResult.content[0].text === "Could not resolve revdiff working directory.", "file cwd should return a clear error");
+		const missingResult = await pi.tools
+			.get("revdiff_review")
+			.execute("call-2", { cwd: path.join(tempDir, "missing") }, undefined, undefined, fakeCtx());
+		testAssert(missingResult.content[0].text === "Could not resolve revdiff working directory.", "missing cwd should return a clear error");
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
 }
 
 async function testToolCwdParameter(): Promise<void> {
@@ -404,10 +429,27 @@ async function testToolCwdParameter(): Promise<void> {
 		const result = await pi.tools.get("revdiff_review").execute("call-1", { args: "README.md", cwd: targetRepo }, undefined, undefined, fakeCtx());
 		const text = result.content[0].text;
 		testAssert(text.includes("Captured 1 annotation for README.md."), "cwd parameter should still review target file");
-		testAssert(readFileSync(cwdFile, "utf8").trim() === targetRepo, "revdiff should launch in requested directory");
-		const argText = readFileSync(argFile, "utf8");
+		testAssert(result.details.cwd === targetRepo, "tool details should preserve cwd for reruns");
+		testAssert(
+			testRealpathSync(readFileSync(cwdFile, "utf8").trim()) === testRealpathSync(targetRepo),
+			"revdiff should launch in requested directory",
+		);
+		let argText = readFileSync(argFile, "utf8");
 		testAssert(argText.includes("--only\nREADME.md\n"), "file target in requested directory should resolve to --only README.md");
 		testAssert(!argText.includes(targetRepo), "cwd parameter should not be passed as a revdiff argument");
+
+		rmSync(cwdFile, { force: true });
+		const rerun = await pi.tools
+			.get("revdiff_review")
+			.execute("call-2", { args: result.details.argsText, cwd: result.details.cwd }, undefined, undefined, fakeCtx());
+		testAssert(rerun.details.cwd === targetRepo, "rerun details should preserve cwd");
+		testAssert(
+			testRealpathSync(readFileSync(cwdFile, "utf8").trim()) === testRealpathSync(targetRepo),
+			"rerun should launch in requested directory",
+		);
+		argText = readFileSync(argFile, "utf8");
+		testAssert(argText.includes("--only\nREADME.md\n"), "rerun should use returned args with preserved cwd");
+		testAssert(!argText.includes(targetRepo), "rerun cwd should not be passed as a revdiff argument");
 	} finally {
 		if (oldBin === undefined) {
 			delete process.env.REVDIFF_BIN;
@@ -575,7 +617,8 @@ async function testStagedSmartDetection(): Promise<void> {
 
 await testCommandRoutesToSkill();
 await testToolReturnsAnnotations();
-testReviewCwdExpansion();
+testReviewCwdResolution();
+await testToolRejectsInvalidCwd();
 await testToolCwdParameter();
 await testSignalTerminatedReviewFails();
 await testArgumentResolution();

--- a/plugins/pi/extensions/revdiff.ts
+++ b/plugins/pi/extensions/revdiff.ts
@@ -25,6 +25,7 @@ interface AnnotationItem {
 interface ReviewResult {
 	args: string[];
 	argsText: string;
+	cwd: string;
 	label: string;
 	rawOutput: string;
 	annotations: AnnotationItem[];
@@ -279,13 +280,14 @@ async function runDirectReview(ctx: ExtensionContext, launch: LaunchSpec, cwd: s
 		return undefined;
 	}
 
-	return buildResult(launch, rawOutput);
+	return buildResult(launch, rawOutput, cwd);
 }
 
-function buildResult(launch: LaunchSpec, rawOutput: string): ReviewResult {
+function buildResult(launch: LaunchSpec, rawOutput: string, cwd: string): ReviewResult {
 	return {
 		args: [...launch.args],
 		argsText: shellJoin(launch.args),
+		cwd,
 		label: launch.label,
 		rawOutput,
 		annotations: parseAnnotations(rawOutput),

--- a/plugins/pi/extensions/revdiff.ts
+++ b/plugins/pi/extensions/revdiff.ts
@@ -138,7 +138,7 @@ function expandHome(value: string): string {
 	if (value === "~") {
 		return homedir();
 	}
-	if (value.startsWith(`~${path.sep}`)) {
+	if (value.startsWith("~/") || value.startsWith("~\\")) {
 		return path.join(homedir(), value.slice(2));
 	}
 	return value;

--- a/plugins/pi/extensions/revdiff.ts
+++ b/plugins/pi/extensions/revdiff.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -72,19 +72,29 @@ export default function revdiffExtension(pi: ExtensionAPI): void {
 						"Optional revdiff arguments as a shell-like string, for example 'main', '--staged', '--only README.md', or '--all-files --exclude vendor'. Omit for smart detection.",
 				}),
 			),
+			cwd: Type.Optional(
+				Type.String({
+					description: "Optional working directory for revdiff and git target resolution. Defaults to the current working directory.",
+				}),
+			),
 		}),
 		async execute(_toolCallId, params, _signal, onUpdate, ctx) {
 			if (!ctx.hasUI) {
 				return toolTextResult("revdiff_review requires the interactive pi TUI.");
 			}
 
-			const launch = await resolveLaunchSpec(params.args?.trim() ?? "", ctx);
+			const cwd = resolveReviewCwd(params.cwd, ctx.cwd);
+			if (!cwd) {
+				return toolTextResult("Could not resolve revdiff working directory.");
+			}
+
+			const launch = await resolveLaunchSpec(params.args?.trim() ?? "", ctx, cwd);
 			if (!launch) {
 				return toolTextResult("Could not resolve a revdiff launch target.");
 			}
 
-			onUpdate?.({ content: [{ type: "text", text: `Launching revdiff for ${launch.label}...` }], details: null });
-			const result = await runDirectReview(ctx, launch);
+			onUpdate?.({ content: [{ type: "text", text: `Launching revdiff for ${launch.label} in ${cwd}...` }], details: null });
+			const result = await runDirectReview(ctx, launch, cwd);
 			if (!result) {
 				return toolTextResult("revdiff review did not complete.");
 			}
@@ -111,15 +121,38 @@ function skillCommand(rawArgs: string): string {
 	return trimmed ? `/skill:revdiff ${trimmed}` : "/skill:revdiff";
 }
 
-async function resolveLaunchSpec(rawArgs: string, ctx: ExtensionContext): Promise<LaunchSpec | undefined> {
+function resolveReviewCwd(rawCwd: string | undefined, baseCwd: string): string | undefined {
+	const expanded = expandHome(rawCwd?.trim() || baseCwd);
+	const resolved = path.resolve(baseCwd, expanded);
+	try {
+		if (!statSync(resolved).isDirectory()) {
+			return undefined;
+		}
+	} catch {
+		return undefined;
+	}
+	return resolved;
+}
+
+function expandHome(value: string): string {
+	if (value === "~") {
+		return homedir();
+	}
+	if (value.startsWith(`~${path.sep}`)) {
+		return path.join(homedir(), value.slice(2));
+	}
+	return value;
+}
+
+async function resolveLaunchSpec(rawArgs: string, ctx: ExtensionContext, cwd: string): Promise<LaunchSpec | undefined> {
 	const trimmed = rawArgs.trim();
 	if (!trimmed) {
-		return detectSmartLaunch(ctx);
+		return detectSmartLaunch(ctx, cwd);
 	}
 
 	const split = shellSplit(trimmed);
 	if (split.length === 0) {
-		return detectSmartLaunch(ctx);
+		return detectSmartLaunch(ctx, cwd);
 	}
 
 	const allFiles = parseAllFilesShortcut(split.join(" "));
@@ -133,7 +166,7 @@ async function resolveLaunchSpec(rawArgs: string, ctx: ExtensionContext): Promis
 		return undefined;
 	}
 
-	if (tokens.length === 1 && isFileReviewArg(tokens[0]!)) {
+	if (tokens.length === 1 && isFileReviewArg(tokens[0]!, cwd)) {
 		const target = tokens[0]!;
 		return { args: ["--only", target], label: target };
 	}
@@ -141,8 +174,8 @@ async function resolveLaunchSpec(rawArgs: string, ctx: ExtensionContext): Promis
 	return { args: tokens, label: describeArgs(tokens) };
 }
 
-async function detectSmartLaunch(ctx: ExtensionContext): Promise<LaunchSpec | undefined> {
-	const detected = detectSmartRef();
+async function detectSmartLaunch(ctx: ExtensionContext, cwd: string): Promise<LaunchSpec | undefined> {
+	const detected = detectSmartRef(cwd);
 	if (!detected) {
 		ctx.ui.notify("Not inside a supported VCS repo or smart detection is unavailable. Use /revdiff --only <file> to review a standalone file.", "warning");
 		return undefined;
@@ -184,7 +217,7 @@ function uncommittedLaunchSpec(detected: SmartDetectResult): LaunchSpec {
 	return { args: [], label: "uncommitted changes" };
 }
 
-async function runDirectReview(ctx: ExtensionContext, launch: LaunchSpec): Promise<ReviewResult | undefined> {
+async function runDirectReview(ctx: ExtensionContext, launch: LaunchSpec, cwd: string): Promise<ReviewResult | undefined> {
 	const revdiffBin = resolveRevdiffBin();
 	if (!revdiffBin) {
 		ctx.ui.notify("revdiff binary not found. Install it or set REVDIFF_BIN.", "error");
@@ -201,7 +234,7 @@ async function runDirectReview(ctx: ExtensionContext, launch: LaunchSpec): Promi
 		tui.stop();
 		process.stdout.write("\x1b[2J\x1b[H");
 		const result = spawnSync(revdiffBin, commandArgs, {
-			cwd: process.cwd(),
+			cwd,
 			env: withAnnotationExitCode(process.env),
 			stdio: "inherit",
 		});
@@ -398,11 +431,11 @@ function sanitizeArgs(args: string[]): string[] {
 	return sanitized;
 }
 
-function isFileReviewArg(arg: string): boolean {
+function isFileReviewArg(arg: string, cwd: string): boolean {
 	if (arg.startsWith("-")) {
 		return false;
 	}
-	if (existsSync(path.resolve(arg))) {
+	if (existsSync(path.resolve(cwd, arg))) {
 		return true;
 	}
 	return arg.startsWith("/") || arg.startsWith("./") || arg.startsWith("../");
@@ -503,15 +536,15 @@ function findInPath(binary: string): string | undefined {
 	return undefined;
 }
 
-function detectSmartRef(): SmartDetectResult | undefined {
-	return runDetectRefScript() ?? detectSmartRefFallback();
+function detectSmartRef(cwd: string): SmartDetectResult | undefined {
+	return runDetectRefScript(cwd) ?? detectSmartRefFallback(cwd);
 }
 
-function runDetectRefScript(): SmartDetectResult | undefined {
+function runDetectRefScript(cwd: string): SmartDetectResult | undefined {
 	if (!existsSync(DETECT_REF_SCRIPT)) {
 		return undefined;
 	}
-	const result = spawnSync(DETECT_REF_SCRIPT, [], { cwd: process.cwd(), encoding: "utf8" });
+	const result = spawnSync(DETECT_REF_SCRIPT, [], { cwd, encoding: "utf8" });
 	if ((result.status ?? 1) !== 0) {
 		return undefined;
 	}
@@ -539,16 +572,16 @@ function runDetectRefScript(): SmartDetectResult | undefined {
 	};
 }
 
-function detectSmartRefFallback(): SmartDetectResult | undefined {
-	if (gitStdout(["rev-parse", "--is-inside-work-tree"]) !== "true") {
+function detectSmartRefFallback(cwd: string): SmartDetectResult | undefined {
+	if (gitStdout(["rev-parse", "--is-inside-work-tree"], cwd) !== "true") {
 		return undefined;
 	}
 
 	// detect no-commits state (fresh repo after git init)
-	const hasCommits = gitOk(["rev-parse", "HEAD"]);
-	const hasUncommitted = gitStdout(["status", "--porcelain"]).trim().length > 0;
-	const hasUnstaged = !gitOk(["diff", "--quiet"]);
-	const hasStaged = !gitOk(["diff", "--cached", "--quiet"]);
+	const hasCommits = gitOk(["rev-parse", "HEAD"], cwd);
+	const hasUncommitted = gitStdout(["status", "--porcelain"], cwd).trim().length > 0;
+	const hasUnstaged = !gitOk(["diff", "--quiet"], cwd);
+	const hasStaged = !gitOk(["diff", "--cached", "--quiet"], cwd);
 	const useStaged = hasUncommitted && hasStaged && !hasUnstaged;
 
 	if (!hasCommits) {
@@ -563,8 +596,8 @@ function detectSmartRefFallback(): SmartDetectResult | undefined {
 		};
 	}
 
-	const branch = gitStdout(["rev-parse", "--abbrev-ref", "HEAD"]) || "HEAD";
-	const mainBranch = detectMainBranch();
+	const branch = gitStdout(["rev-parse", "--abbrev-ref", "HEAD"], cwd) || "HEAD";
+	const mainBranch = detectMainBranch(cwd);
 	const isMain = Boolean(mainBranch) && branch === mainBranch;
 	let suggestedRef = "";
 	let needsAsk = false;
@@ -580,28 +613,28 @@ function detectSmartRefFallback(): SmartDetectResult | undefined {
 	return { branch, mainBranch, isMain, hasUncommitted, useStaged, suggestedRef, needsAsk };
 }
 
-function detectMainBranch(): string {
-	const remoteHead = gitStdout(["symbolic-ref", "refs/remotes/origin/HEAD"]);
+function detectMainBranch(cwd: string): string {
+	const remoteHead = gitStdout(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd);
 	if (remoteHead.startsWith("refs/remotes/origin/")) {
 		return remoteHead.slice("refs/remotes/origin/".length);
 	}
-	if (gitOk(["show-ref", "--verify", "--quiet", "refs/heads/master"])) {
+	if (gitOk(["show-ref", "--verify", "--quiet", "refs/heads/master"], cwd)) {
 		return "master";
 	}
-	if (gitOk(["show-ref", "--verify", "--quiet", "refs/heads/main"])) {
+	if (gitOk(["show-ref", "--verify", "--quiet", "refs/heads/main"], cwd)) {
 		return "main";
 	}
 	return "";
 }
 
-function gitStdout(args: string[]): string {
-	const result = spawnSync("git", args, { cwd: process.cwd(), encoding: "utf8" });
+function gitStdout(args: string[], cwd: string): string {
+	const result = spawnSync("git", args, { cwd, encoding: "utf8" });
 	if ((result.status ?? 1) !== 0) {
 		return "";
 	}
 	return (result.stdout ?? "").trim();
 }
 
-function gitOk(args: string[]): boolean {
-	return (spawnSync("git", args, { cwd: process.cwd(), stdio: "ignore" }).status ?? 1) === 0;
+function gitOk(args: string[], cwd: string): boolean {
+	return (spawnSync("git", args, { cwd, stdio: "ignore" }).status ?? 1) === 0;
 }

--- a/plugins/pi/skills/revdiff/SKILL.md
+++ b/plugins/pi/skills/revdiff/SKILL.md
@@ -56,7 +56,7 @@ When annotations arrive from `/revdiff` or `revdiff_review`:
    - `Done with review` — stop
 5. Before editing repository files, list the planned file/code changes.
 6. Apply code-change directives.
-7. Rerun the original `revdiff_review` target only after repository files changed or when the user chooses to continue reviewing.
+7. Rerun the original `revdiff_review` target only after repository files changed or when the user chooses to continue reviewing; preserve the original `cwd` parameter when one was used.
 8. Add `--untracked` on reruns when agent-created files should be included.
 
 ## User commands

--- a/plugins/pi/skills/revdiff/SKILL.md
+++ b/plugins/pi/skills/revdiff/SKILL.md
@@ -17,6 +17,7 @@ When the user invokes `/skill:revdiff <input>`, treat `<input>` as a request to 
 Reference resolution rules:
 
 - Accept natural language. Resolve the user's requested target to concrete revdiff args before launching.
+- If the request identifies another working directory (for example `in ~/source/repo`), use that directory for any git/ref/path resolution, omit that directory phrase from the revdiff args, and pass the directory as the `revdiff_review` tool's `cwd` parameter.
 - For commit-count requests, use the matching git rev: `prev commit`, `previous commit`, `last commit` → `HEAD~1`; `head-3`, `head 3`, `HEAD~3`, `previous 3 commits`, `last 3 commits` → `HEAD~3`.
 - For tag requests, resolve the actual tag first. `last tag` or `latest tag` → run `git describe --tags --abbrev=0`, then pass that tag as `args`.
 - For date requests, resolve the commit first. Examples: `2 weeks ago`, `yesterday`, `last Friday` → run `git rev-list -1 --before=<phrase> HEAD`, then pass the resulting commit hash as `args`.
@@ -36,6 +37,7 @@ Tool examples:
 - `args: "--description='why this refactor matters' main"`: include review context in the info popup
 - `args: "--description-file=/tmp/revdiff-desc.md main"`: include longer markdown review context
 - `args: "--annotations=/tmp/revdiff-review.md main"`: preload in-session review notes
+- `args: "main", cwd: "~/source/repo"`: run revdiff from a specific working directory when the session was started elsewhere.
 - `args: "--stdin"` with a unified diff piped to stdin (e.g. `gh pr diff 123`, `git format-patch -1 --stdout`, a `.patch` file): review a multi-file diff that lives outside the working tree — revdiff parses it as a real diff (one tree entry per file, hunk navigation, per-file annotations) instead of a context-only buffer
 
 After `revdiff_review` returns annotations, address them directly from the tool result content. Do not read revdiff history after a successful captured-annotation result. Exit code `10` is success-with-annotations and is handled by the extension; do not report it as a failure. If it returns no annotations, report that no annotations were captured and stop. Do not relaunch revdiff after any no-annotation result unless the user explicitly asks for another review.


### PR DESCRIPTION
## Problem

`revdiff_review` currently resolves smart detection, file shorthand, and the final `revdiff` launch from the Pi session working directory. That breaks agent-driven reviews when Pi is running from one directory but the requested review target lives in another repository: smart detection checks the wrong repo, file shorthand is resolved against the wrong path, and revdiff launches in the wrong tree.

## Solution

Add an optional structured `cwd` parameter to the Pi `revdiff_review` tool and thread the resolved directory through target detection, file target resolution, `detect-ref.sh`, fallback git detection, and the final `revdiff` process launch.

The parameter defaults to Pi's `ctx.cwd`, supports leading `~`, and is validated as an existing directory before launch. The skill guidance now tells the agent to translate natural directory requests (for example, “review main in ~/source/repo”) into the tool's `cwd` parameter rather than passing directory wording through as revdiff args.

This keeps the behavior at the Pi tool boundary; it does not add a new `revdiff` CLI flag.
