### PR TITLE
feat(ui): filter unreviewed files

### DIFF
--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -31,7 +31,7 @@ some-command | revdiff --stdin --output /tmp/annotations.txt      # annotate gen
 
 ## Single-File Mode
 
-When a diff contains exactly one file, revdiff automatically hides the file tree pane and gives full terminal width to the diff view. Pane-switching keys (`Tab`, `h/l`, `n/p`, `f`) become no-ops, except when markdown TOC is active (see below). Search navigation (`n`/`N`) still works normally.
+When a diff contains exactly one file, revdiff automatically hides the file tree pane and gives full terminal width to the diff view. Pane-switching keys (`Tab`, `h/l`, `n/p`, `f`, `F`) become no-ops, except when markdown TOC is active (see below). Search navigation (`n`/`N`) still works normally.
 
 ## Markdown TOC Navigation
 
@@ -160,7 +160,7 @@ Press `e` in the diff pane to open the focused file in `$EDITOR` (`open_file_in_
 
 Press `O` to write the current annotations to the `--output` file without exiting (`flush_output` — rebindable). This keeps revdiff open while handing the file to an AI agent: annotate, flush with `O`, let the agent read the file and edit code, then reload with `R` and continue in the same session. Each flush overwrites the file with the full current annotation set (a snapshot, not an append log), using the same atomic write as a normal quit. `O` requires `-o`/`--output`; with no output file, or with no annotations yet, it shows a status hint and writes nothing.
 
-Press `Space` to mark the focused file reviewed. On `R` reload, revdiff keeps the mark only when the file's effective text diff is unchanged; rebases that only shift line numbers or surrounding context keep it, while changed or removed files lose it. Binary files and opaque placeholders are conservatively unmarked on reload because their rendered diff does not expose enough content to prove they are unchanged.
+Press `Space` to mark the focused file reviewed. Press `F` to toggle the sidebar between all files and unreviewed files; while filtered, marking a file reviewed removes it from the list and advances to the next unfinished file. On `R` reload, revdiff keeps the mark only when the file's effective text diff is unchanged; rebases that only shift line numbers or surrounding context keep it, while changed or removed files lose it. Binary files and opaque placeholders are conservatively unmarked on reload because their rendered diff does not expose enough content to prove they are unchanged.
 
 **View:**
 
@@ -176,6 +176,7 @@ Press `Space` to mark the focused file reviewed. On `R` reload, revdiff keeps th
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
 | `f` | Toggle filter: all files / annotated only |
+| `F` | Toggle filter: all files / unreviewed only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle info popup — review scope (mode, VCS, ref, filters, file/status counts, aggregate `+/-` stats) plus the commit log for the current ref range when applicable |
 | `R` | Reload diff from VCS (warns if annotations exist) |
@@ -197,7 +198,7 @@ The status bar shows a fixed row of mode indicators on the right side. All slots
 | `#` | `L` | Line numbers visible in gutter |
 | `b` | `B` | Blame gutter visible |
 | `±` | `W` | Intra-line word-diff highlighting |
-| `✓` | `Space` | Reviewed count (revalidated on reload) |
+| `✓` / `○` | `Space` / `F` | Reviewed files / unreviewed-only filter active |
 | `∅` | `u` | Untracked files visible in tree |
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ Press `e` in the diff pane to open the focused file in `$EDITOR` (`open_file_in_
 
 Press `O` to write the current annotations to the `--output` file without exiting (`flush_output` — rebindable). This keeps revdiff open while handing the file to an AI agent: annotate, flush with `O`, let the agent read the file and edit code, then reload with `R` and continue in the same session. Each flush overwrites the file with the full current annotation set (a snapshot, not an append log), using the same atomic write as a normal quit. `O` requires `-o`/`--output`; with no output file, or with no annotations yet, it shows a status hint and writes nothing.
 
-Press `Space` to mark the focused file reviewed. On `R` reload, revdiff keeps the mark only when the file's effective text diff is unchanged; rebases that only shift line numbers or surrounding context keep it, while changed or removed files lose it. Binary files and opaque placeholders are conservatively unmarked on reload because their rendered diff does not expose enough content to prove they are unchanged.
+Press `Space` to mark the focused file reviewed. Press `F` to toggle the sidebar between all files and unreviewed files; while filtered, marking a file reviewed removes it from the list and advances to the next unfinished file. On `R` reload, revdiff keeps the mark only when the file's effective text diff is unchanged; rebases that only shift line numbers or surrounding context keep it, while changed or removed files lose it. Binary files and opaque placeholders are conservatively unmarked on reload because their rendered diff does not expose enough content to prove they are unchanged.
 
 **View:**
 
@@ -745,6 +745,7 @@ Press `Space` to mark the focused file reviewed. On `R` reload, revdiff keeps th
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
 | `f` | Toggle filter: all files / annotated only (shown when annotations exist) |
+| `F` | Toggle filter: all files / unreviewed only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle info popup — review scope (mode, VCS, ref, filters, file/status counts, aggregate `+/-` stats) plus the commit log for the current ref range when applicable |
 | `R` | Reload diff from VCS (warns if annotations exist) |
@@ -766,7 +767,7 @@ The status bar shows a fixed row of mode indicators on the right side. All slots
 | `#` | `L` | Line numbers visible in gutter |
 | `b` | `B` | Blame gutter visible |
 | `±` | `W` | Intra-line word-diff highlighting |
-| `✓` | `Space` | Reviewed count (revalidated on reload) |
+| `✓` / `○` | `Space` / `F` | Reviewed files / unreviewed-only filter active |
 | `∅` | `u` | Untracked files visible in tree |
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.
@@ -846,7 +847,7 @@ When the leader is pressed, the status bar shows `Pending: ctrl+w, esc to cancel
 
 **Annotations:** `confirm` (annotate line / select file), `annotate_file`, `delete_annotation`, `annot_list`, `open_editor`, `next_annotation`, `prev_annotation`, `flush_output`
 
-**View:** `toggle_collapsed`, `toggle_compact`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_word_diff`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `theme_select`, `filter`, `info`, `reload`
+**View:** `toggle_collapsed`, `toggle_compact`, `toggle_wrap`, `toggle_tree`, `toggle_line_numbers`, `toggle_blame`, `toggle_word_diff`, `toggle_hunk`, `toggle_untracked`, `mark_reviewed`, `filter_unreviewed`, `theme_select`, `filter`, `info`, `reload`
 
 **Quit:** `quit`, `discard_quit`, `help`, `dismiss`
 

--- a/app/keymap/keymap.go
+++ b/app/keymap/keymap.go
@@ -58,6 +58,7 @@ const (
 	ActionToggleHunk       Action = "toggle_hunk"
 	ActionToggleUntracked  Action = "toggle_untracked"
 	ActionMarkReviewed     Action = "mark_reviewed"
+	ActionFilterUnreviewed Action = "filter_unreviewed"
 	ActionFilter           Action = "filter"
 	ActionQuit             Action = "quit"
 	ActionDiscardQuit      Action = "discard_quit"
@@ -88,7 +89,7 @@ var validActions = map[Action]bool{
 	ActionNextAnnotation: true, ActionPrevAnnotation: true,
 	ActionToggleCollapsed: true, ActionToggleCompact: true, ActionToggleWrap: true, ActionToggleTree: true,
 	ActionToggleLineNums: true, ActionToggleBlame: true, ActionToggleWordDiff: true, ActionToggleHunk: true,
-	ActionMarkReviewed: true, ActionFilter: true, ActionToggleUntracked: true,
+	ActionMarkReviewed: true, ActionFilterUnreviewed: true, ActionFilter: true, ActionToggleUntracked: true,
 	ActionQuit: true, ActionDiscardQuit: true, ActionHelp: true, ActionDismiss: true, ActionThemeSelect: true,
 	ActionInfo:             true,
 	ActionReload:           true,
@@ -235,6 +236,7 @@ func defaultDescriptions() []HelpEntry {
 		{ActionToggleHunk, "toggle hunk in collapsed", "View"},
 		{ActionToggleUntracked, "show/hide untracked files", "View"},
 		{ActionMarkReviewed, "mark file as reviewed", "View"},
+		{ActionFilterUnreviewed, "show unreviewed files", "View"},
 		{ActionFilter, "filter files", "View"},
 		{ActionThemeSelect, "theme selector", "View"},
 		{ActionInfo, "show review info popup", "View"},
@@ -293,6 +295,7 @@ func defaultBindings() map[string]Action {
 		"W":      ActionToggleWordDiff,
 		".":      ActionToggleHunk,
 		" ":      ActionMarkReviewed,
+		"F":      ActionFilterUnreviewed,
 		"u":      ActionToggleUntracked,
 		"f":      ActionFilter,
 		"q":      ActionQuit,

--- a/app/keymap/keymap_test.go
+++ b/app/keymap/keymap_test.go
@@ -39,7 +39,7 @@ func TestDefault_allExpectedBindings(t *testing.T) {
 		{"}", ActionNextAnnotation}, {"{", ActionPrevAnnotation}, {"O", ActionFlushOutput},
 		{"v", ActionToggleCollapsed}, {"C", ActionToggleCompact}, {"w", ActionToggleWrap}, {"t", ActionToggleTree},
 		{"L", ActionToggleLineNums}, {"B", ActionToggleBlame}, {"W", ActionToggleWordDiff},
-		{".", ActionToggleHunk}, {" ", ActionMarkReviewed}, {"f", ActionFilter},
+		{".", ActionToggleHunk}, {" ", ActionMarkReviewed}, {"f", ActionFilter}, {"F", ActionFilterUnreviewed},
 		{"u", ActionToggleUntracked},
 		{"q", ActionQuit}, {"Q", ActionDiscardQuit}, {"?", ActionHelp}, {"T", ActionThemeSelect}, {"esc", ActionDismiss},
 		{"i", ActionInfo},

--- a/app/ui/handlers.go
+++ b/app/ui/handlers.go
@@ -228,6 +228,19 @@ func (m Model) handleFilterToggle() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// handleUnreviewedFilterToggle toggles the sidebar between all files and files
+// still awaiting review. It is unavailable in single-file mode.
+func (m Model) handleUnreviewedFilterToggle() (tea.Model, tea.Cmd) {
+	if m.file.singleFile {
+		return m, nil
+	}
+	m.pendingAnnotJump = nil
+	m.nav.pendingHunkJump = nil
+	m.tree.ToggleUnreviewedFilter()
+	m.tree.EnsureVisible(m.treePageSize())
+	return m.loadSelectedIfChanged()
+}
+
 // handleMarkReviewed toggles the reviewed state of the focused file.
 // tree focus uses the selected row; diff/TOC focus uses the displayed file.
 func (m Model) handleMarkReviewed() (tea.Model, tea.Cmd) {
@@ -244,7 +257,7 @@ func (m Model) handleMarkReviewed() (tea.Model, tea.Cmd) {
 	if m.tree.IsReviewed(file) {
 		m.tree.Unreview(file)
 		delete(m.reviewed.pending, file)
-		return m, nil
+		return m.loadSelectedIfChanged()
 	}
 	if _, pending := m.reviewed.pending[file]; pending {
 		delete(m.reviewed.pending, file)
@@ -255,11 +268,11 @@ func (m Model) handleMarkReviewed() (tea.Model, tea.Cmd) {
 		fingerprint := diff.FileFingerprint(entry, m.file.lines)
 		m.reviewed.cache[file] = fingerprint
 		m.tree.SetReviewed(file, fingerprint)
-		return m, nil
+		return m.loadSelectedIfChanged()
 	}
 	if fingerprint := m.reviewed.cache[file]; fingerprint != "" {
 		m.tree.SetReviewed(file, fingerprint)
-		return m, nil
+		return m.loadSelectedIfChanged()
 	}
 
 	m.reviewed.loadSeq++

--- a/app/ui/handlers_test.go
+++ b/app/ui/handlers_test.go
@@ -35,6 +35,36 @@ func TestModel_MarkReviewedFromTreePane(t *testing.T) {
 	assert.Equal(t, 0, model.tree.ReviewedCount(), "space should unmark reviewed file")
 }
 
+func TestModel_UnreviewedFilterAdvancesAsFilesAreReviewed(t *testing.T) {
+	lines := map[string][]diff.DiffLine{
+		"a.go": {{NewNum: 1, Content: "a", ChangeType: diff.ChangeAdd}},
+		"b.go": {{NewNum: 1, Content: "b", ChangeType: diff.ChangeAdd}},
+	}
+	m := testModel([]string{"a.go", "b.go"}, lines)
+	m.tree = testNewFileTree([]string{"a.go", "b.go"})
+	m.file.name = "a.go"
+	m.file.lines = lines["a.go"]
+	m.layout.focus = paneTree
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
+	model := result.(Model)
+	require.True(t, model.tree.UnreviewedFilterActive())
+
+	result, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	model = result.(Model)
+	assert.True(t, model.tree.IsReviewed("a.go"))
+	assert.Equal(t, "b.go", model.tree.SelectedFile())
+	require.NotNil(t, cmd, "advancing to the next unreviewed file loads its diff")
+
+	msg := cmd()
+	loaded, ok := msg.(fileLoadedMsg)
+	require.True(t, ok)
+	assert.Equal(t, "b.go", loaded.file)
+
+	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
+	assert.False(t, result.(Model).tree.UnreviewedFilterActive())
+}
+
 func TestModel_MarkReviewedFromTreePaneUsesSelectedFile(t *testing.T) {
 	lines := []diff.DiffLine{{NewNum: 1, Content: "line1", ChangeType: diff.ChangeContext}}
 	m := testModel([]string{"a.go", "b.go"}, map[string][]diff.DiffLine{

--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -406,6 +406,9 @@ func (m Model) handleFilesLoaded(msg filesLoadedMsg) (tea.Model, tea.Cmd) {
 	if m.tree.FilterActive() {
 		m.tree.RefreshFilter(m.annotatedFiles())
 	}
+	if m.tree.UnreviewedFilterActive() {
+		m.tree.RefreshUnreviewedFilter()
+	}
 	if m.file.name != "" {
 		m.tree.SelectByPath(m.file.name)
 	}
@@ -546,7 +549,7 @@ func (m Model) handleReviewFingerprintLoaded(msg reviewFingerprintLoadedMsg) (te
 	}
 	m.reviewed.cache[msg.path] = msg.fingerprint
 	m.tree.SetReviewed(msg.path, msg.fingerprint)
-	return m, nil
+	return m.loadSelectedIfChanged()
 }
 
 // handleBlameLoaded processes asynchronously loaded blame data for a file.

--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -399,7 +399,18 @@ func (m Model) handleFilesLoaded(msg filesLoadedMsg) (tea.Model, tea.Cmd) {
 			delete(m.reviewed.pending, path)
 		}
 	}
+	// Preserve the visible selection across a reload. In unreviewed-only mode
+	// the displayed diff may still be the file that was just hidden while its
+	// auto-advance load is in flight, so m.file.name cannot restore the intended
+	// next selection below.
+	selectedBeforeRebuild := ""
+	if m.tree.UnreviewedFilterActive() {
+		selectedBeforeRebuild = m.tree.SelectedFile()
+	}
 	m.tree.Rebuild(entries)
+	if selectedBeforeRebuild != "" {
+		m.tree.SelectByPath(selectedBeforeRebuild)
+	}
 	m.tree.ReconcileReviewed(msg.reviewedBefore, msg.reviewedFingerprints)
 	m.reviewed.cache = make(map[string]string, len(msg.reviewedFingerprints))
 	maps.Copy(m.reviewed.cache, msg.reviewedFingerprints)

--- a/app/ui/loaders_test.go
+++ b/app/ui/loaders_test.go
@@ -1832,3 +1832,30 @@ func TestModel_LoadFilesPreservesMarkAddedAfterReviewedSnapshot(t *testing.T) {
 
 	assert.True(t, m.tree.IsReviewed(entry.Path), "fresh mark must survive reconciliation of the older snapshot")
 }
+
+func TestModel_FilesReloadPreservesUnreviewedAutoAdvanceSelection(t *testing.T) {
+	entries := []diff.FileEntry{{Path: "a.go"}, {Path: "b.go"}, {Path: "c.go"}}
+	lines := []diff.DiffLine{{Content: "changed", ChangeType: diff.ChangeAdd}}
+	renderer := &mocks.RendererMock{
+		ChangedFilesFunc: func(string, bool) ([]diff.FileEntry, error) { return entries, nil },
+		FileDiffFunc:     func(diff.FileDiffRequest) ([]diff.DiffLine, error) { return lines, nil },
+	}
+	m := testNewModel(t, renderer, annotation.NewStore(), noopHighlighter(), ModelConfig{})
+	m.tree.Rebuild(entries)
+	m.tree.ToggleUnreviewedFilter()
+	require.True(t, m.tree.SelectByPath("b.go"))
+	m.file.name = "b.go"
+	m.file.lines = lines
+
+	reloadCmd := m.loadFiles() // captures reviewed state before b.go is marked
+	result, advanceCmd := m.handleMarkReviewed()
+	m = result.(Model)
+	require.NotNil(t, advanceCmd)
+	require.Equal(t, "c.go", m.tree.SelectedFile())
+
+	result, followupCmd := m.Update(reloadCmd())
+	m = result.(Model)
+
+	assert.Equal(t, "c.go", m.tree.SelectedFile(), "reload must not jump back to the first unreviewed file")
+	assert.NotNil(t, followupCmd, "reload should issue a fresh load for the preserved selection")
+}

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -198,6 +198,8 @@ type FileTreeComponent interface {
 	OldPath(path string) string
 	// FilterActive returns true when the file tree is showing only annotated files.
 	FilterActive() bool
+	// UnreviewedFilterActive returns true when only unreviewed files are visible.
+	UnreviewedFilterActive() bool
 	// ReviewedCount returns the number of files marked as reviewed.
 	ReviewedCount() int
 	// ReviewedFingerprints returns a copy of reviewed paths and their semantic diff identities.
@@ -222,8 +224,12 @@ type FileTreeComponent interface {
 	Rebuild(entries []diff.FileEntry)
 	// ToggleFilter toggles between showing all files and only annotated files.
 	ToggleFilter(annotated map[string]bool)
+	// ToggleUnreviewedFilter toggles between all files and unreviewed files.
+	ToggleUnreviewedFilter()
 	// RefreshFilter updates the filtered view with the current annotation state.
 	RefreshFilter(annotated map[string]bool)
+	// RefreshUnreviewedFilter updates the view after reviewed state changes.
+	RefreshUnreviewedFilter()
 	// SetReviewed marks a path reviewed at the supplied semantic diff identity.
 	SetReviewed(path, fingerprint string)
 	// Unreview removes the reviewed mark for a path.
@@ -1035,6 +1041,8 @@ func (m Model) dispatchAction(action keymap.Action) (tea.Model, tea.Cmd) {
 		return m, nil
 	case keymap.ActionFilter:
 		return m.handleFilterToggle()
+	case keymap.ActionFilterUnreviewed:
+		return m.handleUnreviewedFilterToggle()
 	case keymap.ActionNextItem:
 		return m.handleFileOrSearchNav(true)
 	case keymap.ActionPrevItem:

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -21,6 +21,7 @@ type FileTree struct {
 	offset       int                        // first visible entry index for viewport scrolling
 	allFiles     []string                   // original full file paths
 	filter       bool                       // when true, show only annotated files
+	unreviewed   bool                       // when true, show only files not marked reviewed
 	reviewed     map[string]string          // semantic diff fingerprint for files marked reviewed
 	fileStatuses map[string]diff.FileStatus // file change status from git, empty for non-git
 	oldPaths     map[string]string          // rename origin keyed by new path, empty for non-renames
@@ -102,6 +103,12 @@ func (ft *FileTree) OldPath(path string) string {
 // FilterActive returns true when the file tree is showing only annotated files.
 func (ft *FileTree) FilterActive() bool {
 	return ft.filter
+}
+
+// UnreviewedFilterActive returns true when the file tree is showing only
+// files that have not been marked reviewed.
+func (ft *FileTree) UnreviewedFilterActive() bool {
+	return ft.unreviewed
 }
 
 // ReviewedCount returns the number of files marked as reviewed.
@@ -215,8 +222,8 @@ func (ft *FileTree) EnsureVisible(height int) {
 // Rebuild rebuilds the file tree from new entries in-place.
 // preserves reviewed map (pruned to files still present), resets cursor/offset,
 // positions cursor on first file entry, and preserves filter state.
-// entries are rebuilt from all files regardless of filter flag;
-// call RefreshFilter afterward when FilterActive returns true.
+// entries are rebuilt from all files regardless of filter flags; callers
+// refresh whichever filter is active after reviewed state is reconciled.
 func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
 	paths := diff.FileEntryPaths(entries)
 	ft.allFiles = paths
@@ -270,6 +277,7 @@ func (ft *FileTree) ToggleFilter(annotatedFiles map[string]bool) {
 			ft.filter = false // nothing to filter, stay on all
 			return
 		}
+		ft.unreviewed = false
 		ft.entries = ft.buildEntries(filtered)
 	} else {
 		ft.entries = ft.buildEntries(ft.allFiles)
@@ -283,6 +291,32 @@ func (ft *FileTree) ToggleFilter(annotatedFiles map[string]bool) {
 			return
 		}
 	}
+}
+
+// ToggleUnreviewedFilter switches between showing all files and only files
+// that have not been marked reviewed. It is mutually exclusive with the
+// annotated-only filter.
+func (ft *FileTree) ToggleUnreviewedFilter() {
+	ft.unreviewed = !ft.unreviewed
+	if ft.unreviewed {
+		ft.filter = false
+		ft.entries = ft.buildEntries(ft.unreviewedFiles())
+	} else {
+		ft.entries = ft.buildEntries(ft.allFiles)
+	}
+	ft.selectAfterRebuild("")
+}
+
+// RefreshUnreviewedFilter rebuilds the unreviewed-only view after reviewed
+// state changes, keeping the current file when possible and otherwise moving
+// forward to the next unfinished file.
+func (ft *FileTree) RefreshUnreviewedFilter() {
+	if !ft.unreviewed {
+		return
+	}
+	previous := ft.SelectedFile()
+	ft.entries = ft.buildEntries(ft.unreviewedFiles())
+	ft.selectAfterRebuild(previous)
 }
 
 // RefreshFilter rebuilds the filtered tree if the filter is active, preserving cursor position.
@@ -327,11 +361,13 @@ func (ft *FileTree) SetReviewed(path, fingerprint string) {
 		return
 	}
 	ft.reviewed[path] = fingerprint
+	ft.RefreshUnreviewedFilter()
 }
 
 // Unreview removes the reviewed mark for path.
 func (ft *FileTree) Unreview(path string) {
 	delete(ft.reviewed, path)
+	ft.RefreshUnreviewedFilter()
 }
 
 // ReconcileReviewed validates the marks captured when a file-list load began.
@@ -347,6 +383,7 @@ func (ft *FileTree) ReconcileReviewed(before, current map[string]string) {
 			delete(ft.reviewed, path)
 		}
 	}
+	ft.RefreshUnreviewedFilter()
 }
 
 // ReconcileReviewedPath validates a reviewed mark when that file's refreshed
@@ -354,6 +391,7 @@ func (ft *FileTree) ReconcileReviewed(before, current map[string]string) {
 func (ft *FileTree) ReconcileReviewedPath(path, currentFingerprint string) {
 	if reviewedFingerprint, ok := ft.reviewed[path]; ok && reviewedFingerprint != currentFingerprint {
 		delete(ft.reviewed, path)
+		ft.RefreshUnreviewedFilter()
 	}
 }
 
@@ -367,6 +405,9 @@ func (ft *FileTree) ScrollState() ScrollState {
 // it adjusts the internal offset so the cursor stays within the visible window.
 func (ft *FileTree) Render(r FileTreeRender) string {
 	if len(ft.entries) == 0 {
+		if ft.unreviewed && len(ft.allFiles) > 0 {
+			return "  all files reviewed"
+		}
 		return "  no changed files"
 	}
 
@@ -391,6 +432,38 @@ func (ft *FileTree) Render(r FileTreeRender) string {
 		}
 	}
 	return b.String()
+}
+
+// selectAfterRebuild restores previous when it is still visible. If a newly
+// reviewed file disappeared, it selects the next visible file in source order,
+// falling back to the first visible file.
+func (ft *FileTree) selectAfterRebuild(previous string) {
+	ft.cursor = 0
+	ft.offset = 0
+	if previous != "" && ft.SelectByPath(previous) {
+		return
+	}
+	if previous != "" {
+		previousIdx := slices.Index(ft.allFiles, previous)
+		visible := make(map[string]struct{}, len(ft.entries))
+		for _, entry := range ft.entries {
+			if !entry.isDir {
+				visible[entry.path] = struct{}{}
+			}
+		}
+		for _, path := range ft.allFiles[previousIdx+1:] {
+			if _, ok := visible[path]; ok {
+				ft.SelectByPath(path)
+				return
+			}
+		}
+	}
+	for i, e := range ft.entries {
+		if !e.isDir {
+			ft.cursor = i
+			return
+		}
+	}
 }
 
 // buildEntries groups files by directory and creates a flat entry list.
@@ -506,6 +579,16 @@ func (ft *FileTree) filterFiles(annotatedFiles map[string]bool) []string {
 	for _, f := range ft.allFiles {
 		if annotatedFiles[f] {
 			filtered = append(filtered, f)
+		}
+	}
+	return filtered
+}
+
+func (ft *FileTree) unreviewedFiles() []string {
+	filtered := make([]string, 0, len(ft.allFiles))
+	for _, path := range ft.allFiles {
+		if !ft.IsReviewed(path) {
+			filtered = append(filtered, path)
 		}
 	}
 	return filtered

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -304,7 +304,7 @@ func (ft *FileTree) ToggleUnreviewedFilter() {
 	} else {
 		ft.entries = ft.buildEntries(ft.allFiles)
 	}
-	ft.selectAfterRebuild("")
+	ft.selectAfterRebuild("", "")
 }
 
 // RefreshUnreviewedFilter rebuilds the unreviewed-only view after reviewed
@@ -315,8 +315,9 @@ func (ft *FileTree) RefreshUnreviewedFilter() {
 		return
 	}
 	previous := ft.SelectedFile()
+	next := ft.nextUnreviewedAfterCursor()
 	ft.entries = ft.buildEntries(ft.unreviewedFiles())
-	ft.selectAfterRebuild(previous)
+	ft.selectAfterRebuild(previous, next)
 }
 
 // RefreshFilter rebuilds the filtered tree if the filter is active, preserving cursor position.
@@ -434,29 +435,16 @@ func (ft *FileTree) Render(r FileTreeRender) string {
 	return b.String()
 }
 
-// selectAfterRebuild restores previous when it is still visible. If a newly
-// reviewed file disappeared, it selects the next visible file in source order,
-// falling back to the first visible file.
-func (ft *FileTree) selectAfterRebuild(previous string) {
+// selectAfterRebuild restores previous when it is still visible, then tries
+// preferred, and finally falls back to the first visible file.
+func (ft *FileTree) selectAfterRebuild(previous, preferred string) {
 	ft.cursor = 0
 	ft.offset = 0
 	if previous != "" && ft.SelectByPath(previous) {
 		return
 	}
-	if previous != "" {
-		previousIdx := slices.Index(ft.allFiles, previous)
-		visible := make(map[string]struct{}, len(ft.entries))
-		for _, entry := range ft.entries {
-			if !entry.isDir {
-				visible[entry.path] = struct{}{}
-			}
-		}
-		for _, path := range ft.allFiles[previousIdx+1:] {
-			if _, ok := visible[path]; ok {
-				ft.SelectByPath(path)
-				return
-			}
-		}
+	if preferred != "" && ft.SelectByPath(preferred) {
+		return
 	}
 	for i, e := range ft.entries {
 		if !e.isDir {
@@ -464,6 +452,18 @@ func (ft *FileTree) selectAfterRebuild(previous string) {
 			return
 		}
 	}
+}
+
+// nextUnreviewedAfterCursor follows the rendered tree order, which can differ
+// from the renderer-provided allFiles order after directory grouping.
+func (ft *FileTree) nextUnreviewedAfterCursor() string {
+	start := min(max(ft.cursor+1, 0), len(ft.entries))
+	for _, entry := range ft.entries[start:] {
+		if !entry.isDir && !ft.IsReviewed(entry.path) {
+			return entry.path
+		}
+	}
+	return ""
 }
 
 // buildEntries groups files by directory and creates a flat entry list.

--- a/app/ui/sidepane/filetree_test.go
+++ b/app/ui/sidepane/filetree_test.go
@@ -188,6 +188,18 @@ func TestFileTree_ToggleUnreviewedFilter(t *testing.T) {
 	assert.Equal(t, "a.go", ft.SelectedFile())
 }
 
+func TestFileTree_UnreviewedAdvanceFollowsDisplayOrder(t *testing.T) {
+	// Renderer order differs from the tree's directory-grouped display order:
+	// b.go, a/c.go, a/d.go.
+	ft := NewFileTree(fileEntries("a/c.go", "b.go", "a/d.go"))
+	ft.ToggleUnreviewedFilter()
+	require.Equal(t, "b.go", ft.SelectedFile())
+
+	ft.SetReviewed("b.go", "fp-b")
+
+	assert.Equal(t, "a/c.go", ft.SelectedFile(), "advance should follow the next file on screen")
+}
+
 func TestFileTree_UnreviewedAndAnnotatedFiltersAreExclusive(t *testing.T) {
 	ft := NewFileTree(fileEntries("a.go", "b.go"))
 	ft.ToggleUnreviewedFilter()

--- a/app/ui/sidepane/filetree_test.go
+++ b/app/ui/sidepane/filetree_test.go
@@ -170,6 +170,49 @@ func TestFileTree_ToggleFilterNoAnnotations(t *testing.T) {
 	assert.False(t, ft.FilterActive())
 }
 
+func TestFileTree_ToggleUnreviewedFilter(t *testing.T) {
+	ft := NewFileTree(fileEntries("a.go", "b.go", "c.go"))
+	ft.SetReviewed("a.go", "fp-a")
+
+	ft.ToggleUnreviewedFilter()
+	assert.True(t, ft.UnreviewedFilterActive())
+	assert.Equal(t, "b.go", ft.SelectedFile())
+	assert.True(t, ft.HasFile(DirectionNext))
+
+	ft.SetReviewed("b.go", "fp-b")
+	assert.Equal(t, "c.go", ft.SelectedFile(), "marking reviewed advances to the next unfinished file")
+	assert.False(t, ft.HasFile(DirectionNext))
+
+	ft.ToggleUnreviewedFilter()
+	assert.False(t, ft.UnreviewedFilterActive())
+	assert.Equal(t, "a.go", ft.SelectedFile())
+}
+
+func TestFileTree_UnreviewedAndAnnotatedFiltersAreExclusive(t *testing.T) {
+	ft := NewFileTree(fileEntries("a.go", "b.go"))
+	ft.ToggleUnreviewedFilter()
+	require.True(t, ft.UnreviewedFilterActive())
+
+	ft.ToggleFilter(map[string]bool{"a.go": true})
+	assert.True(t, ft.FilterActive())
+	assert.False(t, ft.UnreviewedFilterActive())
+
+	ft.ToggleUnreviewedFilter()
+	assert.True(t, ft.UnreviewedFilterActive())
+	assert.False(t, ft.FilterActive())
+}
+
+func TestFileTree_UnreviewedFilterEmptyState(t *testing.T) {
+	ft := NewFileTree(fileEntries("a.go"))
+	ft.SetReviewed("a.go", "fp-a")
+	ft.ToggleUnreviewedFilter()
+
+	res := style.NewResolver(style.Colors{})
+	rnd := style.NewRenderer(res)
+	result := ft.Render(FileTreeRender{Width: 30, Height: 10, Resolver: res, Renderer: rnd})
+	assert.Contains(t, result, "all files reviewed")
+}
+
 func TestFileTree_Render(t *testing.T) {
 	ft := NewFileTree(fileEntries("internal/handler.go", "main.go"))
 	ft.cursor = 1 // select handler.go

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -440,6 +440,10 @@ func (m Model) statusModeIcons() string {
 		icon   string
 		active bool
 	}
+	reviewIcon := "✓"
+	if m.tree.UnreviewedFilterActive() {
+		reviewIcon = "○"
+	}
 	indicators := []indicator{
 		{"▼", m.modes.collapsed.enabled},
 		{"⊂", m.modes.compact},
@@ -450,7 +454,7 @@ func (m Model) statusModeIcons() string {
 		{"#", m.modes.lineNumbers},
 		{"b", m.modes.showBlame},
 		{"±", m.modes.wordDiff},
-		{"✓", m.tree.ReviewedCount() > 0},
+		{reviewIcon, m.tree.ReviewedCount() > 0 || m.tree.UnreviewedFilterActive()},
 		{"∅", m.modes.showUntracked},
 	}
 

--- a/app/ui/view_test.go
+++ b/app/ui/view_test.go
@@ -1394,6 +1394,10 @@ func TestModel_ReviewedModeIcon(t *testing.T) {
 	m.tree.SetReviewed("a.go", "fp-a")
 	icons = m.statusModeIcons()
 	assert.Contains(t, icons, "✓", "reviewed icon should be present when files reviewed")
+
+	m.tree.ToggleUnreviewedFilter()
+	icons = m.statusModeIcons()
+	assert.Contains(t, icons, "○", "unreviewed filter replaces the reviewed marker with its active state")
 }
 
 func TestModel_ViewOutput(t *testing.T) {

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -31,7 +31,7 @@ some-command | revdiff --stdin --output /tmp/annotations.txt      # annotate gen
 
 ## Single-File Mode
 
-When a diff contains exactly one file, revdiff automatically hides the file tree pane and gives full terminal width to the diff view. Pane-switching keys (`Tab`, `h/l`, `n/p`, `f`) become no-ops, except when markdown TOC is active (see below). Search navigation (`n`/`N`) still works normally.
+When a diff contains exactly one file, revdiff automatically hides the file tree pane and gives full terminal width to the diff view. Pane-switching keys (`Tab`, `h/l`, `n/p`, `f`, `F`) become no-ops, except when markdown TOC is active (see below). Search navigation (`n`/`N`) still works normally.
 
 ## Markdown TOC Navigation
 
@@ -154,7 +154,7 @@ Press `e` in the diff pane to open the focused file in `$EDITOR` (`open_file_in_
 
 Press `O` to write the current annotations to the `--output` file without exiting (`flush_output` — rebindable). This keeps revdiff open while handing the file to an AI agent: annotate, flush with `O`, let the agent read the file and edit code, then reload with `R` and continue in the same session. Each flush overwrites the file with the full current annotation set (a snapshot, not an append log), using the same atomic write as a normal quit. `O` requires `-o`/`--output`; with no output file, or with no annotations yet, it shows a status hint and writes nothing.
 
-Press `Space` to mark the focused file reviewed. On `R` reload, revdiff keeps the mark only when the file's effective text diff is unchanged; rebases that only shift line numbers or surrounding context keep it, while changed or removed files lose it. Binary files and opaque placeholders are conservatively unmarked on reload because their rendered diff does not expose enough content to prove they are unchanged.
+Press `Space` to mark the focused file reviewed. Press `F` to toggle the sidebar between all files and unreviewed files; while filtered, marking a file reviewed removes it from the list and advances to the next unfinished file. On `R` reload, revdiff keeps the mark only when the file's effective text diff is unchanged; rebases that only shift line numbers or surrounding context keep it, while changed or removed files lose it. Binary files and opaque placeholders are conservatively unmarked on reload because their rendered diff does not expose enough content to prove they are unchanged.
 
 **View:**
 
@@ -170,6 +170,7 @@ Press `Space` to mark the focused file reviewed. On `R` reload, revdiff keeps th
 | `.` | Expand/collapse individual hunk under cursor (collapsed mode only) |
 | `T` | Open theme selector with live preview |
 | `f` | Toggle filter: all files / annotated only |
+| `F` | Toggle filter: all files / unreviewed only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle info popup — review scope (mode, VCS, ref, filters, file/status counts, aggregate `+/-` stats) plus the commit log for the current ref range when applicable |
 | `R` | Reload diff from VCS (warns if annotations exist) |
@@ -191,7 +192,7 @@ The status bar shows a fixed row of mode indicators on the right side. All slots
 | `#` | `L` | Line numbers visible in gutter |
 | `b` | `B` | Blame gutter visible |
 | `±` | `W` | Intra-line word-diff highlighting |
-| `✓` | `Space` | Reviewed count (revalidated on reload) |
+| `✓` / `○` | `Space` / `F` | Reviewed files / unreviewed-only filter active |
 | `∅` | `u` | Untracked files visible in tree |
 
 On narrow terminals, the left-hand segments are dropped before the icons: search position first, then line and hunk info, then the filename truncates. The icon row on the right stays put.


### PR DESCRIPTION
## Summary

- add an `F` toggle for showing only unreviewed files
- advance to the next file as the current one is marked reviewed
- keep annotated and unreviewed filters separate

This builds on the smarter reviewed-state reconciliation from #256. Reviewed marks now stay trustworthy across reloads, so filtering by them is useful during large reviews.

## Checks

- `TMPDIR=/dev/shm go test ./...`
- `golangci-lint run`
- Codex review: no actionable findings
