### PR TITLE
fix(revdiff-planning): agterm overlay branch for plan-review launcher

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -560,5 +560,5 @@ LAUNCHER
     print_output_and_exit "${rc:-1}"
 fi
 
-echo "error: no overlay terminal available (requires tmux, zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm)" >&2
+echo "error: no overlay terminal available (requires agterm, tmux, zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm)" >&2
 exit 1

--- a/app/plugin_exit_code_test.go
+++ b/app/plugin_exit_code_test.go
@@ -727,6 +727,7 @@ func launcherBackends() []launcherBackend {
 		{name: "ghostty", command: "osascript", env: map[string]string{"TERM_PROGRAM": "ghostty"}},
 		{name: "iterm2", command: "osascript", env: map[string]string{"ITERM_SESSION_ID": "w0t0p0:ABC"}},
 		{name: "emacs", command: "emacsclient", env: map[string]string{"INSIDE_EMACS": "vterm"}},
+		{name: "agterm", command: "agtermctl", env: map[string]string{"AGTERM_SESSION_ID": "sess-1"}},
 	}
 }
 

--- a/app/testdata/plugin-exit-code/fake-overlay-backend.sh
+++ b/app/testdata/plugin-exit-code/fake-overlay-backend.sh
@@ -121,6 +121,28 @@ case "$cmd_name" in
                 ;;
         esac
         ;;
+    agtermctl)
+        case "${1:-} ${2:-}" in
+            "session overlay")
+                # session overlay open <cmd> --target ... --cwd ... --block; run
+                # the command string in a shell and propagate its exit code,
+                # mirroring agtermctl running the overlay command and returning rc
+                if [ "${3:-}" = "open" ]; then
+                    sh -c "${4:-}"
+                    exit $?
+                fi
+                exit 0
+                ;;
+            "session status")
+                # blocked/active indicator toggles; no-op in the fake
+                exit 0
+                ;;
+            *)
+                echo "unexpected agtermctl command: $*" >&2
+                exit 1
+                ;;
+        esac
+        ;;
     *)
         echo "unexpected fake backend: $cmd_name" >&2
         exit 1

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -561,5 +561,5 @@ LAUNCHER
     print_output_and_exit "${rc:-1}"
 fi
 
-echo "error: no overlay terminal available (requires tmux, zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm)" >&2
+echo "error: no overlay terminal available (requires agterm, tmux, zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm)" >&2
 exit 1

--- a/plugins/revdiff-planning/README.md
+++ b/plugins/revdiff-planning/README.md
@@ -9,7 +9,7 @@ Claude Code plugin that intercepts `ExitPlanMode` and opens the proposed plan in
 /plugin install revdiff-planning@revdiff
 ```
 
-Requires the `revdiff` binary in `PATH` and one of: tmux, Zellij, herdr, kitty, wezterm, cmux, ghostty (macOS), iTerm2 (macOS), or Emacs vterm.
+Requires the `revdiff` binary in `PATH` and one of: agterm, tmux, Zellij, herdr, kitty, wezterm, cmux, ghostty (macOS), iTerm2 (macOS), or Emacs vterm.
 
 cmux is detected before ghostty when `$CMUX_SURFACE_ID` is set, `__CFBundleIdentifier=com.cmuxterm.app`, or `GHOSTTY_RESOURCES_DIR` / `GHOSTTY_BIN_DIR` contains `cmux.app`, so cmux uses the cmux CLI instead of Ghostty AppleScript.
 

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -85,6 +85,35 @@ is_cmux_session() {
     return 1
 }
 
+# agterm: `agtermctl session overlay open <cmd> --block` opens revdiff in a full-pane overlay over
+# the agent's own session and blocks until it exits — like tmux's display-popup -E, so no sentinel is
+# needed. checked first so an agterm session always uses its native overlay even when a multiplexer is
+# also present. needs $AGTERM_SESSION_ID (set in every agterm session) and agtermctl on PATH; passes
+# $AGTERM_SOCKET so it reaches the agterm instance hosting this session, and --cwd "$CWD" so the
+# overlay runs in the launcher's directory. the overlay-open stdout is discarded so only the review
+# output reaches this script's stdout (the hook reads it for annotations); revdiff's own exit code is
+# propagated. sets the session status indicator to blocked while the overlay is up and restores active
+# on every exit path.
+if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
+    AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
+    [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
+    # record which pane owns the block so agterm nav lands on the reviewing pane; agterm defaults to
+    # the left pane otherwise, which misroutes navigation from a split or scratch session. only a
+    # recognized value is passed, so anything else falls back to agterm's own default.
+    AGTERM_STATUS=(session status blocked --blink)
+    case "${AGTERM_PANE:-}" in
+        left|right|scratch) AGTERM_STATUS+=(--pane "$AGTERM_PANE") ;;
+    esac
+    agtermctl "${AGTERM_STATUS[@]}" "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
+    trap 'agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true; rm -f "$OUTPUT_FILE"' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    rc=0
+    agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" --cwd "$CWD" --block >/dev/null || rc=$?
+    cat "$OUTPUT_FILE"
+    exit "$rc"
+fi
+
 # tmux: display-popup -E blocks until command exits
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     # -T (title) requires tmux 3.3+; skip on older versions
@@ -488,5 +517,5 @@ LAUNCHER
     exit "${rc:-1}"
 fi
 
-echo "error: no overlay terminal available (requires tmux, zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm)" >&2
+echo "error: no overlay terminal available (requires agterm, tmux, zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm)" >&2
 exit 1

--- a/plugins/revdiff-planning/scripts/plan-review-hook.py
+++ b/plugins/revdiff-planning/scripts/plan-review-hook.py
@@ -11,7 +11,7 @@ returns PreToolUse hook JSON response with permissionDecision:
 
 requirements:
   - revdiff binary in PATH
-  - tmux, herdr, kitty, wezterm, cmux, or ghostty (macOS) terminal
+  - agterm, tmux, zellij, herdr, kitty, wezterm, cmux, ghostty, iTerm2, or emacs vterm terminal
 """
 
 from __future__ import annotations


### PR DESCRIPTION
plan review in revdiff was a no-op under plain agterm. `launch-plan-review.sh` detected tmux/zellij/herdr/kitty/wezterm/cmux/ghostty/iTerm2/emacs but had no agterm branch, so under agterm (`AGTERM_SESSION_ID` set, `agtermctl` on PATH, no multiplexer) every branch fell through to `exit 1` and `plan-review-hook.py` treated it as a soft failure and fell back to the text confirmation.

this adds an agterm overlay branch, ported from the sibling `cc-thingz` planning launcher and placed first, before tmux. It is adapted for this launcher: the overlay-open stdout is discarded so only revdiff's output reaches the hook (which reads stdout for annotations), and revdiff's exit code is propagated since this launcher sets `REVDIFF_EXIT_CODE_ON_ANNOTATIONS=true`. The session status is set to blocked while the overlay is up and restored via EXIT/INT/TERM traps, and the pane is routed via `AGTERM_PANE`.

also in this branch:
- lists agterm in the launcher fall-through message and the plugin README terminal list
- adds agterm to the diff-review `launch-revdiff.sh` fall-through message (both copies) for consistency, those launchers already had an agterm branch
- syncs the hook's requirements docstring to the full backend set
- adds an agterm backend to the launcher exit-code test, covering the new branch and the previously-untested `launch-revdiff.sh` agterm branches

Related to #270
