### PR TITLE
fix(ui): preserve unreviewed tree scroll

### DIFF
--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -399,20 +399,7 @@ func (m Model) handleFilesLoaded(msg filesLoadedMsg) (tea.Model, tea.Cmd) {
 			delete(m.reviewed.pending, path)
 		}
 	}
-	// Preserve the visible selection across a reload. In unreviewed-only mode
-	// the displayed diff may still be the file that was just hidden while its
-	// auto-advance load is in flight, so m.file.name cannot restore the intended
-	// next selection below.
-	selectedBeforeRebuild := ""
-	selectedVisibleRow := 0
-	if m.tree.UnreviewedFilterActive() {
-		selectedBeforeRebuild = m.tree.SelectedFile()
-		selectedVisibleRow = m.tree.SelectedVisibleRow()
-	}
 	m.tree.Rebuild(entries)
-	if selectedBeforeRebuild != "" {
-		m.tree.SelectByPathAtVisibleRow(selectedBeforeRebuild, selectedVisibleRow)
-	}
 	m.tree.ReconcileReviewed(msg.reviewedBefore, msg.reviewedFingerprints)
 	m.reviewed.cache = make(map[string]string, len(msg.reviewedFingerprints))
 	maps.Copy(m.reviewed.cache, msg.reviewedFingerprints)

--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -404,12 +404,14 @@ func (m Model) handleFilesLoaded(msg filesLoadedMsg) (tea.Model, tea.Cmd) {
 	// auto-advance load is in flight, so m.file.name cannot restore the intended
 	// next selection below.
 	selectedBeforeRebuild := ""
+	selectedVisibleRow := 0
 	if m.tree.UnreviewedFilterActive() {
 		selectedBeforeRebuild = m.tree.SelectedFile()
+		selectedVisibleRow = m.tree.SelectedVisibleRow()
 	}
 	m.tree.Rebuild(entries)
 	if selectedBeforeRebuild != "" {
-		m.tree.SelectByPath(selectedBeforeRebuild)
+		m.tree.SelectByPathAtVisibleRow(selectedBeforeRebuild, selectedVisibleRow)
 	}
 	m.tree.ReconcileReviewed(msg.reviewedBefore, msg.reviewedFingerprints)
 	m.reviewed.cache = make(map[string]string, len(msg.reviewedFingerprints))

--- a/app/ui/loaders_test.go
+++ b/app/ui/loaders_test.go
@@ -1867,22 +1867,32 @@ func TestModel_FilesReloadPreservesUnreviewedScrollOffset(t *testing.T) {
 	}
 	m := testModel(nil, nil)
 	m.tree.Rebuild(entries)
+	m.tree.SetReviewed("a.go", "fp-a")
+	m.tree.SetReviewed("b.go", "fp-b")
+	reviewed := map[string]string{"a.go": "fp-a", "b.go": "fp-b"}
 	m.tree.ToggleUnreviewedFilter()
 	require.True(t, m.tree.SelectByPath("h.go"))
 	m.tree.EnsureVisible(5)
 	m.tree.Move(sidepane.MotionUp)
 	m.tree.Move(sidepane.MotionUp)
 	require.Equal(t, "f.go", m.tree.SelectedFile())
-	before := m.tree.ScrollState().Offset
+	require.True(t, m.tree.SelectByVisibleRow(2))
+	require.Equal(t, "f.go", m.tree.SelectedFile(), "selected file starts in the middle of the viewport")
 
 	m.file.name = "f.go"
-	m.triggerReload()
-	result, _ := m.Update(filesLoadedMsg{seq: m.filesLoadSeq, entries: entries})
-	m = result.(Model)
-	m.tree.EnsureVisible(5)
+	for range 3 {
+		m.triggerReload()
+		result, _ := m.Update(filesLoadedMsg{
+			seq: m.filesLoadSeq, entries: entries,
+			reviewedBefore: reviewed, reviewedFingerprints: reviewed,
+		})
+		m = result.(Model)
+		m.tree.EnsureVisible(5)
 
-	assert.Equal(t, "f.go", m.tree.SelectedFile())
-	assert.Equal(t, before, m.tree.ScrollState().Offset, "reload should keep the selected file on the same visible row")
+		assert.Equal(t, "f.go", m.tree.SelectedFile())
+		require.True(t, m.tree.SelectByVisibleRow(2))
+		require.Equal(t, "f.go", m.tree.SelectedFile(), "repeated reloads should keep the selected file on the same row")
+	}
 }
 
 func TestModel_FilesReloadPreservesVisibleRowWhenFilesAboveChange(t *testing.T) {
@@ -1898,7 +1908,8 @@ func TestModel_FilesReloadPreservesVisibleRowWhenFilesAboveChange(t *testing.T) 
 	m.tree.Move(sidepane.MotionUp)
 	m.tree.Move(sidepane.MotionUp)
 	require.Equal(t, "f.go", m.tree.SelectedFile())
-	before := m.tree.SelectedVisibleRow()
+	require.True(t, m.tree.SelectByVisibleRow(2))
+	require.Equal(t, "f.go", m.tree.SelectedFile(), "selected file starts in the middle of the viewport")
 
 	m.file.name = "f.go"
 	m.triggerReload()
@@ -1911,5 +1922,6 @@ func TestModel_FilesReloadPreservesVisibleRowWhenFilesAboveChange(t *testing.T) 
 	m.tree.EnsureVisible(5)
 
 	assert.Equal(t, "f.go", m.tree.SelectedFile())
-	assert.Equal(t, before, m.tree.SelectedVisibleRow(), "reload should preserve the row when files above disappear")
+	require.True(t, m.tree.SelectByVisibleRow(2))
+	require.Equal(t, "f.go", m.tree.SelectedFile(), "reload should preserve the row when files above disappear")
 }

