### PR TITLE
fix(ui): restore mouse after source editor return

### DIFF
--- a/app/ui/editor.go
+++ b/app/ui/editor.go
@@ -113,6 +113,7 @@ type sourceEditorFinishedMsg struct {
 	err                  error
 	fileName             string
 	reloadAfterCleanExit bool
+	restoreMouse         bool
 }
 
 // sourceEditorTargetResult is the UI-side decision for one source-editor
@@ -153,7 +154,12 @@ func (m *Model) openSourceEditor() tea.Cmd {
 		}
 	}
 	return tea.ExecProcess(cmd, func(runErr error) tea.Msg {
-		return sourceEditorFinishedMsg{err: runErr, fileName: result.fileName, reloadAfterCleanExit: result.reloadAfterCleanExit}
+		return sourceEditorFinishedMsg{
+			err:                  runErr,
+			fileName:             result.fileName,
+			reloadAfterCleanExit: result.reloadAfterCleanExit,
+			restoreMouse:         m.cfg.mouseTracking,
+		}
 	})
 }
 
@@ -334,25 +340,32 @@ func (m Model) handleEditorFinished(msg editorFinishedMsg) (tea.Model, tea.Cmd) 
 }
 
 func (m Model) handleSourceEditorFinished(msg sourceEditorFinishedMsg) (tea.Model, tea.Cmd) {
+	var restoreMouseCmd tea.Cmd
+	if msg.restoreMouse {
+		restoreMouseCmd = tea.EnableMouseCellMotion
+	}
 	if msg.err != nil {
 		log.Printf("[WARN] source editor session error: %v", msg.err)
 		m.editorState.hint = "Editor failed"
-		return m, nil
+		return m, restoreMouseCmd
 	}
 	m.editorState.hint = "Returned from editor"
 	if !msg.reloadAfterCleanExit {
-		return m, nil
+		return m, restoreMouseCmd
 	}
 	// Cross-file hunk navigation can advance the tree selection before the
 	// selected file load finishes. In that window, the editor returned for a
 	// stale displayed file, so leave the queued load in control.
 	if msg.fileName != m.tree.SelectedFile() {
 		m.nav.pendingHunkJump = nil
-		return m, nil
+		return m, restoreMouseCmd
 	}
 	if msg.fileName != m.file.name {
-		return m, nil
+		return m, restoreMouseCmd
 	}
-	cmd := m.reloadCurrentFile()
-	return m, cmd
+	reloadCmd := m.reloadCurrentFile()
+	if restoreMouseCmd == nil {
+		return m, reloadCmd
+	}
+	return m, tea.Batch(restoreMouseCmd, reloadCmd)
 }

--- a/app/ui/editor_test.go
+++ b/app/ui/editor_test.go
@@ -723,6 +723,62 @@ func TestHandleSourceEditorFinished_ReloadAfterCleanExit(t *testing.T) {
 	}
 }
 
+func TestHandleSourceEditorFinished_RestoresMouseTracking(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantHint string
+	}{
+		{name: "clean exit", wantHint: "Returned from editor"},
+		{name: "editor error", err: errors.New("editor failed"), wantHint: "Editor failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testModel([]string{"a.go"}, nil)
+
+			result, cmd := m.handleSourceEditorFinished(sourceEditorFinishedMsg{
+				err:          tt.err,
+				fileName:     "a.go",
+				restoreMouse: true,
+			})
+			model := result.(Model)
+
+			require.NotNil(t, cmd)
+			assert.IsType(t, tea.EnableMouseCellMotion(), cmd())
+			assert.Equal(t, tt.wantHint, model.editorState.hint)
+		})
+	}
+}
+
+func TestHandleSourceEditorFinished_DoesNotRestoreDisabledMouseTracking(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+
+	_, cmd := m.handleSourceEditorFinished(sourceEditorFinishedMsg{fileName: "a.go"})
+
+	assert.Nil(t, cmd)
+}
+
+func TestHandleSourceEditorFinished_CombinesMouseRestoreAndReload(t *testing.T) {
+	m := testModel([]string{"a.go"}, nil)
+	m.tree = testNewFileTree([]string{"a.go"})
+	m.file.name = "a.go"
+	beforeSeq := m.file.loadSeq
+
+	result, cmd := m.handleSourceEditorFinished(sourceEditorFinishedMsg{
+		fileName:             "a.go",
+		reloadAfterCleanExit: true,
+		restoreMouse:         true,
+	})
+	model := result.(Model)
+
+	require.NotNil(t, cmd)
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 2)
+	assert.IsType(t, tea.EnableMouseCellMotion(), batch[0]())
+	assert.Greater(t, model.file.loadSeq, beforeSeq)
+}
+
 func TestHandleSourceEditorFinished_SkipsReloadWhenFileChanged(t *testing.T) {
 	m := testModel([]string{"a.go", "b.go"}, nil)
 	m.file.name = "b.go"


### PR DESCRIPTION
## Problem

Opening a source file with `e` releases the terminal through `tea.ExecProcess`, but the source-editor completion path does not restore mouse tracking afterward. This leaves mouse input disabled after both clean and error returns.

## Solution

Mirror the existing annotation-editor behavior by re-enabling mouse cell motion when the session started with mouse tracking enabled. Preserve the source-editor reload behavior by batching restoration with the reload command when both are needed, while continuing to respect `--no-mouse`.

Fixes #275