### PR TITLE
perf(ui): index visual rows for page navigation

### DIFF
--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -581,6 +581,38 @@ func (m Model) cursorViewportYUsing(hunks []int, annotationSet map[string]bool) 
 	return y
 }
 
+// cursorVisualOffsets returns the top visual row for every diff line. Page
+// motions build this index once so each cursor step can read its visual
+// position in O(1) instead of rescanning all preceding lines.
+func (m Model) cursorVisualOffsets(hunks []int, annotationSet map[string]bool) []int {
+	offsets := make([]int, len(m.file.lines))
+	y := 0
+	if m.hasFileAnnotation() {
+		y = m.wrappedAnnotationLineCount(annotKeyFile)
+	}
+	for i := range m.file.lines {
+		offsets[i] = y
+		y += m.hunkLineHeight(i, hunks, annotationSet)
+	}
+	return offsets
+}
+
+// cursorViewportYFromOffsets returns the current cursor's visual row from a
+// pre-built line-offset index.
+func (m Model) cursorViewportYFromOffsets(offsets []int) int {
+	if m.file.name == "" || len(offsets) == 0 {
+		return max(0, m.nav.diffCursor)
+	}
+	if m.nav.diffCursor == -1 {
+		return 0
+	}
+	y := offsets[m.nav.diffCursor]
+	if m.annot.cursorOnAnnotation {
+		y += m.wrappedLineCount(m.nav.diffCursor)
+	}
+	return y
+}
+
 // cursorVisualRange returns the top and bottom viewport Y coordinates the
 // cursor currently occupies. when the cursor is on a diff row, bottom spans
 // any wrap-continuation rows plus any injected annotation rows below it;

--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -598,7 +598,8 @@ func (m Model) cursorVisualOffsets(hunks []int, annotationSet map[string]bool) [
 }
 
 // cursorViewportYFromOffsets returns the current cursor's visual row from a
-// pre-built line-offset index.
+// pre-built line-offset index. offsets must come from cursorVisualOffsets for
+// the current m.file.lines, and m.nav.diffCursor must be in [-1, len(offsets)).
 func (m Model) cursorViewportYFromOffsets(offsets []int) int {
 	if m.file.name == "" || len(offsets) == 0 {
 		return max(0, m.nav.diffCursor)

--- a/app/ui/annotate_test.go
+++ b/app/ui/annotate_test.go
@@ -1532,6 +1532,52 @@ func TestModel_CursorViewportYWithWrappedAnnotation(t *testing.T) {
 	})
 }
 
