### PR TITLE
fix(themes): detect terminal background inside tmux for --theme auto

### DIFF
--- a/app/termbg.go
+++ b/app/termbg.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/muesli/termenv"
+)
+
+// maskedTerm is the TERM value reported to termenv when the real TERM belongs
+// to tmux. any plain xterm value works — it only needs to not match termenv's
+// multiplexer prefixes so the OSC query path stays enabled.
+const maskedTerm = "xterm-256color"
+
+// tmuxQueryTimeout bounds the tmux subprocess so a wedged tmux server (e.g.
+// blocked on a run-shell hook) degrades to the next detection method instead
+// of stalling startup indefinitely. display-message answers over the local
+// socket in single-digit milliseconds when healthy.
+const tmuxQueryTimeout = 500 * time.Millisecond
+
+// detectDarkBackground reports whether the terminal background is dark-ish.
+// termenv refuses to send OSC status-report queries when TERM starts with
+// "tmux" or "screen" (multiplexers historically swallowed them), so inside
+// tmux its detection never queries the terminal and always falls back to
+// "dark". two tmux-specific paths run first:
+//
+//  1. `tmux display-message -p '#{client_theme}'` (tmux >= 3.5) — fed by the
+//     outer terminal's native light/dark reporting, needs no tty, and works
+//     in display-popup panes where tmux does not answer OSC 11 at all.
+//  2. termenv's own OSC 11 query with TERM masked — tmux answers it in
+//     regular panes with the outer terminal's current background.
+//
+// if both fail (old tmux inside a popup), termenv falls back to COLORFGBG
+// and then its dark default — same as before.
+func detectDarkBackground() bool {
+	if !insideTmux(os.Getenv("TMUX"), os.Getenv("TERM"), os.Getenv("TERM_PROGRAM")) {
+		return termenv.HasDarkBackground()
+	}
+	if dark, ok := parseTmuxClientTheme(tmuxClientTheme()); ok {
+		return dark
+	}
+	return termenv.NewOutput(os.Stdout, termenv.WithEnvironment(tmuxEnviron{})).HasDarkBackground()
+}
+
+// insideTmux reports whether the process runs inside tmux: the $TMUX socket
+// variable is the canonical signal; TERM=tmux-* and TERM=screen-* with
+// TERM_PROGRAM=tmux cover environments that scrub $TMUX. plain GNU screen is
+// excluded — it does not answer OSC 11, so masking TERM would only add a
+// query round-trip.
+func insideTmux(tmuxSocket, term, termProgram string) bool {
+	if tmuxSocket != "" {
+		return true
+	}
+	if strings.HasPrefix(term, "tmux") {
+		return true
+	}
+	return strings.HasPrefix(term, "screen") && termProgram == "tmux"
+}
+
+// tmuxClientTheme asks tmux for the attached client's reported theme.
+// returns the raw output; empty on error, timeout, or when the format is
+// unknown (tmux < 3.5 expands unknown formats to an empty string).
+// best-effort: with several clients attached to the session, tmux resolves
+// the format against its notion of the current client — the OSC 11 fallback
+// is relayed through the same client choice, so this path is no worse.
+func tmuxClientTheme() string {
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxQueryTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{client_theme}").Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// parseTmuxClientTheme maps tmux's client_theme output to a dark-background
+// bool. ok is false when the theme is unknown or unreported, signaling the
+// caller to fall through to the next detection method.
+func parseTmuxClientTheme(theme string) (dark, ok bool) {
+	switch strings.TrimSpace(theme) {
+	case "dark":
+		return true, true
+	case "light":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// tmuxEnviron exposes the process environment to termenv with TERM masked to
+// a plain xterm value, re-enabling termenv's OSC 11 background query inside
+// tmux. all other variables pass through unchanged.
+type tmuxEnviron struct{}
+
+// Environ returns the process environment with any TERM entry masked.
+func (tmuxEnviron) Environ() []string {
+	env := os.Environ()
+	for i, kv := range env {
+		if strings.HasPrefix(kv, "TERM=") {
+			env[i] = "TERM=" + maskedTerm
+		}
+	}
+	return env
+}
+
+// Getenv returns the masked TERM value for "TERM" and the real environment
+// value for every other key.
+func (tmuxEnviron) Getenv(key string) string {
+	if key == "TERM" {
+		return maskedTerm
+	}
+	return os.Getenv(key)
+}

--- a/app/termbg_test.go
+++ b/app/termbg_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsideTmux(t *testing.T) {
+	tests := []struct {
+		name        string
+		tmuxSocket  string
+		term        string
+		termProgram string
+		want        bool
+	}{
+		{name: "TMUX socket set", tmuxSocket: "/tmp/tmux-501/default,123,0", term: "xterm-256color", want: true},
+		{name: "tmux TERM", term: "tmux-256color", want: true},
+		{name: "plain tmux TERM", term: "tmux", want: true},
+		{name: "screen TERM under tmux", term: "screen-256color", termProgram: "tmux", want: true},
+		{name: "screen TERM without tmux", term: "screen-256color", want: false},
+		{name: "plain GNU screen", term: "screen", termProgram: "", want: false},
+		{name: "ghostty", term: "xterm-ghostty", want: false},
+		{name: "xterm", term: "xterm-256color", want: false},
+		{name: "empty TERM", term: "", want: false},
+		{name: "empty TERM with tmux program", term: "", termProgram: "tmux", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, insideTmux(tt.tmuxSocket, tt.term, tt.termProgram))
+		})
+	}
+}
+
+func TestParseTmuxClientTheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		theme    string
+		wantDark bool
+		wantOK   bool
+	}{
+		{name: "dark", theme: "dark", wantDark: true, wantOK: true},
+		{name: "light", theme: "light", wantDark: false, wantOK: true},
+		{name: "trailing newline from display-message", theme: "light\n", wantDark: false, wantOK: true},
+		{name: "empty means unreported", theme: "", wantOK: false},
+		{name: "whitespace only", theme: "\n", wantOK: false},
+		{name: "unknown value", theme: "auto", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dark, ok := parseTmuxClientTheme(tt.theme)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantDark, dark)
+			}
+		})
+	}
+}
+
+func TestTmuxEnviron_Getenv(t *testing.T) {
+	t.Setenv("TERM", "tmux-256color")
+	t.Setenv("REVDIFF_TEST_PASSTHROUGH", "value")
+
+	env := tmuxEnviron{}
+	assert.Equal(t, maskedTerm, env.Getenv("TERM"), "TERM should be masked")
+	assert.Equal(t, "value", env.Getenv("REVDIFF_TEST_PASSTHROUGH"), "other keys should pass through")
+}
+
+func TestTmuxEnviron_Environ(t *testing.T) {
+	t.Setenv("TERM", "tmux-256color")
+
+	env := tmuxEnviron{}.Environ()
+	assert.Contains(t, env, "TERM="+maskedTerm, "TERM entry should be masked")
+	assert.NotContains(t, env, "TERM=tmux-256color", "real TERM should not leak through")
+}

