### PR TITLE
agterm overlay: use launcher cwd + flag blocked status

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -113,12 +113,21 @@ POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 # code directly — so, unlike the sentinel-polling backends below, no sentinel is needed. Checked
 # first so an agterm session always uses its native overlay even when a multiplexer is also present.
 # Needs $AGTERM_SESSION_ID (set in every agterm session) and agtermctl on PATH; passes the bound
-# $AGTERM_SOCKET so it reaches the agterm instance hosting this session.
+# $AGTERM_SOCKET so it reaches the agterm instance hosting this session. Passes --cwd "$CWD" so the
+# overlay runs in the launcher's working directory (e.g. a PR worktree) instead of agtermctl's
+# default of the agent session's current directory. Sets the session's agent-status indicator to
+# blocked (blinking) while the overlay is up and back to active after, since claude code does not
+# flag the session blocked while revdiff owns the overlay.
 if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
-    AGTERM_ARGS=(agtermctl session overlay open "$REVDIFF_CMD" --target "$AGTERM_SESSION_ID" --block)
-    [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_ARGS+=(--socket "$AGTERM_SOCKET")
+    # shared target (+ socket) for every agtermctl call in this branch
+    AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
+    [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
+    # claude code does not flag the session blocked while revdiff owns the overlay, so set it here
+    # (blocked + blink draws attention from other windows); restore active once revdiff exits.
+    agtermctl session status blocked --blink "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
     rc=0
-    "${AGTERM_ARGS[@]}" || rc=$?
+    agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" --cwd "$CWD" --block || rc=$?
+    agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
     print_output_and_exit "$rc"
 fi
 

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -123,11 +123,14 @@ if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
     AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
     [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
     # claude code does not flag the session blocked while revdiff owns the overlay, so set it here
-    # (blocked + blink draws attention from other windows); restore active once revdiff exits.
+    # (blocked + blink draws attention from other windows). the EXIT trap restores active on every
+    # exit path, and INT/TERM exit through it, so an interrupt never leaves the indicator stuck.
     agtermctl session status blocked --blink "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
+    trap 'agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
     rc=0
     agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" --cwd "$CWD" --block || rc=$?
-    agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
     print_output_and_exit "$rc"
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,8 @@ TUI for reviewing diffs, files, and documents with inline annotations, built wit
 ## Claude Code Plugin
 - Plugin lives at `.claude-plugin/` with `plugin.json`, `marketplace.json`, and `skills/`
 - Skills path in `plugin.json` is relative to repo root, not to `.claude-plugin/`
-- **CRITICAL: After any plugin file change, ask user if they want to bump the plugin version**
-- When bumping, update version in both `plugin.json` and `marketplace.json`
+- **CRITICAL: Version bumps happen at release only — never per-PR or per-change.** Do NOT prompt to bump `plugin.json` / `marketplace.json` after a plugin file change; the bump is done as part of the release process.
+- When bumping at release, update version in both `plugin.json` and `marketplace.json`
 - **CRITICAL: Defer plugin version bumps when the change depends on a new binary feature.** If a plugin/launcher change relies on a `revdiff` binary feature, flag, env var, or exit code that is not yet in a tagged release, do NOT bump `plugin.json` / `marketplace.json` / `package.json` on the feature branch. The plugin (marketplace) and the binary (brew / `go install`) version independently — bumping the plugin early ships an updated launcher to users still running an old binary, causing a hard mismatch (e.g. the launcher passes an unknown flag, the old binary exits 1, every plugin-triggered review fails). Bump plugin/package versions as part of the binary version release, after the binary is tagged.
 - Reference docs at `.claude-plugin/skills/revdiff/references/` — keep in sync with README.md:
   - `install.md` — installation methods and plugin setup
@@ -84,7 +84,7 @@ TUI for reviewing diffs, files, and documents with inline annotations, built wit
 - Pi package defined in root `package.json`, extensions and skills in `plugins/pi/`
 - Pi review path is direct-terminal only: `/revdiff [args]` suspends pi, runs the `revdiff` binary directly, and sends captured annotations to the agent immediately. There is no Pi overlay mode, pending annotation widget/panel, `/revdiff-rerun`, `/revdiff-results`, `/revdiff-apply`, `/revdiff-clear`, or default post-edit reminder command.
 - Pi ships its own copy of `detect-ref.sh` at `plugins/pi/scripts/detect-ref.sh` (source-of-truth is `.claude-plugin/skills/revdiff/scripts/detect-ref.sh` — keep in sync, same pattern as the codex copy). The pi extension resolves the script relative to its own plugin root, never via `.claude-plugin/`; the pi package must stay installable standalone with no Claude plugin files present. Do not re-add `launch-revdiff.sh` to the Pi package surface unless the workflow is explicitly changed.
-- **CRITICAL: After any pi plugin file change, ask user if they want to bump the version in `package.json`**
+- **CRITICAL: Version bumps happen at release only — never per-PR or per-change.** Do NOT prompt to bump `package.json` after a pi plugin file change; the bump is done as part of the release process.
 - Version in `package.json` is independently versioned (does not track the project's git tags)
 
 ## Gotchas

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -114,12 +114,21 @@ POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 # code directly — so, unlike the sentinel-polling backends below, no sentinel is needed. Checked
 # first so an agterm session always uses its native overlay even when a multiplexer is also present.
 # Needs $AGTERM_SESSION_ID (set in every agterm session) and agtermctl on PATH; passes the bound
-# $AGTERM_SOCKET so it reaches the agterm instance hosting this session.
+# $AGTERM_SOCKET so it reaches the agterm instance hosting this session. Passes --cwd "$CWD" so the
+# overlay runs in the launcher's working directory (e.g. a PR worktree) instead of agtermctl's
+# default of the agent session's current directory. Sets the session's agent-status indicator to
+# blocked (blinking) while the overlay is up and back to active after, since claude code does not
+# flag the session blocked while revdiff owns the overlay.
 if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
-    AGTERM_ARGS=(agtermctl session overlay open "$REVDIFF_CMD" --target "$AGTERM_SESSION_ID" --block)
-    [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_ARGS+=(--socket "$AGTERM_SOCKET")
+    # shared target (+ socket) for every agtermctl call in this branch
+    AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
+    [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
+    # claude code does not flag the session blocked while revdiff owns the overlay, so set it here
+    # (blocked + blink draws attention from other windows); restore active once revdiff exits.
+    agtermctl session status blocked --blink "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
     rc=0
-    "${AGTERM_ARGS[@]}" || rc=$?
+    agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" --cwd "$CWD" --block || rc=$?
+    agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
     print_output_and_exit "$rc"
 fi
 

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -124,11 +124,14 @@ if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
     AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
     [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
     # claude code does not flag the session blocked while revdiff owns the overlay, so set it here
-    # (blocked + blink draws attention from other windows); restore active once revdiff exits.
+    # (blocked + blink draws attention from other windows). the EXIT trap restores active on every
+    # exit path, and INT/TERM exit through it, so an interrupt never leaves the indicator stuck.
     agtermctl session status blocked --blink "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
+    trap 'agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
     rc=0
     agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" --cwd "$CWD" --block || rc=$?
-    agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
     print_output_and_exit "$rc"
 fi
 


### PR DESCRIPTION
two agterm-backend fixes to the overlay launcher, plus a docs note.

**overlay used the wrong directory.** The agterm branch called `agtermctl session overlay open` without `--cwd`, so the overlay opened in the agent session's cwd instead of the dir the launcher ran from. Worktree-based reviews (e.g. a PR review against a git worktree) showed the wrong repo. Every other backend already forwards `$CWD`; agterm now passes `--cwd "$CWD"`.

**no blocked indicator while revdiff is open.** Claude Code doesn't flag the session blocked while revdiff owns the overlay, so the launcher now sets the agent-status indicator to `blocked` (blinking) while the overlay is up and back to `active` after, via `agtermctl session status`.

both fixes touch the `.claude-plugin` and `plugins/codex` launcher copies (kept in sync). The agterm branch needs `agtermctl` to run, so no unit test; verified manually against a worktree.

separate commit: a `CLAUDE.md` note that plugin/pi version bumps happen at release only, not per file change.
