### PR TITLE
fix(themes): resolve --theme auto from tmux client list instead of current client

### DIFF
--- a/app/termbg.go
+++ b/app/termbg.go
@@ -16,30 +16,38 @@ import (
 // multiplexer prefixes so the OSC query path stays enabled.
 const maskedTerm = "xterm-256color"
 
-// tmuxQueryTimeout bounds the tmux subprocess so a wedged tmux server (e.g.
+// tmuxQueryTimeout bounds each tmux subprocess so a wedged tmux server (e.g.
 // blocked on a run-shell hook) degrades to the next detection method instead
-// of stalling startup indefinitely. list-clients answers over the local
-// socket in single-digit milliseconds when healthy.
+// of stalling startup indefinitely. display-message and list-clients answer
+// over the local socket in single-digit milliseconds when healthy.
 const tmuxQueryTimeout = 500 * time.Millisecond
 
 // detectDarkBackground reports whether the terminal background is dark-ish.
 // termenv refuses to send OSC status-report queries when TERM starts with
 // "tmux" or "screen" (multiplexers historically swallowed them), so inside
 // tmux its detection never queries the terminal and always falls back to
-// "dark". two tmux-specific paths run first:
+// "dark". three tmux-specific paths run in order (tmux >= 3.5 for the first
+// two; client themes are fed by each outer terminal's native light/dark
+// reporting and need no tty):
 //
-//  1. `tmux list-clients` themes (tmux >= 3.5) — fed by each outer terminal's
-//     native light/dark reporting, needs no tty, and works no matter which
-//     client tmux considers current. The most recently active client that
-//     reports a theme wins.
-//  2. termenv's own OSC 11 query with TERM masked — tmux answers it in
+//  1. the current client's theme via `tmux display-message` — scoped to the
+//     launching session's client, so with several terminals attached to one
+//     server an unrelated session's client cannot win.
+//  2. the server-wide `tmux list-clients` scan — rescues the detached-session
+//     topology, where the current client is a nested tmux client (the
+//     launcher's display-popup attach) that never learns a theme: the outer
+//     terminal's client only shows up in the full list.
+//  3. termenv's own OSC 11 query with TERM masked — tmux answers it in
 //     regular attached panes with the outer terminal's current background.
 //
-// if both fail (old tmux, or a detached session where tmux answers no tty
+// if all fail (old tmux, or a detached session where tmux answers no tty
 // queries at all), termenv falls back to COLORFGBG and then its dark default.
 func detectDarkBackground() bool {
 	if !insideTmux(os.Getenv("TMUX"), os.Getenv("TERM"), os.Getenv("TERM_PROGRAM")) {
 		return termenv.HasDarkBackground()
+	}
+	if dark, ok := parseTmuxClientTheme(tmuxClientTheme()); ok {
+		return dark
 	}
 	if dark, ok := pickTmuxClientTheme(tmuxClientThemes()); ok {
 		return dark
@@ -62,14 +70,23 @@ func insideTmux(tmuxSocket, term, termProgram string) bool {
 	return strings.HasPrefix(term, "screen") && termProgram == "tmux"
 }
 
+// tmuxClientTheme asks tmux for the current client's reported theme. returns
+// the raw output; empty on error, timeout, or when the format is unknown
+// (tmux < 3.5 expands unknown formats to an empty string).
+func tmuxClientTheme() string {
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxQueryTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{client_theme}").Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
 // tmuxClientThemes asks tmux for every server client's reported theme, one
-// "<activity-epoch> <theme>" line per client. The server-wide list sidesteps
-// tmux's current-client resolution: when revdiff runs in a detached session
-// behind a display-popup attach (the plugin launcher's tmux backend), the
-// current client is the popup's own nested tmux client, which never learns a
-// theme — the outer terminal's client, which does, only shows up in the full
-// list. returns the raw output; empty on error, timeout, or when the format
-// is unknown (tmux < 3.5 expands unknown formats to an empty string).
+// "<activity-epoch> <theme>" line per client. returns the raw output; empty
+// on error, timeout, or when the format is unknown (tmux < 3.5 expands
+// unknown formats to an empty string).
 func tmuxClientThemes() string {
 	ctx, cancel := context.WithTimeout(context.Background(), tmuxQueryTimeout)
 	defer cancel()

--- a/app/termbg.go
+++ b/app/termbg.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,7 +18,7 @@ const maskedTerm = "xterm-256color"
 
 // tmuxQueryTimeout bounds the tmux subprocess so a wedged tmux server (e.g.
 // blocked on a run-shell hook) degrades to the next detection method instead
-// of stalling startup indefinitely. display-message answers over the local
+// of stalling startup indefinitely. list-clients answers over the local
 // socket in single-digit milliseconds when healthy.
 const tmuxQueryTimeout = 500 * time.Millisecond
 
@@ -27,19 +28,20 @@ const tmuxQueryTimeout = 500 * time.Millisecond
 // tmux its detection never queries the terminal and always falls back to
 // "dark". two tmux-specific paths run first:
 //
-//  1. `tmux display-message -p '#{client_theme}'` (tmux >= 3.5) — fed by the
-//     outer terminal's native light/dark reporting, needs no tty, and works
-//     in display-popup panes where tmux does not answer OSC 11 at all.
+//  1. `tmux list-clients` themes (tmux >= 3.5) — fed by each outer terminal's
+//     native light/dark reporting, needs no tty, and works no matter which
+//     client tmux considers current. The most recently active client that
+//     reports a theme wins.
 //  2. termenv's own OSC 11 query with TERM masked — tmux answers it in
-//     regular panes with the outer terminal's current background.
+//     regular attached panes with the outer terminal's current background.
 //
-// if both fail (old tmux inside a popup), termenv falls back to COLORFGBG
-// and then its dark default — same as before.
+// if both fail (old tmux, or a detached session where tmux answers no tty
+// queries at all), termenv falls back to COLORFGBG and then its dark default.
 func detectDarkBackground() bool {
 	if !insideTmux(os.Getenv("TMUX"), os.Getenv("TERM"), os.Getenv("TERM_PROGRAM")) {
 		return termenv.HasDarkBackground()
 	}
-	if dark, ok := parseTmuxClientTheme(tmuxClientTheme()); ok {
+	if dark, ok := pickTmuxClientTheme(tmuxClientThemes()); ok {
 		return dark
 	}
 	return termenv.NewOutput(os.Stdout, termenv.WithEnvironment(tmuxEnviron{})).HasDarkBackground()
@@ -60,25 +62,52 @@ func insideTmux(tmuxSocket, term, termProgram string) bool {
 	return strings.HasPrefix(term, "screen") && termProgram == "tmux"
 }
 
-// tmuxClientTheme asks tmux for the attached client's reported theme.
-// returns the raw output; empty on error, timeout, or when the format is
-// unknown (tmux < 3.5 expands unknown formats to an empty string).
-// best-effort: with several clients attached to the session, tmux resolves
-// the format against its notion of the current client — the OSC 11 fallback
-// is relayed through the same client choice, so this path is no worse.
-func tmuxClientTheme() string {
+// tmuxClientThemes asks tmux for every server client's reported theme, one
+// "<activity-epoch> <theme>" line per client. The server-wide list sidesteps
+// tmux's current-client resolution: when revdiff runs in a detached session
+// behind a display-popup attach (the plugin launcher's tmux backend), the
+// current client is the popup's own nested tmux client, which never learns a
+// theme — the outer terminal's client, which does, only shows up in the full
+// list. returns the raw output; empty on error, timeout, or when the format
+// is unknown (tmux < 3.5 expands unknown formats to an empty string).
+func tmuxClientThemes() string {
 	ctx, cancel := context.WithTimeout(context.Background(), tmuxQueryTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{client_theme}").Output()
+	out, err := exec.CommandContext(ctx, "tmux", "list-clients", "-F", "#{client_activity} #{client_theme}").Output()
 	if err != nil {
 		return ""
 	}
 	return string(out)
 }
 
-// parseTmuxClientTheme maps tmux's client_theme output to a dark-background
+// pickTmuxClientTheme scans tmuxClientThemes output and returns the theme of
+// the most recently active client that reports one. Clients with no theme
+// (nested tmux clients, terminals without light/dark reporting) are skipped.
+// with several real terminals attached to the server, recency is a heuristic
+// for "the terminal the user is looking at" — not a guarantee. ok is false
+// when no client reports a theme, signaling the caller to fall through to
+// the next detection method.
+func pickTmuxClientTheme(clientThemes string) (dark, ok bool) {
+	bestActivity := int64(-1)
+	for line := range strings.SplitSeq(clientThemes, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		activity, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil || activity <= bestActivity {
+			continue
+		}
+		if lineDark, themeOK := parseTmuxClientTheme(fields[1]); themeOK {
+			bestActivity, dark, ok = activity, lineDark, true
+		}
+	}
+	return dark, ok
+}
+
+// parseTmuxClientTheme maps tmux's client_theme value to a dark-background
 // bool. ok is false when the theme is unknown or unreported, signaling the
-// caller to fall through to the next detection method.
+// caller to skip the client.
 func parseTmuxClientTheme(theme string) (dark, ok bool) {
 	switch strings.TrimSpace(theme) {
 	case "dark":

--- a/app/termbg_test.go
+++ b/app/termbg_test.go
@@ -32,6 +32,62 @@ func TestInsideTmux(t *testing.T) {
 	}
 }
 
+func TestPickTmuxClientTheme(t *testing.T) {
+	tests := []struct {
+		name         string
+		clientThemes string
+		wantDark     bool
+		wantOK       bool
+	}{
+		{name: "single light client", clientThemes: "1784717957 light\n", wantDark: false, wantOK: true},
+		{name: "single dark client", clientThemes: "1784717957 dark\n", wantDark: true, wantOK: true},
+		{
+			name:         "themeless popup client alongside real client",
+			clientThemes: "1784717957 light\n1784718000 \n",
+			wantDark:     false,
+			wantOK:       true,
+		},
+		{
+			name:         "most recently active themed client wins",
+			clientThemes: "1784717000 dark\n1784718000 light\n",
+			wantDark:     false,
+			wantOK:       true,
+		},
+		{
+			name:         "order independent",
+			clientThemes: "1784718000 light\n1784717000 dark\n",
+			wantDark:     false,
+			wantOK:       true,
+		},
+		{
+			name:         "equal activity keeps first listed",
+			clientThemes: "1784718000 dark\n1784718000 light\n",
+			wantDark:     true,
+			wantOK:       true,
+		},
+		{
+			name:         "line with extra fields skipped",
+			clientThemes: "1784718000 light extra\n1784717000 dark\n",
+			wantDark:     true,
+			wantOK:       true,
+		},
+		{name: "no clients", clientThemes: "", wantOK: false},
+		{name: "only themeless clients", clientThemes: "1784717957 \n1784718000 \n", wantOK: false},
+		{name: "unknown theme value skipped", clientThemes: "1784717957 auto\n", wantOK: false},
+		{name: "malformed activity skipped", clientThemes: "notanumber light\n", wantOK: false},
+		{name: "tmux pre-3.5 empty theme format", clientThemes: "1784717957 \n", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dark, ok := pickTmuxClientTheme(tt.clientThemes)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantDark, dark)
+			}
+		})
+	}
+}
+
 func TestParseTmuxClientTheme(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -41,7 +97,7 @@ func TestParseTmuxClientTheme(t *testing.T) {
 	}{
 		{name: "dark", theme: "dark", wantDark: true, wantOK: true},
 		{name: "light", theme: "light", wantDark: false, wantOK: true},
-		{name: "trailing newline from display-message", theme: "light\n", wantDark: false, wantOK: true},
+		{name: "trailing newline", theme: "light\n", wantDark: false, wantOK: true},
 		{name: "empty means unreported", theme: "", wantOK: false},
 		{name: "whitespace only", theme: "\n", wantOK: false},
 		{name: "unknown value", theme: "auto", wantOK: false},


### PR DESCRIPTION
`--theme auto` inside tmux now reads themes from `tmux list-clients` across the whole server and picks the most recently active client that reports one, instead of asking `display-message` for the current client's `#{client_theme}`.

Why: when revdiff runs in a detached session that a `display-popup` client attaches to (the plugin launcher's tmux backend), tmux resolves the popup's own nested client as current. A nested tmux client never learns a theme, so `#{client_theme}` expands empty, the masked OSC 11 fallback also gets no answer in that topology, and detection lands on the dark default. Whether detection ran before or after the popup attach was a millisecond race, so auto themes flipped between correct and dark at random. A lost race also stalled startup for termenv's 5-second OSC timeout when stdout was a tty.

- `tmuxClientThemes()` runs `tmux list-clients -F '#{client_activity} #{client_theme}'` server-wide; the outer terminal's client always appears in that list, whichever client tmux considers current.
- `pickTmuxClientTheme()` picks the theme of the most recently active client that reports one and skips themeless clients (nested tmux clients, terminals without light/dark reporting).
- tmux < 3.5 (empty `#{client_theme}` format) and detached sessions with no attached clients fall through to the existing OSC 11 and COLORFGBG paths unchanged. Non-tmux terminals and GNU screen are untouched.

Verified on tmux 3.7b by reproducing the popup topology: with the popup client attached, the old binary resolved the dark theme on a light terminal and the fixed binary resolves the light theme. Both fall-through paths are covered by table tests in `app/termbg_test.go`.