--- a/app/themes.go
+++ b/app/themes.go
@@ -9,8 +9,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/muesli/termenv"
-
 	"github.com/umputun/revdiff/app/fsutil"
 	"github.com/umputun/revdiff/app/highlight"
 	"github.com/umputun/revdiff/app/theme"
@@ -102,7 +100,7 @@ func resolveThemeName(opts options) string {
 	if opts.Theme != autoThemeName {
 		return opts.Theme
 	}
-	return resolveAutoThemeName(opts, termenv.HasDarkBackground())
+	return resolveAutoThemeName(opts, detectDarkBackground())
 }
 
 func resolveAutoThemeName(opts options, darkBackground bool) string {


### PR DESCRIPTION
**Disclosure: this is an AI-generated proposal** (written by Claude in a coding session I was driving). I reviewed the code and QA'd the behavior by hand, and it fixed the problem on my machine, but please review it as machine-written code.

`--theme auto` always picked the dark theme inside tmux. termenv refuses to send OSC status-report queries when `TERM` starts with `tmux` or `screen` (vendor/github.com/muesli/termenv/termenv_unix.go, the multiplexer guard in `termStatusReport`), so the background query never ran. Detection fell through to `COLORFGBG` (usually unset) and then the dark default, no matter what the terminal looked like.

Detection now runs two tmux-aware paths before giving up:

1. `tmux display-message -p '#{client_theme}'` (tmux >= 3.5). tmux reports the outer terminal's light/dark theme from the terminal's native theme reporting. This needs no tty, so it also works inside `display-popup` panes, where tmux does not answer OSC 11 at all. The subprocess has a 500ms timeout so an unresponsive tmux server falls through to the next path instead of stalling startup.
2. termenv's own OSC 11 query, with `TERM` masked as `xterm-256color` via a custom `termenv.Environ` so the multiplexer guard does not trip. tmux answers OSC 11 in regular panes with the outer terminal's current background. On older tmux this covers panes; popups fall through to the existing default.

Outside tmux, behavior is unchanged: plain `termenv.HasDarkBackground()`. If both tmux paths fail, the old fallback still applies (`COLORFGBG`, then dark).

QA'd on macOS with tmux 3.7b and Ghostty, light terminal theme active:

- regular pane: `--theme auto` resolves the light theme (before: always dark)
- `display-popup`: resolves the light theme (before: always dark; this is the path the Claude/codex plugin launchers use)
- switching the terminal between light and dark mid-session changes the result without reattaching, since Ghostty pushes theme-change reports and tmux tracks them
- outside tmux: unchanged

One known limit: with several clients attached to one session from terminals with different themes, tmux resolves `#{client_theme}` against its notion of the current client, which can be the other terminal. The OSC 11 fallback is relayed through the same client choice, so neither path is worse than the other here.