--- a/app/ui/loaders_test.go
+++ b/app/ui/loaders_test.go
@@ -1859,3 +1859,28 @@ func TestModel_FilesReloadPreservesUnreviewedAutoAdvanceSelection(t *testing.T) 
 	assert.Equal(t, "c.go", m.tree.SelectedFile(), "reload must not jump back to the first unreviewed file")
 	assert.NotNil(t, followupCmd, "reload should issue a fresh load for the preserved selection")
 }
+
+func TestModel_FilesReloadPreservesUnreviewedScrollOffset(t *testing.T) {
+	entries := []diff.FileEntry{
+		{Path: "a.go"}, {Path: "b.go"}, {Path: "c.go"}, {Path: "d.go"}, {Path: "e.go"},
+		{Path: "f.go"}, {Path: "g.go"}, {Path: "h.go"}, {Path: "i.go"},
+	}
+	m := testModel(nil, nil)
+	m.tree.Rebuild(entries)
+	m.tree.ToggleUnreviewedFilter()
+	require.True(t, m.tree.SelectByPath("h.go"))
+	m.tree.EnsureVisible(5)
+	m.tree.Move(sidepane.MotionUp)
+	m.tree.Move(sidepane.MotionUp)
+	require.Equal(t, "f.go", m.tree.SelectedFile())
+	before := m.tree.ScrollState().Offset
+
+	m.file.name = "f.go"
+	m.triggerReload()
+	result, _ := m.Update(filesLoadedMsg{seq: m.filesLoadSeq, entries: entries})
+	m = result.(Model)
+	m.tree.EnsureVisible(5)
+
+	assert.Equal(t, "f.go", m.tree.SelectedFile())
+	assert.Equal(t, before, m.tree.ScrollState().Offset, "reload should keep the selected file on the same visible row")
+}

--- a/app/ui/loaders_test.go
+++ b/app/ui/loaders_test.go
@@ -1884,3 +1884,32 @@ func TestModel_FilesReloadPreservesUnreviewedScrollOffset(t *testing.T) {
 	assert.Equal(t, "f.go", m.tree.SelectedFile())
 	assert.Equal(t, before, m.tree.ScrollState().Offset, "reload should keep the selected file on the same visible row")
 }
