### PR TITLE
feat(ui): off-screen change-count labels in diff frame (--frame-labels)

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -32,6 +32,7 @@ Then uncomment and edit the values you want to change.
 | `--line-numbers` | `REVDIFF_LINE_NUMBERS` | Show line numbers in diff gutter | `false` |
 | `--blame` | `REVDIFF_BLAME` | Show blame gutter | `false` |
 | `--word-diff` | `REVDIFF_WORD_DIFF` | Highlight intra-line word-level changes in paired add/remove lines | `false` |
+| `--frame-labels` | `REVDIFF_FRAME_LABELS` | Show off-screen change counts in the diff frame | `false` |
 | `--annotation-marker` | `REVDIFF_ANNOTATION_MARKER` | Prefix shown before annotation lines | `💬` |
 | `--exit-code-on-annotations` | `REVDIFF_EXIT_CODE_ON_ANNOTATIONS` | Exit 10 when annotations are produced | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Positional arguments support several forms:
 | `--line-numbers` | Show line numbers in diff gutter, env: `REVDIFF_LINE_NUMBERS` | `false` |
 | `--blame` | Show blame gutter, env: `REVDIFF_BLAME` | `false` |
 | `--word-diff` | Highlight intra-line word-level changes in paired add/remove lines, env: `REVDIFF_WORD_DIFF` | `false` |
+| `--frame-labels` | Show off-screen change counts in the diff frame, env: `REVDIFF_FRAME_LABELS` | `false` |
 | `--annotation-marker` | Prefix shown before annotation lines, env: `REVDIFF_ANNOTATION_MARKER` | `💬` |
 | `--exit-code-on-annotations` | Exit 10 when annotations are produced, env: `REVDIFF_EXIT_CODE_ON_ANNOTATIONS`, config: `exit-code-on-annotations` | `false` |
 | `--no-confirm-discard` | Skip confirmation when discarding annotations with Q, env: `REVDIFF_NO_CONFIRM_DISCARD` | `false` |

--- a/app/config.go
+++ b/app/config.go
@@ -38,6 +38,7 @@ type options struct {
 	AnnotationMarker      string   `long:"annotation-marker" ini-name:"annotation-marker" env:"REVDIFF_ANNOTATION_MARKER" default:"💬" description:"prefix shown before annotation lines"`
 	ExitCodeOnAnnotations bool     `long:"exit-code-on-annotations" ini-name:"exit-code-on-annotations" env:"REVDIFF_EXIT_CODE_ON_ANNOTATIONS" description:"exit 10 when annotations are produced"`
 	VimMotion             bool     `long:"vim-motion" ini-name:"vim-motion" env:"REVDIFF_VIM_MOTION" description:"enable vim-style motion preset (counts, gg, G, zz/zt/zb, ZZ/ZQ)"`
+	FrameLabels           bool     `long:"frame-labels" ini-name:"frame-labels" env:"REVDIFF_FRAME_LABELS" description:"show off-screen change counts in the diff frame"`
 	ChromaStyle           string   `long:"chroma-style" ini-name:"chroma-style" env:"REVDIFF_CHROMA_STYLE" default:"catppuccin-macchiato" description:"chroma style for syntax highlighting"`
 	AllFiles              bool     `long:"all-files" short:"A" no-ini:"true" description:"browse all tracked files, not just diffs (git and jj only)"`
 	CompareOld            string   `long:"compare-old" no-ini:"true" description:"compare mode: old file path (use with --compare-new)"`

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -564,6 +564,37 @@ func TestParseArgs_VimMotion(t *testing.T) {
 	})
 }
 