+func TestModel_CursorViewportYFromOffsetsMatchesDirectCalculation(t *testing.T) {
+	longLine := strings.Repeat("wrapped content ", 12)
+	lines := []diff.DiffLine{
+		{NewNum: 1, Content: longLine, ChangeType: diff.ChangeContext},
+		{OldNum: 2, Content: "removed", ChangeType: diff.ChangeRemove},
+		{NewNum: 2, Content: "replacement", ChangeType: diff.ChangeAdd},
+		{NewNum: 3, Content: "tail", ChangeType: diff.ChangeContext},
+	}
+	m := testModel([]string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.name = "a.go"
+	m.file.lines = lines
+	m.layout.width = 60
+	m.layout.treeWidth = 20
+	m.modes.wrap = true
+	m.modes.collapsed.enabled = true
+	m.modes.collapsed.expandedHunks = make(map[int]bool)
+	m.store.Add(annotation.Annotation{
+		File: "a.go", Line: 0, Comment: strings.Repeat("file note ", 12),
+	})
+	m.store.Add(annotation.Annotation{
+		File: "a.go", Line: 1, Type: string(diff.ChangeContext),
+		Comment: strings.Repeat("inline note ", 12),
+	})
+
+	hunks := m.findHunks()
+	annotationSet := m.buildAnnotationSet()
+	offsets := m.cursorVisualOffsets(hunks, annotationSet)
+	require.Greater(t, m.wrappedLineCount(0), 1, "fixture must wrap a diff line")
+	require.Greater(t, m.wrappedAnnotationLineCount(annotKeyFile), 1, "fixture must wrap the file annotation")
+	require.Greater(t, m.wrappedAnnotationLineCount(m.annotationKey(1, string(diff.ChangeContext))), 1,
+		"fixture must wrap the inline annotation")
+	require.Zero(t, m.hunkLineHeight(1, hunks, annotationSet), "fixture must contain a collapsed hidden line")
+
+	for cursor := -1; cursor < len(lines); cursor++ {
+		for _, onAnnotation := range []bool{false, true} {
+			m.nav.diffCursor = cursor
+			m.annot.cursorOnAnnotation = onAnnotation
+			assert.Equal(t,
+				m.cursorViewportYUsing(hunks, annotationSet),
+				m.cursorViewportYFromOffsets(offsets),
+				"cursor=%d cursorOnAnnotation=%v", cursor, onAnnotation,
+			)
+		}
+	}
+}
+
 func TestModel_RenderWrappedAnnotation(t *testing.T) {
 	m := testModel(nil, nil)
 	m.file.name = "a.go"

--- a/app/ui/diffnav.go
+++ b/app/ui/diffnav.go
@@ -137,19 +137,21 @@ func (m *Model) moveDiffCursorHalfPageUp() {
 // transitions onto an annotation sub-row (cursorOnAnnotation flip with no diffCursor change)
 // count as real progress so the loop does not terminate early on annotated lines.
 func (m *Model) moveDiffCursorDownBy(rows int) {
-	startY := m.cursorViewportY()
+	hunks := m.findHunks()
+	offsets := m.cursorVisualOffsets(hunks, m.buildAnnotationSet())
+	startY := m.cursorViewportYFromOffsets(offsets)
 	for {
 		prevCursor := m.nav.diffCursor
 		prevAnnot := m.annot.cursorOnAnnotation
-		m.moveDiffCursorDown()
+		m.moveDiffCursorDownWithHunks(hunks)
 		if m.nav.diffCursor == prevCursor && m.annot.cursorOnAnnotation == prevAnnot {
 			break // no more movement possible (end of content)
 		}
-		if m.cursorViewportY()-startY >= rows {
+		if m.cursorViewportYFromOffsets(offsets)-startY >= rows {
 			break
 		}
 	}
-	actualDelta := m.cursorViewportY() - startY
+	actualDelta := m.cursorViewportYFromOffsets(offsets) - startY
 	maxOffset := max(0, m.layout.viewport.TotalLineCount()-m.layout.viewport.Height)
 	m.layout.viewport.SetYOffset(min(m.layout.viewport.YOffset+actualDelta, maxOffset))
 	m.layout.viewport.SetContent(m.renderDiff())
@@ -162,19 +164,21 @@ func (m *Model) moveDiffCursorDownBy(rows int) {
 // transitions off an annotation sub-row count as real progress so the loop does not
 // terminate early on annotated lines.
 func (m *Model) moveDiffCursorUpBy(rows int) {
-	startY := m.cursorViewportY()
+	hunks := m.findHunks()
+	offsets := m.cursorVisualOffsets(hunks, m.buildAnnotationSet())
+	startY := m.cursorViewportYFromOffsets(offsets)
 	for {
 		prevCursor := m.nav.diffCursor
 		prevAnnot := m.annot.cursorOnAnnotation
-		m.moveDiffCursorUp()
+		m.moveDiffCursorUpWithHunks(hunks)
 		if m.nav.diffCursor == prevCursor && m.annot.cursorOnAnnotation == prevAnnot {
 			break // no more movement possible (start of content)
 		}
-		if startY-m.cursorViewportY() >= rows {
+		if startY-m.cursorViewportYFromOffsets(offsets) >= rows {
 			break
 		}
 	}
-	actualDelta := startY - m.cursorViewportY()
+	actualDelta := startY - m.cursorViewportYFromOffsets(offsets)
 	m.layout.viewport.SetYOffset(max(0, m.layout.viewport.YOffset-actualDelta))
 	m.layout.viewport.SetContent(m.renderDiff())
 }

--- a/app/ui/diffnav_test.go
+++ b/app/ui/diffnav_test.go
@@ -3226,3 +3226,33 @@ func TestModel_JKScrollDiffNoOpWhenContentFits(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkModel_PageNavigation(b *testing.B) {
+	lines := make([]diff.DiffLine, 10_000)
+	for i := range lines {
+		lines[i] = diff.DiffLine{
+			NewNum:     i + 1,
+			Content:    "func pageNavigationBenchmark() {}",
+			ChangeType: diff.ChangeContext,
+		}
+	}
+
+	m := testModel([]string{"large.go"}, map[string][]diff.DiffLine{"large.go": lines})
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 44})
+	model := result.(Model)
+	result, _ = model.Update(fileLoadedMsg{file: "large.go", lines: lines})
+	model = result.(Model)
+	model.layout.focus = paneDiff
+	model.nav.diffCursor = len(lines) / 2
+	model.layout.viewport.SetContent(model.renderDiff())
+	model.layout.viewport.SetYOffset(model.nav.diffCursor)
+
+	b.ResetTimer()
+	for i := range b.N {
+		if i%2 == 0 {
+			model.moveDiffCursorPageDown()
+		} else {
+			model.moveDiffCursorPageUp()
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Page navigation recalculates the cursor visual row from the start of the diff after every cursor step. Each calculation also rebuilds annotation metadata and, in collapsed mode, rescans hunks. PgUp, PgDown, Ctrl-U, and Ctrl-D therefore become progressively slower deeper into large files.

On an Apple M4 with a 10,000-line diff and a 44-row terminal, the included benchmark measured:

```
before: 232-240 ms/op, 10.2 MB/op, 681k allocs/op
after:   47-48 ms/op,  4.0 MB/op,  90k allocs/op
```

## Solution

Build one visual-row offset index for each page motion and reuse one hunk list and annotation set throughout the cursor walk. Cursor lookup becomes constant-time per step while preserving wrapped lines, collapsed hunks, inline annotations, cursor position, and viewport behavior.

The benchmark remains in the test suite to make this path measurable.

## Verification

- `go test -race -timeout=100s ./...`
- `golangci-lint run` with v2.11.4
- focused page, wrap, collapsed, and viewport navigation tests
- `BenchmarkModel_PageNavigation`, repeated with allocation reporting