+
+func TestModel_FilesReloadPreservesVisibleRowWhenFilesAboveChange(t *testing.T) {
+	entries := []diff.FileEntry{
+		{Path: "a.go"}, {Path: "b.go"}, {Path: "c.go"}, {Path: "d.go"}, {Path: "e.go"},
+		{Path: "f.go"}, {Path: "g.go"}, {Path: "h.go"}, {Path: "i.go"},
+	}
+	m := testModel(nil, nil)
+	m.tree.Rebuild(entries)
+	m.tree.ToggleUnreviewedFilter()
+	require.True(t, m.tree.SelectByPath("h.go"))
+	m.tree.EnsureVisible(5)
+	m.tree.Move(sidepane.MotionUp)
+	m.tree.Move(sidepane.MotionUp)
+	require.Equal(t, "f.go", m.tree.SelectedFile())
+	before := m.tree.SelectedVisibleRow()
+
+	m.file.name = "f.go"
+	m.triggerReload()
+	reloaded := []diff.FileEntry{
+		{Path: "a.go"}, {Path: "d.go"}, {Path: "e.go"}, {Path: "f.go"},
+		{Path: "g.go"}, {Path: "h.go"}, {Path: "i.go"},
+	}
+	result, _ := m.Update(filesLoadedMsg{seq: m.filesLoadSeq, entries: reloaded})
+	m = result.(Model)
+	m.tree.EnsureVisible(5)
+
+	assert.Equal(t, "f.go", m.tree.SelectedFile())
+	assert.Equal(t, before, m.tree.SelectedVisibleRow(), "reload should preserve the row when files above disappear")
+}

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -220,6 +220,10 @@ type FileTreeComponent interface {
 	SelectByVisibleRow(row int) bool
 	// EnsureVisible adjusts offset so the cursor is within the visible range.
 	EnsureVisible(height int)
+	// SelectedVisibleRow returns the selected entry's row relative to the viewport.
+	SelectedVisibleRow() int
+	// SelectByPathAtVisibleRow selects path and adjusts the offset to place it on row.
+	SelectByPathAtVisibleRow(path string, row int) bool
 	// Rebuild rebuilds the file tree from new entries in-place.
 	Rebuild(entries []diff.FileEntry)
 	// ToggleFilter toggles between showing all files and only annotated files.

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -220,8 +220,6 @@ type FileTreeComponent interface {
 	SelectByVisibleRow(row int) bool
 	// EnsureVisible adjusts offset so the cursor is within the visible range.
 	EnsureVisible(height int)
-	// SelectedVisibleRow returns the selected entry's row relative to the viewport.
-	SelectedVisibleRow() int
 	// Rebuild rebuilds the file tree from new entries in-place.
 	Rebuild(entries []diff.FileEntry)
 	// ToggleFilter toggles between showing all files and only annotated files.

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -222,8 +222,6 @@ type FileTreeComponent interface {
 	EnsureVisible(height int)
 	// SelectedVisibleRow returns the selected entry's row relative to the viewport.
 	SelectedVisibleRow() int
-	// SelectByPathAtVisibleRow selects path and adjusts the offset to place it on row.
-	SelectByPathAtVisibleRow(path string, row int) bool
 	// Rebuild rebuilds the file tree from new entries in-place.
 	Rebuild(entries []diff.FileEntry)
 	// ToggleFilter toggles between showing all files and only annotated files.

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -219,6 +219,20 @@ func (ft *FileTree) EnsureVisible(height int) {
 	ensureVisible(&ft.cursor, &ft.offset, len(ft.entries), height)
 }
 
+// SelectedVisibleRow returns the selected entry's row relative to the viewport.
+func (ft *FileTree) SelectedVisibleRow() int {
+	return ft.cursor - ft.offset
+}
+
+// SelectByPathAtVisibleRow selects path and adjusts the offset to place it on row.
+func (ft *FileTree) SelectByPathAtVisibleRow(path string, row int) bool {
+	if !ft.SelectByPath(path) {
+		return false
+	}
+	ft.offset = max(ft.cursor-max(row, 0), 0)
+	return true
+}
+
 // Rebuild rebuilds the file tree from new entries in-place.
 // preserves reviewed map (pruned to files still present), resets the cursor,
 // positions it on the first file entry, and preserves filter state. The offset
@@ -440,8 +454,8 @@ func (ft *FileTree) Render(r FileTreeRender) string {
 }
 
 // selectAfterRebuild restores previous when it is still visible, then tries
-// preferred, and finally falls back to the first visible file. The viewport
-// offset is preserved so EnsureVisible only scrolls when the selection is hidden.
+// preferred, and finally resets to the first visible file. Anchored selections
+// preserve the offset so EnsureVisible only scrolls when they are hidden.
 func (ft *FileTree) selectAfterRebuild(previous, preferred string) {
 	ft.cursor = 0
 	if len(ft.entries) == 0 {
@@ -454,6 +468,7 @@ func (ft *FileTree) selectAfterRebuild(previous, preferred string) {
 	if preferred != "" && ft.SelectByPath(preferred) {
 		return
 	}
+	ft.offset = 0
 	for i, e := range ft.entries {
 		if !e.isDir {
 			ft.cursor = i

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -224,22 +224,19 @@ func (ft *FileTree) SelectedVisibleRow() int {
 	return ft.cursor - ft.offset
 }
 
-// SelectByPathAtVisibleRow selects path and adjusts the offset to place it on row.
-func (ft *FileTree) SelectByPathAtVisibleRow(path string, row int) bool {
-	if !ft.SelectByPath(path) {
-		return false
-	}
-	ft.offset = max(ft.cursor-max(row, 0), 0)
-	return true
-}
-
 // Rebuild rebuilds the file tree from new entries in-place.
-// preserves reviewed map (pruned to files still present), resets the cursor,
-// positions it on the first file entry, and preserves filter state. The offset
-// is also preserved for the unreviewed filter so reloads retain visual context.
+// preserves reviewed map (pruned to files still present), filter state, and the
+// selected file's visible row for the unreviewed filter. Other rebuilds reset
+// the cursor and offset to the first file entry.
 // entries are rebuilt from all files regardless of filter flags; callers
 // refresh whichever filter is active after reviewed state is reconciled.
 func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
+	selected, visibleRow := "", 0
+	if ft.unreviewed {
+		selected = ft.SelectedFile()
+		visibleRow = ft.SelectedVisibleRow()
+	}
+
 	paths := diff.FileEntryPaths(entries)
 	ft.allFiles = paths
 
@@ -272,17 +269,18 @@ func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
 	// without annotated map here — refreshFilter will be called separately if needed
 	ft.entries = ft.buildEntries(paths)
 
-	// reset cursor and position on first file entry. Preserve the unreviewed
-	// viewport across reloads; EnsureVisible will clamp it after filtering.
+	// reset cursor and offset, then restore the unreviewed viewport anchor when
+	// its selected file survived the rebuild.
 	ft.cursor = 0
-	if !ft.unreviewed || len(ft.entries) == 0 {
-		ft.offset = 0
-	}
+	ft.offset = 0
 	for i, e := range ft.entries {
 		if !e.isDir {
 			ft.cursor = i
 			break
 		}
+	}
+	if selected != "" && ft.SelectByPath(selected) {
+		ft.offset = max(ft.cursor-max(visibleRow, 0), 0)
 	}
 }
 

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -219,6 +219,10 @@ func (ft *FileTree) EnsureVisible(height int) {
 	ensureVisible(&ft.cursor, &ft.offset, len(ft.entries), height)
 }
 
+func (ft *FileTree) visibleRow() int {
+	return ft.cursor - ft.offset
+}
+
 // Rebuild rebuilds the file tree from new entries in-place.
 // preserves reviewed map (pruned to files still present), filter state, and the
 // selected file's visible row for the unreviewed filter. Other rebuilds reset
@@ -229,7 +233,7 @@ func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
 	selected, visibleRow := "", 0
 	if ft.unreviewed {
 		selected = ft.SelectedFile()
-		visibleRow = ft.cursor - ft.offset
+		visibleRow = ft.visibleRow()
 	}
 
 	paths := diff.FileEntryPaths(entries)
@@ -264,6 +268,7 @@ func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
 	// without annotated map here — refreshFilter will be called separately if needed
 	ft.entries = ft.buildEntries(paths)
 
+	// This temporary unfiltered anchor is load-bearing: it carries the visible row into RefreshUnreviewedFilter.
 	ft.selectAfterRebuild(selected, "", visibleRow)
 }
 
@@ -297,7 +302,7 @@ func (ft *FileTree) ToggleFilter(annotatedFiles map[string]bool) {
 // annotated-only filter.
 func (ft *FileTree) ToggleUnreviewedFilter() {
 	previous := ft.SelectedFile()
-	visibleRow := ft.cursor - ft.offset
+	visibleRow := ft.visibleRow()
 	ft.unreviewed = !ft.unreviewed
 	if ft.unreviewed {
 		ft.filter = false
@@ -318,7 +323,7 @@ func (ft *FileTree) RefreshUnreviewedFilter() {
 	}
 	previous := ft.SelectedFile()
 	next := ft.nextUnreviewedAfterCursor()
-	visibleRow := ft.cursor - ft.offset
+	visibleRow := ft.visibleRow()
 	ft.entries = ft.buildEntries(ft.unreviewedFiles())
 	ft.selectAfterRebuild(previous, next, visibleRow)
 }

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -220,8 +220,9 @@ func (ft *FileTree) EnsureVisible(height int) {
 }
 
 // Rebuild rebuilds the file tree from new entries in-place.
-// preserves reviewed map (pruned to files still present), resets cursor/offset,
-// positions cursor on first file entry, and preserves filter state.
+// preserves reviewed map (pruned to files still present), resets the cursor,
+// positions it on the first file entry, and preserves filter state. The offset
+// is also preserved for the unreviewed filter so reloads retain visual context.
 // entries are rebuilt from all files regardless of filter flags; callers
 // refresh whichever filter is active after reviewed state is reconciled.
 func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
@@ -257,9 +258,12 @@ func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
 	// without annotated map here — refreshFilter will be called separately if needed
 	ft.entries = ft.buildEntries(paths)
 
-	// reset cursor/offset and position on first file entry
+	// reset cursor and position on first file entry. Preserve the unreviewed
+	// viewport across reloads; EnsureVisible will clamp it after filtering.
 	ft.cursor = 0
-	ft.offset = 0
+	if !ft.unreviewed || len(ft.entries) == 0 {
+		ft.offset = 0
+	}
 	for i, e := range ft.entries {
 		if !e.isDir {
 			ft.cursor = i
@@ -436,10 +440,14 @@ func (ft *FileTree) Render(r FileTreeRender) string {
 }
 
 // selectAfterRebuild restores previous when it is still visible, then tries
-// preferred, and finally falls back to the first visible file.
+// preferred, and finally falls back to the first visible file. The viewport
+// offset is preserved so EnsureVisible only scrolls when the selection is hidden.
 func (ft *FileTree) selectAfterRebuild(previous, preferred string) {
 	ft.cursor = 0
-	ft.offset = 0
+	if len(ft.entries) == 0 {
+		ft.offset = 0
+		return
+	}
 	if previous != "" && ft.SelectByPath(previous) {
 		return
 	}

--- a/app/ui/sidepane/filetree.go
+++ b/app/ui/sidepane/filetree.go
@@ -219,11 +219,6 @@ func (ft *FileTree) EnsureVisible(height int) {
 	ensureVisible(&ft.cursor, &ft.offset, len(ft.entries), height)
 }
 
-// SelectedVisibleRow returns the selected entry's row relative to the viewport.
-func (ft *FileTree) SelectedVisibleRow() int {
-	return ft.cursor - ft.offset
-}
-
 // Rebuild rebuilds the file tree from new entries in-place.
 // preserves reviewed map (pruned to files still present), filter state, and the
 // selected file's visible row for the unreviewed filter. Other rebuilds reset
@@ -234,7 +229,7 @@ func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
 	selected, visibleRow := "", 0
 	if ft.unreviewed {
 		selected = ft.SelectedFile()
-		visibleRow = ft.SelectedVisibleRow()
+		visibleRow = ft.cursor - ft.offset
 	}
 
 	paths := diff.FileEntryPaths(entries)
@@ -269,19 +264,7 @@ func (ft *FileTree) Rebuild(entries []diff.FileEntry) {
 	// without annotated map here — refreshFilter will be called separately if needed
 	ft.entries = ft.buildEntries(paths)
 
-	// reset cursor and offset, then restore the unreviewed viewport anchor when
-	// its selected file survived the rebuild.
-	ft.cursor = 0
-	ft.offset = 0
-	for i, e := range ft.entries {
-		if !e.isDir {
-			ft.cursor = i
-			break
-		}
-	}
-	if selected != "" && ft.SelectByPath(selected) {
-		ft.offset = max(ft.cursor-max(visibleRow, 0), 0)
-	}
+	ft.selectAfterRebuild(selected, "", visibleRow)
 }
 
 // ToggleFilter switches between showing all files and only annotated files.
@@ -313,14 +296,17 @@ func (ft *FileTree) ToggleFilter(annotatedFiles map[string]bool) {
 // that have not been marked reviewed. It is mutually exclusive with the
 // annotated-only filter.
 func (ft *FileTree) ToggleUnreviewedFilter() {
+	previous := ft.SelectedFile()
+	visibleRow := ft.cursor - ft.offset
 	ft.unreviewed = !ft.unreviewed
 	if ft.unreviewed {
 		ft.filter = false
 		ft.entries = ft.buildEntries(ft.unreviewedFiles())
-	} else {
-		ft.entries = ft.buildEntries(ft.allFiles)
+		ft.selectAfterRebuild(previous, "", visibleRow)
+		return
 	}
-	ft.selectAfterRebuild("", "")
+	ft.entries = ft.buildEntries(ft.allFiles)
+	ft.selectAfterRebuild("", "", 0)
 }
 
 // RefreshUnreviewedFilter rebuilds the unreviewed-only view after reviewed
@@ -332,8 +318,9 @@ func (ft *FileTree) RefreshUnreviewedFilter() {
 	}
 	previous := ft.SelectedFile()
 	next := ft.nextUnreviewedAfterCursor()
+	visibleRow := ft.cursor - ft.offset
 	ft.entries = ft.buildEntries(ft.unreviewedFiles())
-	ft.selectAfterRebuild(previous, next)
+	ft.selectAfterRebuild(previous, next, visibleRow)
 }
 
 // RefreshFilter rebuilds the filtered tree if the filter is active, preserving cursor position.
@@ -453,17 +440,20 @@ func (ft *FileTree) Render(r FileTreeRender) string {
 
 // selectAfterRebuild restores previous when it is still visible, then tries
 // preferred, and finally resets to the first visible file. Anchored selections
-// preserve the offset so EnsureVisible only scrolls when they are hidden.
-func (ft *FileTree) selectAfterRebuild(previous, preferred string) {
+// preserve their row in the viewport.
+func (ft *FileTree) selectAfterRebuild(previous, preferred string, visibleRow int) {
 	ft.cursor = 0
 	if len(ft.entries) == 0 {
 		ft.offset = 0
 		return
 	}
+	visibleRow = max(visibleRow, 0)
 	if previous != "" && ft.SelectByPath(previous) {
+		ft.offset = max(ft.cursor-visibleRow, 0)
 		return
 	}
 	if preferred != "" && ft.SelectByPath(preferred) {
+		ft.offset = max(ft.cursor-visibleRow, 0)
 		return
 	}
 	ft.offset = 0

--- a/app/ui/sidepane/filetree_test.go
+++ b/app/ui/sidepane/filetree_test.go
@@ -238,6 +238,20 @@ func TestFileTree_EnableUnreviewedFilterPreservesVisibleSelection(t *testing.T) 
 	assert.Equal(t, 2, ft.cursor-ft.offset, "filter toggle should keep the selected file on the same row")
 }
 
+func TestFileTree_EnableUnreviewedFilterWithoutAnchorResetsViewport(t *testing.T) {
+	ft := NewFileTree(fileEntries("a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go"))
+	require.True(t, ft.SelectByPath("h.go"))
+	ft.EnsureVisible(5)
+	require.Positive(t, ft.offset)
+	ft.SetReviewed("h.go", "fp-h")
+
+	ft.ToggleUnreviewedFilter()
+
+	assert.Equal(t, "a.go", ft.SelectedFile())
+	assert.Zero(t, ft.offset, "fallback selection should reset the viewport")
+	assert.Equal(t, "./", ft.entries[ft.offset].name, "the root header should remain visible")
+}
+
 func TestFileTree_UnreviewedAndAnnotatedFiltersAreExclusive(t *testing.T) {
 	ft := NewFileTree(fileEntries("a.go", "b.go"))
 	ft.ToggleUnreviewedFilter()

--- a/app/ui/sidepane/filetree_test.go
+++ b/app/ui/sidepane/filetree_test.go
@@ -220,17 +220,22 @@ func TestFileTree_UnreviewedAdvancePreservesVisibleRow(t *testing.T) {
 	assert.Equal(t, 2, ft.cursor-ft.offset, "next file should stay on the same visible row")
 }
 
-func TestFileTree_ToggleUnreviewedFilterResetsScrolledViewport(t *testing.T) {
+func TestFileTree_EnableUnreviewedFilterPreservesVisibleSelection(t *testing.T) {
 	ft := NewFileTree(fileEntries("a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go"))
+	ft.SetReviewed("a.go", "fp-a")
+	ft.SetReviewed("b.go", "fp-b")
 	require.True(t, ft.SelectByPath("h.go"))
 	ft.EnsureVisible(5)
-	require.Positive(t, ft.offset)
+	ft.Move(MotionUp)
+	ft.Move(MotionUp)
+	require.Equal(t, "f.go", ft.SelectedFile())
+	require.Equal(t, 2, ft.cursor-ft.offset, "selected file starts in the middle of the viewport")
 
 	ft.ToggleUnreviewedFilter()
 	ft.EnsureVisible(5)
 
-	assert.Equal(t, "a.go", ft.SelectedFile())
-	assert.Zero(t, ft.offset, "toggle should restore the directory header at the top")
+	assert.Equal(t, "f.go", ft.SelectedFile())
+	assert.Equal(t, 2, ft.cursor-ft.offset, "filter toggle should keep the selected file on the same row")
 }
 
 func TestFileTree_UnreviewedAndAnnotatedFiltersAreExclusive(t *testing.T) {

--- a/app/ui/sidepane/filetree_test.go
+++ b/app/ui/sidepane/filetree_test.go
@@ -200,6 +200,26 @@ func TestFileTree_UnreviewedAdvanceFollowsDisplayOrder(t *testing.T) {
 	assert.Equal(t, "a/c.go", ft.SelectedFile(), "advance should follow the next file on screen")
 }
 
+func TestFileTree_UnreviewedAdvancePreservesVisibleRow(t *testing.T) {
+	ft := NewFileTree(fileEntries("a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go"))
+	ft.ToggleUnreviewedFilter()
+
+	for range 7 {
+		ft.Move(MotionDown)
+	}
+	ft.EnsureVisible(5)
+	ft.Move(MotionUp)
+	ft.Move(MotionUp)
+	require.Equal(t, "f.go", ft.SelectedFile())
+	require.Equal(t, 2, ft.cursor-ft.offset, "selected file starts in the middle of the viewport")
+
+	ft.SetReviewed("f.go", "fp-f")
+	ft.EnsureVisible(5)
+
+	assert.Equal(t, "g.go", ft.SelectedFile(), "marking reviewed advances to the next unfinished file")
+	assert.Equal(t, 2, ft.cursor-ft.offset, "next file should stay on the same visible row")
+}
+
 func TestFileTree_UnreviewedAndAnnotatedFiltersAreExclusive(t *testing.T) {
 	ft := NewFileTree(fileEntries("a.go", "b.go"))
 	ft.ToggleUnreviewedFilter()
@@ -223,6 +243,21 @@ func TestFileTree_UnreviewedFilterEmptyState(t *testing.T) {
 	rnd := style.NewRenderer(res)
 	result := ft.Render(FileTreeRender{Width: 30, Height: 10, Resolver: res, Renderer: rnd})
 	assert.Contains(t, result, "all files reviewed")
+}
+
+func TestFileTree_UnreviewedFilterEmptyStateResetsOffset(t *testing.T) {
+	paths := []string{"a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go"}
+	ft := NewFileTree(fileEntries(paths...))
+	ft.ToggleUnreviewedFilter()
+	require.True(t, ft.SelectByPath("h.go"))
+	ft.EnsureVisible(5)
+	require.Positive(t, ft.offset)
+
+	for _, path := range paths {
+		ft.SetReviewed(path, "fp-"+path)
+	}
+
+	assert.Equal(t, ScrollState{Total: 0, Offset: 0}, ft.ScrollState())
 }
 
 func TestFileTree_Render(t *testing.T) {

--- a/app/ui/sidepane/filetree_test.go
+++ b/app/ui/sidepane/filetree_test.go
@@ -220,6 +220,19 @@ func TestFileTree_UnreviewedAdvancePreservesVisibleRow(t *testing.T) {
 	assert.Equal(t, 2, ft.cursor-ft.offset, "next file should stay on the same visible row")
 }
 
+func TestFileTree_ToggleUnreviewedFilterResetsScrolledViewport(t *testing.T) {
+	ft := NewFileTree(fileEntries("a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go"))
+	require.True(t, ft.SelectByPath("h.go"))
+	ft.EnsureVisible(5)
+	require.Positive(t, ft.offset)
+
+	ft.ToggleUnreviewedFilter()
+	ft.EnsureVisible(5)
+
+	assert.Equal(t, "a.go", ft.SelectedFile())
+	assert.Zero(t, ft.offset, "toggle should restore the directory header at the top")
+}
+
 func TestFileTree_UnreviewedAndAnnotatedFiltersAreExclusive(t *testing.T) {
 	ft := NewFileTree(fileEntries("a.go", "b.go"))
 	ft.ToggleUnreviewedFilter()


### PR DESCRIPTION
- Keep the next unreviewed file on the same visible row after marking the current file reviewed.
- Preserve the unreviewed tree scroll position across force reloads, resetting it when the filtered tree becomes empty.

Closes #258.