+func TestParseArgs_FrameLabels(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.False(t, opts.FrameLabels)
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		opts, err := parseArgs(append(noConfigArgs(t), "--frame-labels"))
+		require.NoError(t, err)
+		assert.True(t, opts.FrameLabels)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("REVDIFF_FRAME_LABELS", "true")
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.True(t, opts.FrameLabels)
+	})
+
+	t.Run("config file", func(t *testing.T) {
+		cfgDir := t.TempDir()
+		cfgPath := filepath.Join(cfgDir, "config")
+		err := os.WriteFile(cfgPath, []byte("[Application Options]\nframe-labels = true\n"), 0o600)
+		require.NoError(t, err)
+		opts, err := parseArgs([]string{"--config", cfgPath})
+		require.NoError(t, err)
+		assert.True(t, opts.FrameLabels)
+	})
+}
+
 func TestParseArgs_OutputFlag(t *testing.T) {
 	opts, err := parseArgs([]string{"-o", "/tmp/out.txt"})
 	require.NoError(t, err)

--- a/app/main.go
+++ b/app/main.go
@@ -214,6 +214,7 @@ func run(opts options) (int, error) {
 		ShowUntracked:        opts.startupUntracked(),
 		WordDiff:             opts.WordDiff,
 		VimMotion:            opts.VimMotion,
+		FrameLabels:          opts.FrameLabels,
 		ReviewInfo: reviewInfoFromOptions(opts, reviewInfoInputs{
 			workDir:     workDir,
 			vcsType:     vcsType,

--- a/app/ui/framelabel.go
+++ b/app/ui/framelabel.go
@@ -1,0 +1,271 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+
+	"github.com/umputun/revdiff/app/diff"
+	"github.com/umputun/revdiff/app/ui/style"
+)
+
+// bottom-frame label layout constants.
+const (
+	// frameLabelLeadDashes is the number of border runes drawn between the
+	// corner and the label ("└─ +x/-y …").
+	frameLabelLeadDashes = 1
+	// frameLabelEllipsis is appended when the label is truncated to fit.
+	frameLabelEllipsis = "..."
+	// frameLabelMinAvail is the smallest usable dash region (after the lead)
+	// worth placing a label into; below it the border stays plain.
+	frameLabelMinAvail = 10
+)
+
+// NormalBorder runes used by the diff pane; the label surgery locates and
+// rebuilds the dash run between the two corners of a border line.
+const (
+	topLeftCorner     = "┌"
+	topRightCorner    = "┐"
+	bottomLeftCorner  = "└"
+	bottomRightCorner = "┘"
+	horizBar          = "─"
+)
+
+// frameSpan is one styled run in a frame label. color == "" renders in the
+// frame's own color (the border SGR already active on the line); a non-empty
+// color wraps the run and is restored to the border SGR after it.
+type frameSpan struct {
+	text  string
+	color style.Color
+}
+
+// frameLabelsEnabled reports whether the frame-label hints should be drawn:
+// the --frame-labels flag is set, a file is loaded, and it has at least one
+// change. the change gate keeps pure-context views (plain file, markdown TOC)
+// from showing "no modified lines below" on every screen.
+func (m Model) frameLabelsEnabled() bool {
+	return m.cfg.frameLabels && m.file.name != "" && len(m.file.lines) > 0 &&
+		(m.file.adds > 0 || m.file.removes > 0)
+}
+
+// applyDiffTopLabel embeds a "+x/-y modified lines above" / "no modified lines
+// above" hint into the diff pane's top border line (the changes the reader has
+// scrolled past). see applyDiffBottomLabel for the shared surgery contract.
+func (m Model) applyDiffTopLabel(rendered string) string {
+	if !m.frameLabelsEnabled() {
+		return rendered
+	}
+	lines := strings.Split(rendered, "\n")
+	if len(lines) == 0 {
+		return rendered
+	}
+	newTop, ok := m.buildFrameLabelLine(lines[0], topLeftCorner, topRightCorner, m.aboveSpans())
+	if !ok {
+		return rendered
+	}
+	lines[0] = newTop
+	return strings.Join(lines, "\n")
+}
+
+// applyDiffBottomLabel embeds a "+x/-y modified lines below" / "no modified
+// lines below" hint into the diff pane's bottom border line. rendered is the
+// fully styled diff pane (post-scrollbar); the transform rebuilds only the
+// border line, preserving its display width and ANSI envelope so horizontal
+// joins and the frame color stay intact. no-op when disabled or when the
+// border line can't be located / is too narrow.
+func (m Model) applyDiffBottomLabel(rendered string) string {
+	if !m.frameLabelsEnabled() {
+		return rendered
+	}
+	lines := strings.Split(rendered, "\n")
+	last := len(lines) - 1
+	if last < 0 {
+		return rendered
+	}
+	newBottom, ok := m.buildFrameLabelLine(lines[last], bottomLeftCorner, bottomRightCorner, m.belowSpans())
+	if !ok {
+		return rendered
+	}
+	lines[last] = newBottom
+	return strings.Join(lines, "\n")
+}
+
+// buildFrameLabelLine rewrites a single border line with the given spans
+// embedded between leftCorner and rightCorner. returns (line, false) when the
+// line is not a recognizable border of that shape or the dash region is too
+// narrow to hold a label.
+func (m Model) buildFrameLabelLine(line, leftCorner, rightCorner string, spans []frameSpan) (string, bool) {
+	li := strings.Index(line, leftCorner)
+	ri := strings.LastIndex(line, rightCorner)
+	if li < 0 || ri < 0 || ri <= li {
+		return "", false
+	}
+	leadingSGR := line[:li]               // border fg/bg SGR active for the whole line
+	suffix := line[ri+len(rightCorner):]  // trailing reset after the corner
+	mid := line[li+len(leftCorner) : ri]  // the "─" run between the corners
+	width := strings.Count(mid, horizBar) // dash count == inner pane width
+	avail := width - frameLabelLeadDashes
+	if width <= 0 || avail < frameLabelMinAvail {
+		return "", false
+	}
+
+	label, used := renderFrameLabel(spans, avail, leadingSGR)
+	fill := width - frameLabelLeadDashes - used
+	if fill < 0 {
+		fill = 0
+	}
+	var b strings.Builder
+	b.WriteString(leadingSGR)
+	b.WriteString(leftCorner)
+	b.WriteString(strings.Repeat(horizBar, frameLabelLeadDashes))
+	b.WriteString(label)
+	b.WriteString(strings.Repeat(horizBar, fill))
+	b.WriteString(rightCorner)
+	b.WriteString(suffix)
+	return b.String(), true
+}
+
+// belowSpans returns the label runs for the bottom border: changes below the
+// viewport's last visible row.
+func (m Model) belowSpans() []frameSpan {
+	adds, removes := m.modifiedBelow()
+	return m.changeLabelSpans(adds, removes, "modified lines below", "no modified lines below")
+}
+
+// aboveSpans returns the label runs for the top border: changes above the
+// viewport's first visible row.
+func (m Model) aboveSpans() []frameSpan {
+	adds, removes := m.modifiedAbove()
+	return m.changeLabelSpans(adds, removes, "modified lines above", "no modified lines above")
+}
+
+// changeLabelSpans builds the styled runs: "+x" in the add color, "-y" in the
+// remove color, " <suffix>" in the frame color; the all-frame-color <none>
+// text when there are no changes on that side.
+func (m Model) changeLabelSpans(adds, removes int, suffix, none string) []frameSpan {
+	if adds == 0 && removes == 0 {
+		return []frameSpan{{text: none}}
+	}
+	return []frameSpan{
+		{text: fmt.Sprintf("+%d", adds), color: m.resolver.Color(style.ColorKeyAddLineFg)},
+		{text: "/"},
+		{text: fmt.Sprintf("-%d", removes), color: m.resolver.Color(style.ColorKeyRemoveLineFg)},
+		{text: " " + suffix},
+	}
+}
+
+// renderFrameLabel wraps spans in surround spaces (frame-colored) and renders
+// them capped at avail display cells, returning the ANSI string and its width.
+func renderFrameLabel(spans []frameSpan, avail int, borderSGR string) (out string, used int) {
+	surrounded := make([]frameSpan, 0, len(spans)+2)
+	surrounded = append(surrounded, frameSpan{text: " "})
+	surrounded = append(surrounded, spans...)
+	surrounded = append(surrounded, frameSpan{text: " "})
+	return renderFrameSpans(surrounded, avail, borderSGR)
+}
+
+// renderFrameSpans emits spans into at most avail display cells. when the total
+// plain width exceeds avail the tail is cut and frameLabelEllipsis appended
+// (in the frame color). colored spans are wrapped with their color and closed
+// by re-emitting borderSGR so subsequent runs return to the frame color.
+func renderFrameSpans(spans []frameSpan, avail int, borderSGR string) (out string, used int) {
+	total := 0
+	for _, s := range spans {
+		total += runewidth.StringWidth(s.text)
+	}
+	budget := avail
+	ellipsis := ""
+	if total > avail {
+		ellipsis = frameLabelEllipsis
+		budget = avail - runewidth.StringWidth(frameLabelEllipsis)
+		if budget < 0 {
+			budget = 0
+		}
+	}
+
+	var b strings.Builder
+	for _, s := range spans {
+		if used >= budget {
+			break
+		}
+		text := s.text
+		w := runewidth.StringWidth(text)
+		if used+w > budget {
+			text = cutRightToWidth(text, budget-used)
+			w = runewidth.StringWidth(text)
+		}
+		if s.color != "" {
+			b.WriteString(string(s.color))
+			b.WriteString(text)
+			b.WriteString(borderSGR)
+		} else {
+			b.WriteString(text)
+		}
+		used += w
+	}
+	if ellipsis != "" {
+		b.WriteString(ellipsis)
+		used += runewidth.StringWidth(ellipsis)
+	}
+	return b.String(), used
+}
+
+// modifiedBelow counts added and removed lines below the diff viewport's last
+// visible visual row, i.e. the changes the reader has not scrolled to yet.
+// returns (0, 0) when the viewport already reaches the end of the file.
+func (m Model) modifiedBelow() (adds, removes int) {
+	if len(m.file.lines) == 0 {
+		return 0, 0
+	}
+	bottomRow := m.layout.viewport.YOffset + m.layout.viewport.Height - 1
+	idx, _ := m.visualRowToDiffLine(bottomRow)
+	from := idx + 1 // idx == -1 (file-annotation region) → count the whole file
+	if from < 0 {
+		from = 0
+	}
+	if from >= len(m.file.lines) {
+		return 0, 0
+	}
+	return diff.CountChanges(m.file.lines[from:])
+}
+
+// modifiedAbove counts added and removed lines above the diff viewport's first
+// visible visual row, i.e. the changes the reader has scrolled past. returns
+// (0, 0) when the viewport is at the top of the file.
+func (m Model) modifiedAbove() (adds, removes int) {
+	if len(m.file.lines) == 0 {
+		return 0, 0
+	}
+	idx, _ := m.visualRowToDiffLine(m.layout.viewport.YOffset)
+	upto := idx // lines strictly above the first visible line
+	if upto < 0 {
+		upto = 0
+	}
+	if upto > len(m.file.lines) {
+		upto = len(m.file.lines)
+	}
+	return diff.CountChanges(m.file.lines[:upto])
+}
+
+// cutRightToWidth truncates s to at most w display cells, keeping the start.
+// returns "" for w <= 0. wide runes that would straddle the boundary are dropped.
+func cutRightToWidth(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(s) <= w {
+		return s
+	}
+	var b strings.Builder
+	used := 0
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if used+rw > w {
+			break
+		}
+		b.WriteRune(r)
+		used += rw
+	}
+	return b.String()
+}

--- a/app/ui/framelabel_test.go
+++ b/app/ui/framelabel_test.go
@@ -1,0 +1,203 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/umputun/revdiff/app/diff"
+	"github.com/umputun/revdiff/app/ui/style"
+)
+
+// diffLinesForLabel builds a file with a leading context block followed by
+// removes then adds, so change lines sit below a short viewport.
+func diffLinesForLabel(adds, removes int) []diff.DiffLine {
+	var lines []diff.DiffLine
+	for i := 0; i < 20; i++ {
+		lines = append(lines, diff.DiffLine{ChangeType: diff.ChangeContext, OldNum: i + 1, NewNum: i + 1, Content: fmt.Sprintf("ctx %d", i)})
+	}
+	for i := 0; i < removes; i++ {
+		lines = append(lines, diff.DiffLine{ChangeType: diff.ChangeRemove, OldNum: 21 + i, Content: fmt.Sprintf("old %d", i)})
+	}
+	for i := 0; i < adds; i++ {
+		lines = append(lines, diff.DiffLine{ChangeType: diff.ChangeAdd, NewNum: 21 + i, Content: fmt.Sprintf("new %d", i)})
+	}
+	return lines
+}
+
+func labelModel(t *testing.T, adds, removes int) Model {
+	t.Helper()
+	res := style.NewResolver(style.Colors{
+		Border: "#888888", Accent: "#00aaff",
+		AddFg: "#00ff00", RemoveFg: "#ff0000",
+		Normal: "#cccccc", Muted: "#777777",
+	})
+	m := testModel([]string{"a.go"}, nil)
+	m.resolver = res
+	m.cfg.frameLabels = true
+	m.file.name = "a.go"
+	m.file.lines = diffLinesForLabel(adds, removes)
+	m.file.adds, m.file.removes = adds, removes
+	m.layout.viewport.Height = 10
+	return m
+}
+
+func TestModel_ModifiedBelow(t *testing.T) {
+	m := labelModel(t, 3, 2) // 20 ctx, then 2 removes, 3 adds
+
+	t.Run("top of file counts all changes below", func(t *testing.T) {
+		m.layout.viewport.YOffset = 0
+		a, r := m.modifiedBelow()
+		assert.Equal(t, 3, a)
+		assert.Equal(t, 2, r)
+	})
+
+	t.Run("scrolled to end counts nothing below", func(t *testing.T) {
+		m.layout.viewport.YOffset = 100
+		a, r := m.modifiedBelow()
+		assert.Equal(t, 0, a)
+		assert.Equal(t, 0, r)
+	})
+
+	t.Run("mid-scroll counts only remaining changes below", func(t *testing.T) {
+		// lines: 0..19 context, 20 remove#0, 21 remove#1, 22..24 adds.
+		// bottom visible row = 20 (remove#0) → below remain 1 remove + 3 adds.
+		m.layout.viewport.YOffset = 11 // bottom row = 11+10-1 = 20
+		a, r := m.modifiedBelow()
+		assert.Equal(t, 3, a)
+		assert.Equal(t, 1, r)
+	})
+}
+
+func TestModel_ModifiedAbove(t *testing.T) {
+	m := labelModel(t, 3, 2)
+
+	t.Run("top of file counts nothing above", func(t *testing.T) {
+		m.layout.viewport.YOffset = 0
+		a, r := m.modifiedAbove()
+		assert.Equal(t, 0, a)
+		assert.Equal(t, 0, r)
+	})
+
+	t.Run("mid-scroll counts changes scrolled past", func(t *testing.T) {
+		// first visible row = 22 (add#0) → above are 2 removes + 0 adds.
+		m.layout.viewport.YOffset = 22
+		a, r := m.modifiedAbove()
+		assert.Equal(t, 0, a)
+		assert.Equal(t, 2, r)
+	})
+
+	t.Run("scrolled to end counts every change above the last visible line", func(t *testing.T) {
+		// the last diff line (add#2, idx 24) is always on screen, so it is never
+		// "above": above = 2 removes + 2 adds (idx 22,23).
+		m.layout.viewport.YOffset = 100 // clamps to the last line index
+		a, r := m.modifiedAbove()
+		assert.Equal(t, 2, a)
+		assert.Equal(t, 2, r)
+	})
+}
+
+// bottomLine renders a diff pane and returns its bottom border line.
+func bottomLine(m Model, width int) string {
+	pane := m.resolver.Style(style.StyleKeyDiffPane).Width(width).Height(4).Render("body")
+	pl := strings.Split(pane, "\n")
+	return pl[len(pl)-1]
+}
+
+func topLine(m Model, width int) string {
+	pane := m.resolver.Style(style.StyleKeyDiffPane).Width(width).Height(4).Render("body")
+	return strings.Split(pane, "\n")[0]
+}
+
+func TestModel_BuildBottomLabel(t *testing.T) {
+	m := labelModel(t, 5, 3)
+	m.layout.viewport.YOffset = 0
+	orig := bottomLine(m, 60)
+
+	got, ok := m.buildFrameLabelLine(orig, bottomLeftCorner, bottomRightCorner, m.belowSpans())
+	require.True(t, ok)
+
+	assert.Equal(t, lipgloss.Width(orig), lipgloss.Width(got), "label must not change border width")
+	plain := ansi.Strip(got)
+	assert.Contains(t, plain, "+5/-3 modified lines below")
+	assert.True(t, strings.HasPrefix(plain, "└─ +5/-3"), "label starts just after the corner: %q", plain)
+	assert.True(t, strings.HasSuffix(plain, "┘"))
+	assert.Contains(t, got, string(m.resolver.Color(style.ColorKeyAddLineFg))+"+5")
+	assert.Contains(t, got, string(m.resolver.Color(style.ColorKeyRemoveLineFg))+"-3")
+}
+
+func TestModel_BuildTopLabel(t *testing.T) {
+	m := labelModel(t, 5, 3)
+	m.layout.viewport.YOffset = 100 // scrolled to end (last add line stays on screen)
+	orig := topLine(m, 60)
+
+	got, ok := m.buildFrameLabelLine(orig, topLeftCorner, topRightCorner, m.aboveSpans())
+	require.True(t, ok)
+
+	assert.Equal(t, lipgloss.Width(orig), lipgloss.Width(got))
+	plain := ansi.Strip(got)
+	assert.Contains(t, plain, "+4/-3 modified lines above")
+	assert.True(t, strings.HasPrefix(plain, "┌─ +4/-3"), "label starts just after the corner: %q", plain)
+	assert.True(t, strings.HasSuffix(plain, "┐"))
+}
+
+func TestModel_BottomLabel_NoChangesBelow(t *testing.T) {
+	m := labelModel(t, 2, 1)
+	m.layout.viewport.YOffset = 500 // past the end
+	got, ok := m.buildFrameLabelLine(bottomLine(m, 50), bottomLeftCorner, bottomRightCorner, m.belowSpans())
+	require.True(t, ok)
+	assert.Contains(t, ansi.Strip(got), "no modified lines below")
+}
+
+func TestModel_TopLabel_NoChangesAbove(t *testing.T) {
+	m := labelModel(t, 2, 1)
+	m.layout.viewport.YOffset = 0 // at the top
+	got, ok := m.buildFrameLabelLine(topLine(m, 50), topLeftCorner, topRightCorner, m.aboveSpans())
+	require.True(t, ok)
+	assert.Contains(t, ansi.Strip(got), "no modified lines above")
+}
+
+func TestModel_BuildLabel_Truncation(t *testing.T) {
+	m := labelModel(t, 5, 3)
+	m.layout.viewport.YOffset = 0
+	orig := bottomLine(m, 20)
+	got, ok := m.buildFrameLabelLine(orig, bottomLeftCorner, bottomRightCorner, m.belowSpans())
+	require.True(t, ok)
+	plain := ansi.Strip(got)
+	assert.Equal(t, lipgloss.Width(orig), lipgloss.Width(got))
+	assert.Contains(t, plain, "...", "narrow border truncates with ellipsis: %q", plain)
+	assert.True(t, strings.HasPrefix(plain, "└─ +5/-3"), "numeric prefix survives truncation: %q", plain)
+}
+
+func TestModel_ApplyLabels_FlagOff(t *testing.T) {
+	m := labelModel(t, 5, 3)
+	m.cfg.frameLabels = false // flag hides the feature
+	pane := m.resolver.Style(style.StyleKeyDiffPane).Width(50).Height(4).Render("body")
+	assert.Equal(t, pane, m.applyDiffTopLabel(pane), "top label off when flag disabled")
+	assert.Equal(t, pane, m.applyDiffBottomLabel(pane), "bottom label off when flag disabled")
+}
+
+func TestModel_ApplyLabels_SkipsPureContext(t *testing.T) {
+	m := labelModel(t, 0, 0) // flag on but no changes at all
+	pane := m.resolver.Style(style.StyleKeyDiffPane).Width(50).Height(4).Render("body")
+	assert.Equal(t, pane, m.applyDiffTopLabel(pane), "pure-context file keeps a plain top border")
+	assert.Equal(t, pane, m.applyDiffBottomLabel(pane), "pure-context file keeps a plain bottom border")
+}
+
+// TestModel_FrameLabelDemo prints the rendered borders at several scroll
+// positions so the visual result can be eyeballed with `go test -run Demo -v`.
+func TestModel_FrameLabelDemo(t *testing.T) {
+	m := labelModel(t, 5, 3)
+	m.layout.viewport.Height = 8
+	for _, off := range []int{0, 12, 100} {
+		m.layout.viewport.YOffset = off
+		top, _ := m.buildFrameLabelLine(topLine(m, 60), topLeftCorner, topRightCorner, m.aboveSpans())
+		bot, _ := m.buildFrameLabelLine(bottomLine(m, 60), bottomLeftCorner, bottomRightCorner, m.belowSpans())
+		t.Logf("off=%d\n  top: %q\n  bot: %q", off, ansi.Strip(top), ansi.Strip(bot))
+	}
+}

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -320,6 +320,7 @@ type modelConfigState struct {
 	annotPrefix        string             // cached: marker + " "
 	annotFilePrefix    string             // cached: marker + " file: "
 	outputPath         string             // --output destination for the O in-session flush; empty disables it
+	frameLabels        bool               // draw off-screen change-count hints in the diff frame borders
 }
 
 // layoutState holds viewport and layout concerns that change on resize and pane toggles.
@@ -746,6 +747,10 @@ type ModelConfig struct {
 	// the modal-key handler and keymap.Resolve. Copied into modes.vimMotion at
 	// construction; the feature is gated on that field everywhere.
 	VimMotion bool
+	// FrameLabels enables the off-screen change-count hints drawn into the diff
+	// pane's top ("+x/-y changes above") and bottom ("+x/-y modified lines
+	// below") border lines. Off by default; copied into modelConfigState.frameLabels.
+	FrameLabels bool
 	// AnnotationMarker is the prefix shown before annotation lines.
 	// Empty is preserved so callers can intentionally render no marker.
 	AnnotationMarker string
@@ -857,6 +862,7 @@ func NewModel(cfg ModelConfig) (Model, error) {
 			annotPrefix:        cfg.AnnotationMarker + " ",
 			annotFilePrefix:    cfg.AnnotationMarker + " file: ",
 			outputPath:         cfg.OutputPath,
+			frameLabels:        cfg.FrameLabels,
 		},
 		layout: layoutState{
 			focus: paneTree,

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -62,7 +62,7 @@ func (m Model) View() string {
 			Width(diffPaneW).
 			Height(ph).
 			Render(diffContent)
-		mainView = m.applyScrollbar(diffPane)
+		mainView = m.applyDiffTopLabel(m.applyDiffBottomLabel(m.applyScrollbar(diffPane)))
 
 	case m.file.singleFile && m.file.mdTOC != nil:
 		// single-file markdown with TOC: two-pane layout with TOC in left pane
@@ -112,7 +112,7 @@ func (m Model) renderTwoPaneLayout(leftContent, diffContent string, leftScroll s
 		Width(diffPaneW).
 		Height(ph).
 		Render(diffContent)
-	diffPane = m.applyScrollbar(diffPane)
+	diffPane = m.applyDiffTopLabel(m.applyDiffBottomLabel(m.applyScrollbar(diffPane)))
 
 	return lipgloss.JoinHorizontal(lipgloss.Top, leftPane, diffPane)
 }

--- a/site/docs.html
+++ b/site/docs.html
@@ -406,6 +406,7 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>--cross-file-hunks</code></td><td>Allow <code>[</code> and <code>]</code> to continue into adjacent files</td><td><code>false</code></td></tr>
                 <tr><td><code>--line-numbers</code></td><td>Show line numbers in diff gutter</td><td><code>false</code></td></tr>
                 <tr><td><code>--word-diff</code></td><td>Highlight intra-line word-level changes in paired add/remove lines</td><td><code>false</code></td></tr>
+                <tr><td><code>--frame-labels</code></td><td>Show off-screen change counts in the diff frame</td><td><code>false</code></td></tr>
                 <tr><td><code>--annotation-marker</code></td><td>Prefix shown before annotation lines</td><td><code>💬</code></td></tr>
                 <tr><td><code>--exit-code-on-annotations</code></td><td>Exit 10 when annotations are produced</td><td><code>false</code></td></tr>
                 <tr><td><code>--no-confirm-discard</code></td><td>Skip discard confirmation</td><td><code>false</code></td></tr>


### PR DESCRIPTION
Off-screen change-count hints in the diff pane's frame borders, gated behind `--frame-labels` (off by default).

- Bottom border: `+x/-y modified lines below` — changes past the viewport bottom
- Top border: `+x/-y modified lines above` — changes scrolled above the viewport top
- Collapses to `no modified lines below` / `no modified lines above` at the ends

`+x` uses the add color, `-y` the remove color, the rest the frame color. Updates live on scroll. Skipped for pure-context views (plain file, markdown TOC) — no changes to count.

```
┌─ +4/-3 modified lines above ───────────────────────────────┐
│  ...diff...                                                │
└─ no modified lines below ──────────────────────────────────┘
```

## Motivation

In a large file you can't tell whether more changes lie below the viewport without scrolling to the end. `no modified lines below` says the rest of the file is unchanged — skip the scroll, move to the next file. The top label does the same looking back: `no modified lines above` means nothing was missed higher up.

## Flag

`--frame-labels` / `REVDIFF_FRAME_LABELS` / `frame-labels = true`. Off by default.

## Implementation

- `app/ui/framelabel.go` — post-render surgery on the pane's top/bottom border lines (sibling of the scrollbar transform in `scrollbar.go`). Reuses the line's own leading SGR to restore frame color after each colored run, so display width and the ANSI envelope stay intact (safe for the horizontal pane join).
- `modifiedAbove` / `modifiedBelow` map the viewport edge to a diff-line index via the existing `visualRowToDiffLine`, then `diff.CountChanges` on the slice above/below.
- Wired into both `View()` branches after `applyScrollbar`; gated by `frameLabelsEnabled()` (flag + file loaded + has changes).
- Flag threaded `options` → `main.go` → `ModelConfig.FrameLabels` → `modelConfigState.frameLabels`. Model reads the resolved bool, does not re-derive.

## Not included

- No SKILL.md entry: display-only preference, not agent-actionable — matches how `--vim-motion` / `--line-numbers` / `--word-diff` / `--compact` are handled (references only, absent from SKILL.md).
- No runtime toggle key — flag/env/config only.

## Docs

Flag row added to README.md, site/docs.html, references/config.md.

## Tests

`app/ui/framelabel_test.go` — above/below counts (top/mid/end scroll), top+bottom label build, no-changes states, ellipsis truncation, flag-off no-op, pure-context skip. `TestParseArgs_FrameLabels` in `app/config_test.go` (flag/env/config). `make test` green; gofmt + `go vet` clean.
