### PR TITLE
fix(revdiff-planning): use percentage pane size for zellij plan review

### DIFF
--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -123,13 +123,13 @@ LAUNCHER
     fi
 
     if [ -n "$ZELLIJ_ORIG_TAB_ID" ] && zellij run --floating --close-on-exit --tab-id "$ZELLIJ_ORIG_TAB_ID" \
-            --width 90 --height 90 \
+            --width 90% --height 90% \
             --name "$OVERLAY_TITLE" \
             -- "$LAUNCH_SCRIPT" >/dev/null 2>&1; then
         :
     else
         zellij run --floating --close-on-exit \
-            --width 90 --height 90 \
+            --width 90% --height 90% \
             --name "$OVERLAY_TITLE" \
             -- "$LAUNCH_SCRIPT" >/dev/null 2>&1
     fi


### PR DESCRIPTION
Hi, I did read the contributing guide, but given this is a tiny mechanical bugfix I didn't think it fell in line with the spirit of the open an issue first rule.  If that's a bad assumption on my part let me know, I'm happy to create an issue and link this PR to it.

## What is the problem?

When `revdiff-planning` opens a plan for review inside **Zellij**, the floating pane is a tall, skinny column instead of the intended ~90% overlay.

Root cause: in `plugins/revdiff-planning/scripts/launch-plan-review.sh`, the zellij branch passes `--width 90 --height 90` to `zellij run`. Per `zellij run --help`, `--width`/`--height` treat a **bare integer as a fixed cell count**, not a percentage:

```
--height <HEIGHT>   The height if the pane is floating as a bare integer (eg. 1) or percent (eg. 10%)
--width  <WIDTH>    The width if the pane is floating as a bare integer (eg. 1) or percent (eg. 10%)
```

The `tmux` branch of this same script already uses `-w 90% -h 90%`, and the main `launch-revdiff.sh` passes `--width 90% --height 90%` (via `$POPUP_W`/`$POPUP_H`) — so only the plan-review zellij path is affected.

## How does this solve it?

Add the `%` so both `zellij run` invocations pass `--width 90% --height 90%`.

