### PR TITLE
perf(ui): keep trackpad scrolling continuous

### DIFF
--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -526,8 +526,7 @@ func (m Model) handleFileLoaded(msg fileLoadedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.file.requestedPath = ""
-	m.discardWheelFrame()
-	m.wheel.direction = 0
+	m.wheel.chrome = wheelChrome{}
 	m.wheel.renderPending = false
 	m.wheel.tickInFlight = false
 	m.wheel.gen++

--- a/app/ui/loaders.go
+++ b/app/ui/loaders.go
@@ -526,6 +526,11 @@ func (m Model) handleFileLoaded(msg fileLoadedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.file.requestedPath = ""
+	m.discardWheelFrame()
+	m.wheel.direction = 0
+	m.wheel.renderPending = false
+	m.wheel.tickInFlight = false
+	m.wheel.gen++
 	if msg.err != nil {
 		m.layout.viewport.SetContent(fmt.Sprintf("error loading diff: %v", msg.err))
 		return m, nil

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -975,6 +975,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handlePostFlushFinished(msg)
 	case wheelDebounceMsg:
 		return m.handleWheelDebounce(msg)
+	case wheelFrameMsg:
+		return m.handleWheelFrame(msg)
 	}
 
 	// forward other messages to textinput when annotating (e.g. cursor blink)

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -975,8 +975,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handlePostFlushFinished(msg)
 	case wheelDebounceMsg:
 		return m.handleWheelDebounce(msg)
-	case wheelFrameMsg:
-		return m.handleWheelFrame(msg)
 	}
 
 	// forward other messages to textinput when annotating (e.g. cursor blink)
@@ -1339,12 +1337,7 @@ func (m *Model) toggleLineNumbers() {
 func (m Model) computeLineNumWidth() int {
 	maxNum := 0
 	for _, dl := range m.file.lines {
-		if dl.OldNum > maxNum {
-			maxNum = dl.OldNum
-		}
-		if dl.NewNum > maxNum {
-			maxNum = dl.NewNum
-		}
+		maxNum = max(maxNum, dl.OldNum, dl.NewNum)
 	}
 	if maxNum == 0 {
 		return 1

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -591,7 +591,7 @@ type Model struct {
 	output      outputState       // transient hint state for the O in-session output flush
 	keys        keyState          // chord-pending state and transient hint for leader-chord keybindings
 	vim         vimState          // count accumulator, pending letter leader, and transient hint for vim-motion preset
-	wheel       wheelState        // diff-pane mouse wheel coalescing (debounced render via wheelDebounceMsg)
+	wheel       wheelState        // diff-pane wheel frame coalescing and deferred cursor/render state
 
 	ready        bool   // true after first WindowSizeMsg
 	filesLoaded  bool   // true after the first filesLoadedMsg is handled (keeps the loading view pinned until real data arrives)

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -15,9 +15,9 @@ import (
 const wheelStep = overlay.WheelStep
 
 // wheelFrameDelay caps diff-pane wheel updates at the terminal's practical
-// render cadence. Raw trackpad packets accumulate until this tick fires, so
+// render cadence. Packets after the first accumulate until this tick fires, so
 // Bubble Tea can keep returning the previous frame instead of rebuilding the
-// full layout for every packet.
+// full layout for every raw trackpad packet.
 const wheelFrameDelay = 16 * time.Millisecond
 
 // wheelRenderDelay is the idle window after the last applied diff-pane wheel
@@ -26,27 +26,26 @@ const wheelRenderDelay = 30 * time.Millisecond
 
 // wheelState tracks the coalescing state for diff-pane wheel events.
 //
-// delta and frameInFlight collect raw packets behind one 16 ms tick. snapshot
-// holds the last complete frame so View stays cheap until the tick applies the
-// exact accumulated distance. frameGen invalidates ticks after an early flush.
+// The first packet in a burst moves the viewport immediately. targetOffset and
+// frameInFlight collect later same-direction packets behind one 16 ms tick.
+// snapshot holds the first packet's complete frame so View stays cheap while
+// those later packets accumulate. direction detects reversals even between
+// frames, and frameGen invalidates ticks after an early flush or a file switch.
 //
 // gen is bumped on every applied frame that shifts YOffset. renderPending stays
 // true while a cursor pin/render is owed (cleared by flushWheelPending).
 //
-// tickInFlight gates tea.Tick scheduling: only ONE tick is alive at a time,
-// regardless of how many wheel events arrive. The first wheel of a burst
-// schedules a tick; subsequent wheels in the same burst just bump gen. If the
-// tick fires with stale gen (burst still going), handleWheelDebounce
-// reschedules a new tick for the current gen. This keeps the debounce-msg
-// count proportional to burst duration (one per wheelRenderDelay), not to
-// wheel event count — drops thousands of redundant Update+View cycles on
-// trackpad/free-spin bursts and stops the wheel-up from queueing behind them.
+// tickInFlight gates render-debounce scheduling: only one debounce tick is alive
+// across the burst. Applied frames bump gen; a stale debounce tick reschedules
+// for the current gen. This keeps debounce traffic proportional to burst
+// duration rather than packet count.
 type wheelState struct {
 	gen           int
 	renderPending bool
 	tickInFlight  bool
 
-	delta         int
+	targetOffset  int
+	direction     int
 	frameGen      int
 	frameInFlight bool
 	snapshot      string
@@ -257,44 +256,61 @@ func (m Model) wheelStepFor(shift bool) int {
 // the highlight stays on screen. this matches less/vim mouse behavior and
 // keeps the cursor from being yanked along with the wheel.
 //
-// when the diff pane scrolls, both the cursor pin and the SetContent
-// (renderDiff()) call are deferred via a tea.Tick debounce — see
-// wheelRenderDelay. the only per-event work is SetYOffset (and the modal/zone
-// checks that were already free), so each event is O(1). this coalesces a
-// burst of wheel events (a trackpad flick or free-spin wheel) into a single
-// pin+render at burst-end, so an opposite-direction wheel event isn't blocked
-// behind a backlog of expensive per-event operations on large diffs.
+// The first diff-pane packet applies immediately so a discrete wheel has no
+// frame delay. Later same-direction packets accumulate as a clamped target
+// behind a 16 ms tick, and View reuses the first packet's completed frame until
+// that target applies. Cursor pinning and SetContent(renderDiff()) remain behind
+// the existing wheelRenderDelay debounce. Reversals flush and apply immediately.
 // fixes #179.
 func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 	switch zone {
 	case hitDiff:
-		// A reversal must not wait behind the current frame. Apply both the
-		// accumulated distance and this first opposite packet immediately so
-		// the viewport visibly changes direction in the next View call.
-		if m.wheel.delta != 0 && (m.wheel.delta < 0) != (delta < 0) {
-			m.wheel.delta += delta
-			return m.flushWheelFrame()
+		if !m.wheel.renderPending {
+			if !m.scrollDiffViewportBy(delta) {
+				return m, nil
+			}
+			m.wheel.direction = delta
+			cmd := m.markWheelRenderPending()
+			return m, cmd
 		}
-		if !m.canScrollDiffViewportBy(m.wheel.delta + delta) {
+
+		// A reversal must not wait behind the current frame. Apply the clamped
+		// target collected so far, then move one packet in the new direction.
+		if (m.wheel.direction < 0) != (delta < 0) {
+			if m.wheel.frameInFlight {
+				flushed, _ := m.flushWheelFrame()
+				m = flushed.(Model)
+			}
+			if m.scrollDiffViewportBy(delta) {
+				m.wheel.direction = delta
+				cmd := m.markWheelRenderPending()
+				return m, cmd
+			}
 			return m, nil
 		}
 
-		// Preserve the last rendered frame while packets accumulate. Building
-		// this snapshot once on the first packet makes all later View calls in
-		// the same frame a cheap string return.
-		if m.wheel.delta == 0 {
+		if !m.wheel.frameInFlight {
 			m.wheel.snapshot = m.View()
+			m.wheel.targetOffset = m.clampedDiffOffset(delta)
+			if m.wheel.targetOffset == m.layout.viewport.YOffset {
+				m.wheel.snapshot = ""
+				return m, nil
+			}
+			m.wheel.frameInFlight = true
+			m.wheel.frameGen++
+			gen := m.wheel.frameGen
+			return m, tea.Tick(wheelFrameDelay, func(time.Time) tea.Msg {
+				return wheelFrameMsg{gen: gen}
+			})
 		}
-		m.wheel.delta += delta
-		if m.wheel.frameInFlight {
+
+		pendingDelta := m.wheel.targetOffset - m.layout.viewport.YOffset + delta
+		target := m.clampedDiffOffset(pendingDelta)
+		if target == m.wheel.targetOffset {
 			return m, nil
 		}
-		m.wheel.frameInFlight = true
-		m.wheel.frameGen++
-		gen := m.wheel.frameGen
-		return m, tea.Tick(wheelFrameDelay, func(time.Time) tea.Msg {
-			return wheelFrameMsg{gen: gen}
-		})
+		m.wheel.targetOffset = target
+		return m, nil
 	case hitTree:
 		m.flushWheelPending()
 		// tree/TOC wheel = direct cursor navigation, one entry per notch.
@@ -320,13 +336,13 @@ func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) canScrollDiffViewportBy(delta int) bool {
+// clampedDiffOffset returns the reachable viewport offset after applying delta.
+func (m Model) clampedDiffOffset(delta int) int {
 	if m.file.name == "" {
-		return false
+		return m.layout.viewport.YOffset
 	}
 	maxOffset := max(0, m.layout.viewport.TotalLineCount()-m.layout.viewport.Height)
-	target := max(0, min(m.layout.viewport.YOffset+delta, maxOffset))
-	return target != m.layout.viewport.YOffset
+	return max(0, min(m.layout.viewport.YOffset+delta, maxOffset))
 }
 
 // handleWheelFrame applies one frame's accumulated wheel distance. Stale ticks
@@ -341,25 +357,37 @@ func (m Model) handleWheelFrame(msg wheelFrameMsg) (tea.Model, tea.Cmd) {
 // flushWheelFrame changes YOffset exactly once for all packets collected in
 // the current frame and schedules the existing cursor/render debounce.
 func (m Model) flushWheelFrame() (tea.Model, tea.Cmd) {
-	delta := m.wheel.delta
-	m.wheel.delta = 0
-	m.wheel.snapshot = ""
-	m.wheel.frameInFlight = false
-	m.wheel.frameGen++
-	if !m.scrollDiffViewportBy(delta) {
+	target := m.wheel.targetOffset
+	m.discardWheelFrame()
+	if !m.scrollDiffViewportBy(target - m.layout.viewport.YOffset) {
 		return m, nil
 	}
+	cmd := m.markWheelRenderPending()
+	return m, cmd
+}
 
+// markWheelRenderPending records that the cursor pin and diff render are owed,
+// and keeps at most one debounce tick alive across the burst.
+func (m *Model) markWheelRenderPending() tea.Cmd {
 	m.wheel.renderPending = true
 	m.wheel.gen++
 	gen := m.wheel.gen
 	if m.wheel.tickInFlight {
-		return m, nil
+		return nil
 	}
 	m.wheel.tickInFlight = true
-	return m, tea.Tick(wheelRenderDelay, func(time.Time) tea.Msg {
+	return tea.Tick(wheelRenderDelay, func(time.Time) tea.Msg {
 		return wheelDebounceMsg{gen: gen}
 	})
+}
+
+// discardWheelFrame invalidates the frame tick and drops only unapplied wheel
+// input. Deferred cursor/render work for offsets already applied is preserved.
+func (m *Model) discardWheelFrame() {
+	m.wheel.targetOffset = 0
+	m.wheel.snapshot = ""
+	m.wheel.frameInFlight = false
+	m.wheel.frameGen++
 }
 
 // handleWheelDebounce processes a deferred tick for a wheel burst. branches:
@@ -426,17 +454,12 @@ func (m Model) clickTree(y int) (tea.Model, tea.Cmd) {
 // caller should schedule a deferred cursor pin + render); returns false when
 // no file is loaded or the clamped target equals the current offset.
 //
-// Raw packets are accumulated before this helper runs. The expensive cursor pin
-// and full-diff render remain deferred to handleWheelDebounce after the frame
-// changes YOffset. During a burst the cursor stays stale until the debounce or
-// an external cursor-dependent action flushes early.
+// The expensive cursor pin and full-diff render remain deferred to
+// handleWheelDebounce. During a burst the cursor stays stale until the debounce
+// or an external cursor-dependent action flushes early.
 func (m *Model) scrollDiffViewportBy(delta int) bool {
-	if m.file.name == "" {
-		return false
-	}
-	maxOffset := max(0, m.layout.viewport.TotalLineCount()-m.layout.viewport.Height)
 	current := m.layout.viewport.YOffset
-	target := max(0, min(current+delta, maxOffset))
+	target := m.clampedDiffOffset(delta)
 	if target == current {
 		return false
 	}
@@ -444,19 +467,12 @@ func (m *Model) scrollDiffViewportBy(delta int) bool {
 	return true
 }
 
-// flushWheelPending applies the deferred cursor pin + diff re-render owed by
-// an in-flight wheel burst, then clears renderPending AND tickInFlight.
-// callers invoke this before any action that reads m.nav.diffCursor or
-// relies on a fresh diff content string. Production call sites:
-//   - handleKey (model.go) — cursor-relative key actions (j/k, search,
-//     annotate) must see the pinned cursor before they read m.nav.diffCursor
-//   - handleResize (model.go) — syncViewportToCursor must anchor at the
-//     wheeled-to position, not the pre-burst cursor
-//   - handleBlameLoaded (loaders.go) — same syncViewportToCursor rationale
-//   - handleWheelDebounce (mouse.go) — the matching-gen tick path
+// flushWheelPending applies any frame target, then performs the deferred cursor
+// pin and diff re-render owed by the wheel burst. Callers use it before actions
+// that depend on the current viewport, cursor, or rendered diff.
 //
-// no-op when no render is pending. when pinDiffCursorTo returns false (the
-// cursor stayed in view through the burst, no pin needed), syncTOCActiveSection
+// When pinDiffCursorTo returns false (the cursor stayed in view through the
+// burst, no pin needed), syncTOCActiveSection
 // and SetContent are skipped — the existing rendered string already has the
 // correct cursor highlight and the TOC active section is keyed off the
 // (unchanged) cursor index, so a re-render would be redundant. Only the
@@ -469,13 +485,11 @@ func (m *Model) scrollDiffViewportBy(delta int) bool {
 // after the flush hits the !renderPending or stale-gen branches and is
 // harmless.
 func (m *Model) flushWheelPending() {
-	if m.wheel.delta != 0 {
+	if m.wheel.frameInFlight && m.wheel.targetOffset != m.layout.viewport.YOffset {
 		flushed, _ := m.flushWheelFrame()
 		*m = flushed.(Model)
 	}
-	m.wheel.snapshot = ""
-	m.wheel.frameInFlight = false
-	m.wheel.frameGen++
+	m.discardWheelFrame()
 	if !m.wheel.renderPending {
 		return
 	}
@@ -485,6 +499,7 @@ func (m *Model) flushWheelPending() {
 	}
 	m.wheel.renderPending = false
 	m.wheel.tickInFlight = false
+	m.wheel.direction = 0
 }
 
 // pinDiffCursorTo moves the diff cursor onto the visible viewport range when it

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -14,47 +14,32 @@ import (
 // overlay popup scroll feels the same as diff-pane scroll.
 const wheelStep = overlay.WheelStep
 
-// wheelFrameDelay caps diff-pane wheel updates at the terminal's practical
-// render cadence. Packets after the first accumulate until this tick fires, so
-// Bubble Tea can keep returning the previous frame instead of rebuilding the
-// full layout for every raw trackpad packet.
-const wheelFrameDelay = 16 * time.Millisecond
-
-// wheelRenderDelay is the idle window after the last applied diff-pane wheel
-// frame before the deferred cursor pin + SetContent(renderDiff()) runs.
+// wheelRenderDelay is the idle window after the last diff-pane wheel packet
+// before the deferred cursor pin + SetContent(renderDiff()) runs.
 const wheelRenderDelay = 30 * time.Millisecond
 
-// wheelState tracks the coalescing state for diff-pane wheel events.
-//
-// The first packet in a burst moves the viewport immediately. targetOffset and
-// frameInFlight collect later same-direction packets behind one 16 ms tick.
-// snapshot holds the first packet's complete frame so View stays cheap while
-// those later packets accumulate. direction detects reversals even between
-// frames, and frameGen invalidates ticks after an early flush or a file switch.
-//
-// gen is bumped on every applied frame that shifts YOffset. renderPending stays
+// wheelState tracks deferred diff rendering for wheel events.
+// gen is bumped on every packet that shifts YOffset. renderPending stays
 // true while a cursor pin/render is owed (cleared by flushWheelPending).
 //
 // tickInFlight gates render-debounce scheduling: only one debounce tick is alive
-// across the burst. Applied frames bump gen; a stale debounce tick reschedules
+// across the burst. Applied packets bump gen; a stale debounce tick reschedules
 // for the current gen. This keeps debounce traffic proportional to burst
 // duration rather than packet count.
 type wheelState struct {
 	gen           int
 	renderPending bool
 	tickInFlight  bool
-
-	targetOffset  int
-	direction     int
-	frameGen      int
-	frameInFlight bool
-	snapshot      string
+	chrome        wheelChrome
 }
 
-// wheelFrameMsg applies all raw wheel distance collected during one render
-// frame. gen makes ticks invalidated by an early flush harmless.
-type wheelFrameMsg struct {
-	gen int
+// wheelChrome caches pane elements that cannot change while diff-wheel work is
+// deferred. The viewport remains live and is rendered for every packet.
+type wheelChrome struct {
+	active     bool
+	diffHeader string
+	leftPane   string
+	status     string
 }
 
 // wheelDebounceMsg is the deferred flush trigger for diff-pane wheel events.
@@ -256,61 +241,19 @@ func (m Model) wheelStepFor(shift bool) int {
 // the highlight stays on screen. this matches less/vim mouse behavior and
 // keeps the cursor from being yanked along with the wheel.
 //
-// The first diff-pane packet applies immediately so a discrete wheel has no
-// frame delay. Later same-direction packets accumulate as a clamped target
-// behind a 16 ms tick, and View reuses the first packet's completed frame until
-// that target applies. Cursor pinning and SetContent(renderDiff()) remain behind
-// the existing wheelRenderDelay debounce. Reversals flush and apply immediately.
+// Every packet applies its viewport offset immediately so trackpad motion stays
+// continuous. Cursor pinning and SetContent(renderDiff()) remain behind the
+// existing wheelRenderDelay debounce.
 // fixes #179.
 func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 	switch zone {
 	case hitDiff:
-		if !m.wheel.renderPending {
-			if !m.scrollDiffViewportBy(delta) {
-				return m, nil
-			}
-			m.wheel.direction = delta
-			cmd := m.markWheelRenderPending()
-			return m, cmd
-		}
-
-		// A reversal must not wait behind the current frame. Apply the clamped
-		// target collected so far, then move one packet in the new direction.
-		if (m.wheel.direction < 0) != (delta < 0) {
-			if m.wheel.frameInFlight {
-				flushed, _ := m.flushWheelFrame()
-				m = flushed.(Model)
-			}
-			if m.scrollDiffViewportBy(delta) {
-				m.wheel.direction = delta
-				cmd := m.markWheelRenderPending()
-				return m, cmd
-			}
+		if !m.scrollDiffViewportBy(delta) {
 			return m, nil
 		}
-
-		if !m.wheel.frameInFlight {
-			m.wheel.snapshot = m.View()
-			m.wheel.targetOffset = m.clampedDiffOffset(delta)
-			if m.wheel.targetOffset == m.layout.viewport.YOffset {
-				m.wheel.snapshot = ""
-				return m, nil
-			}
-			m.wheel.frameInFlight = true
-			m.wheel.frameGen++
-			gen := m.wheel.frameGen
-			return m, tea.Tick(wheelFrameDelay, func(time.Time) tea.Msg {
-				return wheelFrameMsg{gen: gen}
-			})
-		}
-
-		pendingDelta := m.wheel.targetOffset - m.layout.viewport.YOffset + delta
-		target := m.clampedDiffOffset(pendingDelta)
-		if target == m.wheel.targetOffset {
-			return m, nil
-		}
-		m.wheel.targetOffset = target
-		return m, nil
+		m.prepareWheelChrome()
+		cmd := m.markWheelRenderPending()
+		return m, cmd
 	case hitTree:
 		m.flushWheelPending()
 		// tree/TOC wheel = direct cursor navigation, one entry per notch.
@@ -345,27 +288,6 @@ func (m Model) clampedDiffOffset(delta int) int {
 	return max(0, min(m.layout.viewport.YOffset+delta, maxOffset))
 }
 
-// handleWheelFrame applies one frame's accumulated wheel distance. Stale ticks
-// are expected after a reversal or an external event flushes early.
-func (m Model) handleWheelFrame(msg wheelFrameMsg) (tea.Model, tea.Cmd) {
-	if msg.gen != m.wheel.frameGen || !m.wheel.frameInFlight {
-		return m, nil
-	}
-	return m.flushWheelFrame()
-}
-
-// flushWheelFrame changes YOffset exactly once for all packets collected in
-// the current frame and schedules the existing cursor/render debounce.
-func (m Model) flushWheelFrame() (tea.Model, tea.Cmd) {
-	target := m.wheel.targetOffset
-	m.discardWheelFrame()
-	if !m.scrollDiffViewportBy(target - m.layout.viewport.YOffset) {
-		return m, nil
-	}
-	cmd := m.markWheelRenderPending()
-	return m, cmd
-}
-
 // markWheelRenderPending records that the cursor pin and diff render are owed,
 // and keeps at most one debounce tick alive across the burst.
 func (m *Model) markWheelRenderPending() tea.Cmd {
@@ -379,15 +301,6 @@ func (m *Model) markWheelRenderPending() tea.Cmd {
 	return tea.Tick(wheelRenderDelay, func(time.Time) tea.Msg {
 		return wheelDebounceMsg{gen: gen}
 	})
-}
-
-// discardWheelFrame invalidates the frame tick and drops only unapplied wheel
-// input. Deferred cursor/render work for offsets already applied is preserved.
-func (m *Model) discardWheelFrame() {
-	m.wheel.targetOffset = 0
-	m.wheel.snapshot = ""
-	m.wheel.frameInFlight = false
-	m.wheel.frameGen++
 }
 
 // handleWheelDebounce processes a deferred tick for a wheel burst. branches:
@@ -467,8 +380,8 @@ func (m *Model) scrollDiffViewportBy(delta int) bool {
 	return true
 }
 
-// flushWheelPending applies any frame target, then performs the deferred cursor
-// pin and diff re-render owed by the wheel burst. Callers use it before actions
+// flushWheelPending performs the deferred cursor pin and diff re-render owed by
+// the wheel burst. Callers use it before actions
 // that depend on the current viewport, cursor, or rendered diff.
 //
 // When pinDiffCursorTo returns false (the cursor stayed in view through the
@@ -485,11 +398,7 @@ func (m *Model) scrollDiffViewportBy(delta int) bool {
 // after the flush hits the !renderPending or stale-gen branches and is
 // harmless.
 func (m *Model) flushWheelPending() {
-	if m.wheel.frameInFlight && m.wheel.targetOffset != m.layout.viewport.YOffset {
-		flushed, _ := m.flushWheelFrame()
-		*m = flushed.(Model)
-	}
-	m.discardWheelFrame()
+	m.wheel.chrome = wheelChrome{}
 	if !m.wheel.renderPending {
 		return
 	}
@@ -499,7 +408,6 @@ func (m *Model) flushWheelPending() {
 	}
 	m.wheel.renderPending = false
 	m.wheel.tickInFlight = false
-	m.wheel.direction = 0
 }
 
 // pinDiffCursorTo moves the diff cursor onto the visible viewport range when it

--- a/app/ui/mouse.go
+++ b/app/ui/mouse.go
@@ -14,24 +14,24 @@ import (
 // overlay popup scroll feels the same as diff-pane scroll.
 const wheelStep = overlay.WheelStep
 
-// wheelRenderDelay is the idle window after the last diff-pane wheel event
-// before the deferred cursor pin + SetContent(renderDiff()) runs. Each wheel
-// event updates the viewport YOffset synchronously and defers both the cursor
-// pin and the diff render to a single tea.Tick so a burst of wheel events
-// produces one pin + render at burst-end instead of per-event work. Short
-// enough that the cursor highlight reappears quickly after the user stops
-// scrolling, long enough to coalesce a typical trackpad flick into one render.
+// wheelFrameDelay caps diff-pane wheel updates at the terminal's practical
+// render cadence. Raw trackpad packets accumulate until this tick fires, so
+// Bubble Tea can keep returning the previous frame instead of rebuilding the
+// full layout for every packet.
+const wheelFrameDelay = 16 * time.Millisecond
+
+// wheelRenderDelay is the idle window after the last applied diff-pane wheel
+// frame before the deferred cursor pin + SetContent(renderDiff()) runs.
 const wheelRenderDelay = 30 * time.Millisecond
 
 // wheelState tracks the coalescing state for diff-pane wheel events.
 //
-// gen is bumped on every wheel event that actually shifts YOffset (i.e.
-// scrollDiffViewportBy returned true — at-edge no-ops do NOT bump). The
-// in-flight tea.Tick captures the gen at scheduling time so the resulting
-// debounce msg can tell whether the burst has advanced past it.
+// delta and frameInFlight collect raw packets behind one 16 ms tick. snapshot
+// holds the last complete frame so View stays cheap until the tick applies the
+// exact accumulated distance. frameGen invalidates ticks after an early flush.
 //
-// renderPending stays true while a render is owed (set by wheel events,
-// cleared by flushWheelPending).
+// gen is bumped on every applied frame that shifts YOffset. renderPending stays
+// true while a cursor pin/render is owed (cleared by flushWheelPending).
 //
 // tickInFlight gates tea.Tick scheduling: only ONE tick is alive at a time,
 // regardless of how many wheel events arrive. The first wheel of a burst
@@ -45,6 +45,17 @@ type wheelState struct {
 	gen           int
 	renderPending bool
 	tickInFlight  bool
+
+	delta         int
+	frameGen      int
+	frameInFlight bool
+	snapshot      string
+}
+
+// wheelFrameMsg applies all raw wheel distance collected during one render
+// frame. gen makes ticks invalidated by an early flush harmless.
+type wheelFrameMsg struct {
+	gen int
 }
 
 // wheelDebounceMsg is the deferred flush trigger for diff-pane wheel events.
@@ -172,6 +183,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		return m.handleWheel(zone, m.wheelStepFor(msg.Shift))
 	case tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight:
+		m.flushWheelPending()
 		// horizontal wheel is intentionally swallowed — horizontal scroll
 		// stays keyboard-driven so users keep a single mental model.
 		return m, nil
@@ -179,6 +191,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		if msg.Action != tea.MouseActionPress {
 			return m, nil // ignore release and motion while holding
 		}
+		m.flushWheelPending()
 		switch zone {
 		case hitTree:
 			return m.clickTree(msg.Y)
@@ -189,6 +202,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	default:
+		m.flushWheelPending()
 		// right, middle, back, forward, none — no-op for this pass.
 		return m, nil
 	}
@@ -254,28 +268,35 @@ func (m Model) wheelStepFor(shift bool) int {
 func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 	switch zone {
 	case hitDiff:
-		if !m.scrollDiffViewportBy(delta) {
+		// A reversal must not wait behind the current frame. Apply both the
+		// accumulated distance and this first opposite packet immediately so
+		// the viewport visibly changes direction in the next View call.
+		if m.wheel.delta != 0 && (m.wheel.delta < 0) != (delta < 0) {
+			m.wheel.delta += delta
+			return m.flushWheelFrame()
+		}
+		if !m.canScrollDiffViewportBy(m.wheel.delta + delta) {
 			return m, nil
 		}
-		m.wheel.renderPending = true
-		m.wheel.gen++
-		gen := m.wheel.gen
 
-		// schedule a tick only when none is in flight; subsequent wheels in the
-		// same burst just bump gen. an in-flight tick fires at its own
-		// wallclock deadline and reschedules itself if it lands on a stale gen
-		// (see handleWheelDebounce). this keeps message count proportional to
-		// burst duration, not wheel event count — without this guard each
-		// wheel event spawns a tea.Tick goroutine and a debounce Msg, every
-		// one of which forces another Update + View cycle (~2ms each).
-		if m.wheel.tickInFlight {
+		// Preserve the last rendered frame while packets accumulate. Building
+		// this snapshot once on the first packet makes all later View calls in
+		// the same frame a cheap string return.
+		if m.wheel.delta == 0 {
+			m.wheel.snapshot = m.View()
+		}
+		m.wheel.delta += delta
+		if m.wheel.frameInFlight {
 			return m, nil
 		}
-		m.wheel.tickInFlight = true
-		return m, tea.Tick(wheelRenderDelay, func(time.Time) tea.Msg {
-			return wheelDebounceMsg{gen: gen}
+		m.wheel.frameInFlight = true
+		m.wheel.frameGen++
+		gen := m.wheel.frameGen
+		return m, tea.Tick(wheelFrameDelay, func(time.Time) tea.Msg {
+			return wheelFrameMsg{gen: gen}
 		})
 	case hitTree:
+		m.flushWheelPending()
 		// tree/TOC wheel = direct cursor navigation, one entry per notch.
 		// no debounce, no shift-half-page tricks (those are diff-pane things);
 		// the tree is small and cheap so single-step matches j/k semantics.
@@ -297,6 +318,48 @@ func (m Model) handleWheel(zone hitZone, delta int) (tea.Model, tea.Cmd) {
 		// no-op zones — wheel outside the interactive panes is ignored.
 	}
 	return m, nil
+}
+
+func (m Model) canScrollDiffViewportBy(delta int) bool {
+	if m.file.name == "" {
+		return false
+	}
+	maxOffset := max(0, m.layout.viewport.TotalLineCount()-m.layout.viewport.Height)
+	target := max(0, min(m.layout.viewport.YOffset+delta, maxOffset))
+	return target != m.layout.viewport.YOffset
+}
+
+// handleWheelFrame applies one frame's accumulated wheel distance. Stale ticks
+// are expected after a reversal or an external event flushes early.
+func (m Model) handleWheelFrame(msg wheelFrameMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.wheel.frameGen || !m.wheel.frameInFlight {
+		return m, nil
+	}
+	return m.flushWheelFrame()
+}
+
+// flushWheelFrame changes YOffset exactly once for all packets collected in
+// the current frame and schedules the existing cursor/render debounce.
+func (m Model) flushWheelFrame() (tea.Model, tea.Cmd) {
+	delta := m.wheel.delta
+	m.wheel.delta = 0
+	m.wheel.snapshot = ""
+	m.wheel.frameInFlight = false
+	m.wheel.frameGen++
+	if !m.scrollDiffViewportBy(delta) {
+		return m, nil
+	}
+
+	m.wheel.renderPending = true
+	m.wheel.gen++
+	gen := m.wheel.gen
+	if m.wheel.tickInFlight {
+		return m, nil
+	}
+	m.wheel.tickInFlight = true
+	return m, tea.Tick(wheelRenderDelay, func(time.Time) tea.Msg {
+		return wheelDebounceMsg{gen: gen}
+	})
 }
 
 // handleWheelDebounce processes a deferred tick for a wheel burst. branches:
@@ -363,13 +426,10 @@ func (m Model) clickTree(y int) (tea.Model, tea.Cmd) {
 // caller should schedule a deferred cursor pin + render); returns false when
 // no file is loaded or the clamped target equals the current offset.
 //
-// the expensive cursor pin (pinDiffCursorTo loops O(cursor_idx) via
-// cursorVisualRange) and the full-diff render (SetContent(renderDiff()))
-// are both deferred to handleWheelDebounce so each wheel event is O(1).
-// during a wheel burst the cursor index in m.nav.diffCursor stays stale and
-// the rendered string still highlights the old cursor row, matching less/vim
-// behavior; the deferred work runs at burst-end (wheelRenderDelay of wheel
-// idle) or when handleKey, handleResize, or handleBlameLoaded flushes early.
+// Raw packets are accumulated before this helper runs. The expensive cursor pin
+// and full-diff render remain deferred to handleWheelDebounce after the frame
+// changes YOffset. During a burst the cursor stays stale until the debounce or
+// an external cursor-dependent action flushes early.
 func (m *Model) scrollDiffViewportBy(delta int) bool {
 	if m.file.name == "" {
 		return false
@@ -409,6 +469,13 @@ func (m *Model) scrollDiffViewportBy(delta int) bool {
 // after the flush hits the !renderPending or stale-gen branches and is
 // harmless.
 func (m *Model) flushWheelPending() {
+	if m.wheel.delta != 0 {
+		flushed, _ := m.flushWheelFrame()
+		*m = flushed.(Model)
+	}
+	m.wheel.snapshot = ""
+	m.wheel.frameInFlight = false
+	m.wheel.frameGen++
 	if !m.wheel.renderPending {
 		return
 	}

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -203,27 +203,17 @@ func wheelMsg(button tea.MouseButton, x, y int, shift bool) tea.MouseMsg {
 // resulting render-debounce tick so the test sees settled state.
 func updateWheelAndFlush(t *testing.T, m Model, msg tea.MouseMsg) Model {
 	t.Helper()
-	result, cmd := m.Update(msg)
+	result, _ := m.Update(msg)
 	model := result.(Model)
-	if cmd == nil {
-		return model
+	if model.wheel.frameInFlight {
+		result, _ = model.Update(wheelFrameMsg{gen: model.wheel.frameGen})
+		model = result.(Model)
 	}
-	produced := cmd()
-	frameMsg, ok := produced.(wheelFrameMsg)
-	if !ok {
-		t.Fatalf("updateWheelAndFlush: wheel handler returned non-wheelFrameMsg cmd: %T", produced)
+	if model.wheel.renderPending {
+		result, _ = model.Update(wheelDebounceMsg{gen: model.wheel.gen})
+		model = result.(Model)
 	}
-	result, cmd = model.Update(frameMsg)
-	model = result.(Model)
-	if cmd == nil {
-		return model
-	}
-	debounceMsg, ok := cmd().(wheelDebounceMsg)
-	if !ok {
-		t.Fatalf("updateWheelAndFlush: frame handler returned non-wheelDebounceMsg cmd")
-	}
-	result, _ = model.Update(debounceMsg)
-	return result.(Model)
+	return model
 }
 
 // leftPressAt builds a left-click press MouseMsg at (x, y).
@@ -392,7 +382,7 @@ func TestModel_HandleMouse_WheelInWrapMode_StraddlePinsToNextLine(t *testing.T) 
 		"cursor must advance to line 1 (first line after the straddling wrapped span)")
 }
 
-func TestModel_HandleMouse_WheelFramePreservesInlineAndFileAnnotations(t *testing.T) {
+func TestModel_HandleMouse_WheelFramePinsPastWrappedAnnotationRows(t *testing.T) {
 	lines := make([]diff.DiffLine, 80)
 	for i := range lines {
 		lines[i] = diff.DiffLine{NewNum: i + 1, Content: strings.Repeat("wrapped content ", 12), ChangeType: diff.ChangeAdd}
@@ -406,8 +396,8 @@ func TestModel_HandleMouse_WheelFramePreservesInlineAndFileAnnotations(t *testin
 
 	model := updateWheelAndFlush(t, m, wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
-	assert.Len(t, model.store.Get("a.go"), 2)
-	assert.True(t, model.modes.wrap)
+	assert.Positive(t, model.nav.diffCursor, "wrapped annotation rows must participate in cursor pinning")
+	assert.False(t, model.annot.cursorOnAnnotation, "cursor must land on a diff line rather than the annotation row above it")
 }
 
 func TestModel_HandleMouse_ShiftWheelHalfPage(t *testing.T) {
@@ -1261,31 +1251,35 @@ func TestModel_HandleMouse_WheelFrameAccumulatesExactDistance(t *testing.T) {
 	m.file.lines = lines
 	m.layout.viewport.SetContent(m.renderDiff())
 
-	baseline := m.View()
 	model := m
-	var frame wheelFrameMsg
+	var firstFrame string
 	for i := range 4 {
 		result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 		model = result.(Model)
-		if i == 0 {
+		switch i {
+		case 0:
 			require.NotNil(t, cmd)
-			var ok bool
-			frame, ok = cmd().(wheelFrameMsg)
-			require.True(t, ok)
-		} else {
+			assert.Equal(t, wheelStep, model.layout.viewport.YOffset, "first packet must apply immediately")
+			assert.Empty(t, model.wheel.snapshot, "a single packet must not allocate a cached frame")
+			assert.False(t, model.wheel.frameInFlight, "a single packet must not schedule a frame tick")
+			firstFrame = model.View()
+		case 1:
+			require.NotNil(t, cmd, "second packet must start the coalescing frame")
+			assert.Equal(t, firstFrame, model.View(), "second packet must preserve the first packet's frame")
+		default:
 			assert.Nil(t, cmd, "only one frame tick may be scheduled")
+			assert.Equal(t, firstFrame, model.View(), "later packets must reuse the first packet's frame")
 		}
-		assert.Equal(t, baseline, model.View(), "raw packets must reuse the pre-frame snapshot")
 	}
-	assert.Equal(t, 0, model.layout.viewport.YOffset)
-	assert.Equal(t, 4*wheelStep, model.wheel.delta)
+	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
+	assert.Equal(t, 4*wheelStep, model.wheel.targetOffset)
 
-	result, cmd := model.Update(frame)
+	result, cmd := model.Update(wheelFrameMsg{gen: model.wheel.frameGen})
 	model = result.(Model)
 	assert.Equal(t, 4*wheelStep, model.layout.viewport.YOffset)
-	assert.Zero(t, model.wheel.delta)
+	assert.False(t, model.wheel.frameInFlight)
 	assert.True(t, model.wheel.renderPending)
-	require.NotNil(t, cmd, "the applied frame must schedule the cursor/render debounce")
+	assert.Nil(t, cmd, "the in-flight debounce gate must suppress a second ticker")
 }
 
 func TestModel_HandleMouse_WheelDeferredRender_NoDebounceWhenYOffsetCannotChange(t *testing.T) {
@@ -1449,20 +1443,22 @@ func TestModel_HandleMouse_WheelBurst_OppositeDirectionProcessesImmediately(t *t
 	for i := 1; i <= 5; i++ {
 		result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 		model = result.(Model)
-		if i == 1 {
-			require.NotNil(t, cmd, "first wheel of a frame must schedule a tick")
-		} else {
+		switch i {
+		case 1:
+			require.NotNil(t, cmd, "first packet must schedule the render debounce")
+		case 2:
+			require.NotNil(t, cmd, "second packet must schedule the frame tick")
+		default:
 			assert.Nil(t, cmd)
 		}
 	}
-	require.Equal(t, 0, model.layout.viewport.YOffset)
-	require.Equal(t, 5*wheelStep, model.wheel.delta)
+	require.Equal(t, wheelStep, model.layout.viewport.YOffset)
+	require.Equal(t, 5*wheelStep, model.wheel.targetOffset)
 
 	result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
 	model = result.(Model)
-	require.NotNil(t, cmd, "reversal flush must schedule the render debounce")
+	assert.Nil(t, cmd, "the existing debounce tick must cover the reversal")
 	assert.Equal(t, 4*wheelStep, model.layout.viewport.YOffset, "wheel-up must shift YOffset by -wheelStep relative to last down")
-	assert.Zero(t, model.wheel.delta)
 	assert.False(t, model.wheel.frameInFlight)
 }
 
@@ -1482,8 +1478,64 @@ func TestModel_HandleMouse_WheelReversalCanNetToZero(t *testing.T) {
 
 	assert.Nil(t, cmd)
 	assert.Zero(t, model.layout.viewport.YOffset)
-	assert.Zero(t, model.wheel.delta)
 	assert.False(t, model.wheel.frameInFlight)
+}
+
+func TestModel_HandleMouse_WheelReversalAfterBottomEdgeMovesUp(t *testing.T) {
+	lines := make([]diff.DiffLine, 80)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
+	maxOffset := m.layout.viewport.TotalLineCount() - m.layout.viewport.Height
+	require.Greater(t, maxOffset, 10)
+	m.layout.viewport.SetYOffset(maxOffset - 10)
+
+	model := m
+	for range 4 {
+		result, _ := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+		model = result.(Model)
+	}
+	require.True(t, model.wheel.frameInFlight)
+	require.Equal(t, maxOffset, model.wheel.targetOffset, "the accumulated target must clamp to the reachable edge")
+
+	result, _ := model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
+	model = result.(Model)
+	assert.Equal(t, maxOffset-wheelStep, model.layout.viewport.YOffset,
+		"the first reverse packet must move away from the clamped edge")
+}
+
+func TestModel_HandleFileLoaded_DiscardsPendingWheelFrame(t *testing.T) {
+	oldLines := make([]diff.DiffLine, 80)
+	newLines := make([]diff.DiffLine, 80)
+	for i := range oldLines {
+		oldLines[i] = diff.DiffLine{NewNum: i + 1, Content: "old", ChangeType: diff.ChangeContext}
+		newLines[i] = diff.DiffLine{NewNum: i + 1, Content: "new", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go", "b.go"}, map[string][]diff.DiffLine{"a.go": oldLines, "b.go": newLines})
+	m.file.lines = oldLines
+	m.layout.viewport.SetContent(m.renderDiff())
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	result, _ = model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model = result.(Model)
+	require.True(t, model.wheel.frameInFlight)
+	staleFrame := wheelFrameMsg{gen: model.wheel.frameGen}
+
+	result, _ = model.Update(fileLoadedMsg{file: "b.go", seq: model.file.loadSeq, lines: newLines})
+	model = result.(Model)
+	require.Equal(t, 0, model.layout.viewport.YOffset)
+	assert.False(t, model.wheel.frameInFlight)
+	assert.Empty(t, model.wheel.snapshot)
+	assert.False(t, model.wheel.renderPending)
+	assert.False(t, model.wheel.tickInFlight)
+
+	result, _ = model.Update(staleFrame)
+	model = result.(Model)
+	assert.Equal(t, 0, model.layout.viewport.YOffset, "a stale frame must not scroll the newly loaded file")
 }
 
 func TestModel_HandleMouse_ClickFlushesPendingWheelFrame(t *testing.T) {
@@ -1500,7 +1552,7 @@ func TestModel_HandleMouse_ClickFlushesPendingWheelFrame(t *testing.T) {
 	result, _ = model.Update(leftPressAt(60, 2))
 	model = result.(Model)
 
-	assert.Zero(t, model.wheel.delta)
+	assert.False(t, model.wheel.frameInFlight)
 	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
 	assert.Equal(t, wheelStep, model.nav.diffCursor, "click row must use the flushed YOffset")
 }
@@ -1523,8 +1575,7 @@ func TestModel_HandleKey_FlushesPendingWheelBeforeAction(t *testing.T) {
 	// stale at the pre-burst position (0), renderPending+tickInFlight true.
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	require.NotZero(t, model.wheel.delta)
-	require.True(t, model.wheel.frameInFlight)
+	require.True(t, model.wheel.renderPending)
 	require.Equal(t, 0, model.nav.diffCursor, "cursor pin is deferred — stays at pre-burst position")
 
 	// arbitrary keypress — even one with no resolved action — triggers the
@@ -1533,7 +1584,7 @@ func TestModel_HandleKey_FlushesPendingWheelBeforeAction(t *testing.T) {
 	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	model = result.(Model)
 
-	assert.Zero(t, model.wheel.delta)
+	assert.False(t, model.wheel.frameInFlight)
 	assert.False(t, model.wheel.renderPending, "handleKey must flush pending wheel work before processing the key")
 	assert.False(t, model.wheel.tickInFlight, "handleKey flush must also clear tickInFlight")
 	assert.Equal(t, wheelStep, model.nav.diffCursor, "cursor must be pinned to viewport top by the pre-key flush")
@@ -1554,7 +1605,7 @@ func TestModel_HandleResize_FlushesPendingWheelBeforeSync(t *testing.T) {
 
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	require.NotZero(t, model.wheel.delta)
+	require.True(t, model.wheel.renderPending)
 
 	// a window resize at the same dimensions still routes through handleResize
 	// and exercises the flush path; the values match the testModel defaults so
@@ -1583,7 +1634,7 @@ func TestModel_HandleBlameLoaded_FlushesPendingWheelBeforeSync(t *testing.T) {
 
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	require.NotZero(t, model.wheel.delta)
+	require.True(t, model.wheel.renderPending)
 	require.Equal(t, 0, model.nav.diffCursor)
 
 	result, _ = model.Update(blameLoadedMsg{
@@ -1627,8 +1678,15 @@ func BenchmarkModel_TrackpadWheelFrames(b *testing.B) {
 			model := base
 			for range b.N {
 				model.layout.viewport.SetYOffset(100)
+				model.nav.diffCursor = 100
+				model.annot.cursorOnAnnotation = false
 				for range packets {
 					result, _ := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+					model = result.(Model)
+					_ = model.View()
+				}
+				if model.wheel.frameInFlight {
+					result, _ := model.Update(wheelFrameMsg{gen: model.wheel.frameGen})
 					model = result.(Model)
 					_ = model.View()
 				}

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -199,16 +199,12 @@ func wheelMsg(button tea.MouseButton, x, y int, shift bool) tea.MouseMsg {
 	})
 }
 
-// updateWheelAndFlush dispatches a wheel event, its frame tick, and the
-// resulting render-debounce tick so the test sees settled state.
+// updateWheelAndFlush dispatches a wheel event and the resulting
+// render-debounce tick so the test sees settled state.
 func updateWheelAndFlush(t *testing.T, m Model, msg tea.MouseMsg) Model {
 	t.Helper()
 	result, _ := m.Update(msg)
 	model := result.(Model)
-	if model.wheel.frameInFlight {
-		result, _ = model.Update(wheelFrameMsg{gen: model.wheel.frameGen})
-		model = result.(Model)
-	}
 	if model.wheel.renderPending {
 		result, _ = model.Update(wheelDebounceMsg{gen: model.wheel.gen})
 		model = result.(Model)
@@ -382,7 +378,7 @@ func TestModel_HandleMouse_WheelInWrapMode_StraddlePinsToNextLine(t *testing.T) 
 		"cursor must advance to line 1 (first line after the straddling wrapped span)")
 }
 
-func TestModel_HandleMouse_WheelFramePinsPastWrappedAnnotationRows(t *testing.T) {
+func TestModel_HandleMouse_WheelPinsPastWrappedAnnotationRows(t *testing.T) {
 	lines := make([]diff.DiffLine, 80)
 	for i := range lines {
 		lines[i] = diff.DiffLine{NewNum: i + 1, Content: strings.Repeat("wrapped content ", 12), ChangeType: diff.ChangeAdd}
@@ -1242,44 +1238,36 @@ func TestModel_HandleMouse_ClickInDiffSyncsTOCActiveSection(t *testing.T) {
 	assert.Equal(t, 4, idx, "TOC active section must match clicked diff line (Third section at lineIdx=4)")
 }
 
-func TestModel_HandleMouse_WheelFrameAccumulatesExactDistance(t *testing.T) {
+func TestModel_HandleMouse_WheelPacketsMoveContinuously(t *testing.T) {
 	lines := make([]diff.DiffLine, 60)
 	for i := range lines {
-		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: fmt.Sprintf("line %d", i+1), ChangeType: diff.ChangeContext}
 	}
 	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
 	m.file.lines = lines
 	m.layout.viewport.SetContent(m.renderDiff())
 
 	model := m
-	var firstFrame string
+	previousView := model.View()
 	for i := range 4 {
 		result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 		model = result.(Model)
-		switch i {
-		case 0:
+		if i == 0 {
 			require.NotNil(t, cmd)
-			assert.Equal(t, wheelStep, model.layout.viewport.YOffset, "first packet must apply immediately")
-			assert.Empty(t, model.wheel.snapshot, "a single packet must not allocate a cached frame")
-			assert.False(t, model.wheel.frameInFlight, "a single packet must not schedule a frame tick")
-			firstFrame = model.View()
-		case 1:
-			require.NotNil(t, cmd, "second packet must start the coalescing frame")
-			assert.Equal(t, firstFrame, model.View(), "second packet must preserve the first packet's frame")
-		default:
-			assert.Nil(t, cmd, "only one frame tick may be scheduled")
-			assert.Equal(t, firstFrame, model.View(), "later packets must reuse the first packet's frame")
+		} else {
+			assert.Nil(t, cmd, "the debounce gate must keep one tick in flight")
 		}
+		assert.Equal(t, (i+1)*wheelStep, model.layout.viewport.YOffset,
+			"every packet must update the visible offset")
+		currentView := model.View()
+		assert.NotEqual(t, previousView, currentView, "every packet must produce a newly scrolled frame")
+		uncached := model
+		uncached.wheel.chrome = wheelChrome{}
+		assert.Equal(t, uncached.View(), currentView, "cached chrome must preserve the complete frame")
+		previousView = currentView
 	}
-	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
-	assert.Equal(t, 4*wheelStep, model.wheel.targetOffset)
-
-	result, cmd := model.Update(wheelFrameMsg{gen: model.wheel.frameGen})
-	model = result.(Model)
-	assert.Equal(t, 4*wheelStep, model.layout.viewport.YOffset)
-	assert.False(t, model.wheel.frameInFlight)
 	assert.True(t, model.wheel.renderPending)
-	assert.Nil(t, cmd, "the in-flight debounce gate must suppress a second ticker")
+	assert.True(t, model.wheel.chrome.active)
 }
 
 func TestModel_HandleMouse_WheelDeferredRender_NoDebounceWhenYOffsetCannotChange(t *testing.T) {
@@ -1443,23 +1431,18 @@ func TestModel_HandleMouse_WheelBurst_OppositeDirectionProcessesImmediately(t *t
 	for i := 1; i <= 5; i++ {
 		result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 		model = result.(Model)
-		switch i {
-		case 1:
+		if i == 1 {
 			require.NotNil(t, cmd, "first packet must schedule the render debounce")
-		case 2:
-			require.NotNil(t, cmd, "second packet must schedule the frame tick")
-		default:
+		} else {
 			assert.Nil(t, cmd)
 		}
+		assert.Equal(t, i*wheelStep, model.layout.viewport.YOffset)
 	}
-	require.Equal(t, wheelStep, model.layout.viewport.YOffset)
-	require.Equal(t, 5*wheelStep, model.wheel.targetOffset)
 
 	result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
 	model = result.(Model)
 	assert.Nil(t, cmd, "the existing debounce tick must cover the reversal")
 	assert.Equal(t, 4*wheelStep, model.layout.viewport.YOffset, "wheel-up must shift YOffset by -wheelStep relative to last down")
-	assert.False(t, model.wheel.frameInFlight)
 }
 
 func TestModel_HandleMouse_WheelReversalCanNetToZero(t *testing.T) {
@@ -1478,7 +1461,6 @@ func TestModel_HandleMouse_WheelReversalCanNetToZero(t *testing.T) {
 
 	assert.Nil(t, cmd)
 	assert.Zero(t, model.layout.viewport.YOffset)
-	assert.False(t, model.wheel.frameInFlight)
 }
 
 func TestModel_HandleMouse_WheelReversalAfterBottomEdgeMovesUp(t *testing.T) {
@@ -1498,8 +1480,7 @@ func TestModel_HandleMouse_WheelReversalAfterBottomEdgeMovesUp(t *testing.T) {
 		result, _ := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 		model = result.(Model)
 	}
-	require.True(t, model.wheel.frameInFlight)
-	require.Equal(t, maxOffset, model.wheel.targetOffset, "the accumulated target must clamp to the reachable edge")
+	require.Equal(t, maxOffset, model.layout.viewport.YOffset)
 
 	result, _ := model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
 	model = result.(Model)
@@ -1507,38 +1488,7 @@ func TestModel_HandleMouse_WheelReversalAfterBottomEdgeMovesUp(t *testing.T) {
 		"the first reverse packet must move away from the clamped edge")
 }
 
-func TestModel_HandleFileLoaded_DiscardsPendingWheelFrame(t *testing.T) {
-	oldLines := make([]diff.DiffLine, 80)
-	newLines := make([]diff.DiffLine, 80)
-	for i := range oldLines {
-		oldLines[i] = diff.DiffLine{NewNum: i + 1, Content: "old", ChangeType: diff.ChangeContext}
-		newLines[i] = diff.DiffLine{NewNum: i + 1, Content: "new", ChangeType: diff.ChangeContext}
-	}
-	m := mouseTestModel(t, []string{"a.go", "b.go"}, map[string][]diff.DiffLine{"a.go": oldLines, "b.go": newLines})
-	m.file.lines = oldLines
-	m.layout.viewport.SetContent(m.renderDiff())
-
-	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
-	model := result.(Model)
-	result, _ = model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
-	model = result.(Model)
-	require.True(t, model.wheel.frameInFlight)
-	staleFrame := wheelFrameMsg{gen: model.wheel.frameGen}
-
-	result, _ = model.Update(fileLoadedMsg{file: "b.go", seq: model.file.loadSeq, lines: newLines})
-	model = result.(Model)
-	require.Equal(t, 0, model.layout.viewport.YOffset)
-	assert.False(t, model.wheel.frameInFlight)
-	assert.Empty(t, model.wheel.snapshot)
-	assert.False(t, model.wheel.renderPending)
-	assert.False(t, model.wheel.tickInFlight)
-
-	result, _ = model.Update(staleFrame)
-	model = result.(Model)
-	assert.Equal(t, 0, model.layout.viewport.YOffset, "a stale frame must not scroll the newly loaded file")
-}
-
-func TestModel_HandleMouse_ClickFlushesPendingWheelFrame(t *testing.T) {
+func TestModel_HandleMouse_ClickFlushesPendingWheelRender(t *testing.T) {
 	lines := make([]diff.DiffLine, 60)
 	for i := range lines {
 		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
@@ -1552,7 +1502,6 @@ func TestModel_HandleMouse_ClickFlushesPendingWheelFrame(t *testing.T) {
 	result, _ = model.Update(leftPressAt(60, 2))
 	model = result.(Model)
 
-	assert.False(t, model.wheel.frameInFlight)
 	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
 	assert.Equal(t, wheelStep, model.nav.diffCursor, "click row must use the flushed YOffset")
 }
@@ -1584,9 +1533,9 @@ func TestModel_HandleKey_FlushesPendingWheelBeforeAction(t *testing.T) {
 	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	model = result.(Model)
 
-	assert.False(t, model.wheel.frameInFlight)
 	assert.False(t, model.wheel.renderPending, "handleKey must flush pending wheel work before processing the key")
 	assert.False(t, model.wheel.tickInFlight, "handleKey flush must also clear tickInFlight")
+	assert.False(t, model.wheel.chrome.active, "external flush must invalidate cached wheel chrome")
 	assert.Equal(t, wheelStep, model.nav.diffCursor, "cursor must be pinned to viewport top by the pre-key flush")
 }
 
@@ -1649,7 +1598,7 @@ func TestModel_HandleBlameLoaded_FlushesPendingWheelBeforeSync(t *testing.T) {
 	assert.Equal(t, wheelStep, model.nav.diffCursor, "cursor must be pinned to viewport top by the pre-blame flush")
 }
 
-func BenchmarkModel_TrackpadWheelFrames(b *testing.B) {
+func BenchmarkModel_TrackpadWheelPackets(b *testing.B) {
 	lines := make([]diff.DiffLine, 10_000)
 	for i := range lines {
 		lines[i] = diff.DiffLine{
@@ -1675,8 +1624,8 @@ func BenchmarkModel_TrackpadWheelFrames(b *testing.B) {
 	for _, packets := range []int{1, 4, 16} {
 		b.Run(fmt.Sprintf("packets_per_frame_%d", packets), func(b *testing.B) {
 			b.ReportAllocs()
-			model := base
 			for range b.N {
+				model := base
 				model.layout.viewport.SetYOffset(100)
 				model.nav.diffCursor = 100
 				model.annot.cursorOnAnnotation = false
@@ -1685,13 +1634,6 @@ func BenchmarkModel_TrackpadWheelFrames(b *testing.B) {
 					model = result.(Model)
 					_ = model.View()
 				}
-				if model.wheel.frameInFlight {
-					result, _ := model.Update(wheelFrameMsg{gen: model.wheel.frameGen})
-					model = result.(Model)
-					_ = model.View()
-				}
-				model.flushWheelPending()
-				_ = model.View()
 			}
 		})
 	}

--- a/app/ui/mouse_test.go
+++ b/app/ui/mouse_test.go
@@ -199,17 +199,8 @@ func wheelMsg(button tea.MouseButton, x, y int, shift bool) tea.MouseMsg {
 	})
 }
 
-// updateWheelAndFlush dispatches a wheel event through Update, then dispatches
-// the resulting wheelDebounceMsg (if any) so the test sees the final post-flush
-// state. mirrors what bubbletea does after wheelRenderDelay idle: the latest
-// debounce tick fires, the cursor pins and the diff re-renders. tests that
-// want to observe burst-time state (pre-flush) should call Update directly
-// instead.
-//
-// fails loudly when the wheel handler returns a cmd that is NOT a
-// wheelDebounceMsg producer — a future refactor (e.g. tea.Batch) would
-// otherwise silently degrade this helper into a plain Update and produce
-// misleading "post-flush" assertions on pre-flush state.
+// updateWheelAndFlush dispatches a wheel event, its frame tick, and the
+// resulting render-debounce tick so the test sees settled state.
 func updateWheelAndFlush(t *testing.T, m Model, msg tea.MouseMsg) Model {
 	t.Helper()
 	result, cmd := m.Update(msg)
@@ -218,9 +209,18 @@ func updateWheelAndFlush(t *testing.T, m Model, msg tea.MouseMsg) Model {
 		return model
 	}
 	produced := cmd()
-	debounceMsg, ok := produced.(wheelDebounceMsg)
+	frameMsg, ok := produced.(wheelFrameMsg)
 	if !ok {
-		t.Fatalf("updateWheelAndFlush: wheel handler returned non-wheelDebounceMsg cmd: %T", produced)
+		t.Fatalf("updateWheelAndFlush: wheel handler returned non-wheelFrameMsg cmd: %T", produced)
+	}
+	result, cmd = model.Update(frameMsg)
+	model = result.(Model)
+	if cmd == nil {
+		return model
+	}
+	debounceMsg, ok := cmd().(wheelDebounceMsg)
+	if !ok {
+		t.Fatalf("updateWheelAndFlush: frame handler returned non-wheelDebounceMsg cmd")
 	}
 	result, _ = model.Update(debounceMsg)
 	return result.(Model)
@@ -267,8 +267,7 @@ func TestModel_HandleMouse_WheelInDiff_CursorStaysWhenInView(t *testing.T) {
 	m.layout.viewport.SetContent(m.renderDiff())
 	m.nav.diffCursor = 20 // cursor sits comfortably inside the 30-row viewport
 
-	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
-	model := result.(Model)
+	model := updateWheelAndFlush(t, m, wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
 	assert.Equal(t, 20, model.nav.diffCursor, "cursor must not move while still inside the viewport")
 }
@@ -391,6 +390,24 @@ func TestModel_HandleMouse_WheelInWrapMode_StraddlePinsToNextLine(t *testing.T) 
 	// viewTop=wheelStep is inside line 0's span [0, cursorBottom]; cursor must advance to line 1.
 	assert.Equal(t, 1, model.nav.diffCursor,
 		"cursor must advance to line 1 (first line after the straddling wrapped span)")
+}
+
+func TestModel_HandleMouse_WheelFramePreservesInlineAndFileAnnotations(t *testing.T) {
+	lines := make([]diff.DiffLine, 80)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: strings.Repeat("wrapped content ", 12), ChangeType: diff.ChangeAdd}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.modes.wrap = true
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 1, Type: "+", Comment: "inline note"})
+	m.store.Add(annotation.Annotation{File: "a.go", Line: 0, Type: "F", Comment: "file note"})
+	m.layout.viewport.SetContent(m.renderDiff())
+
+	model := updateWheelAndFlush(t, m, wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
+	assert.Len(t, model.store.Get("a.go"), 2)
+	assert.True(t, model.modes.wrap)
 }
 
 func TestModel_HandleMouse_ShiftWheelHalfPage(t *testing.T) {
@@ -1235,11 +1252,7 @@ func TestModel_HandleMouse_ClickInDiffSyncsTOCActiveSection(t *testing.T) {
 	assert.Equal(t, 4, idx, "TOC active section must match clicked diff line (Third section at lineIdx=4)")
 }
 
-func TestModel_HandleMouse_WheelDeferredRender_SchedulesDebounceWhenYOffsetChanges(t *testing.T) {
-	// when a wheel event shifts YOffset, both the cursor pin AND the render are
-	// deferred to handleWheelDebounce. the wheel handler returns a tea.Tick
-	// command carrying the current gen; the per-event path is O(1) so a burst
-	// of events doesn't queue behind expensive per-event work.
+func TestModel_HandleMouse_WheelFrameAccumulatesExactDistance(t *testing.T) {
 	lines := make([]diff.DiffLine, 60)
 	for i := range lines {
 		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
@@ -1248,19 +1261,31 @@ func TestModel_HandleMouse_WheelDeferredRender_SchedulesDebounceWhenYOffsetChang
 	m.file.lines = lines
 	m.layout.viewport.SetContent(m.renderDiff())
 
-	result, cmd := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
-	model := result.(Model)
+	baseline := m.View()
+	model := m
+	var frame wheelFrameMsg
+	for i := range 4 {
+		result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+		model = result.(Model)
+		if i == 0 {
+			require.NotNil(t, cmd)
+			var ok bool
+			frame, ok = cmd().(wheelFrameMsg)
+			require.True(t, ok)
+		} else {
+			assert.Nil(t, cmd, "only one frame tick may be scheduled")
+		}
+		assert.Equal(t, baseline, model.View(), "raw packets must reuse the pre-frame snapshot")
+	}
+	assert.Equal(t, 0, model.layout.viewport.YOffset)
+	assert.Equal(t, 4*wheelStep, model.wheel.delta)
 
-	assert.Equal(t, wheelStep, model.layout.viewport.YOffset, "YOffset must advance synchronously")
-	assert.Equal(t, 0, model.nav.diffCursor, "cursor pin is deferred — diffCursor stays at the pre-burst position")
-	assert.True(t, model.wheel.renderPending, "render must be marked pending after YOffset shift")
-	assert.Equal(t, 1, model.wheel.gen, "wheel gen must bump on each YOffset-shifting event")
-	require.NotNil(t, cmd, "wheel that shifts YOffset must return a debounce command")
-
-	msg := cmd()
-	debounce, ok := msg.(wheelDebounceMsg)
-	require.True(t, ok, "debounce command must produce wheelDebounceMsg, got %T", msg)
-	assert.Equal(t, 1, debounce.gen, "debounce msg gen must match wheel gen at scheduling")
+	result, cmd := model.Update(frame)
+	model = result.(Model)
+	assert.Equal(t, 4*wheelStep, model.layout.viewport.YOffset)
+	assert.Zero(t, model.wheel.delta)
+	assert.True(t, model.wheel.renderPending)
+	require.NotNil(t, cmd, "the applied frame must schedule the cursor/render debounce")
 }
 
 func TestModel_HandleMouse_WheelDeferredRender_NoDebounceWhenYOffsetCannotChange(t *testing.T) {
@@ -1412,12 +1437,6 @@ func TestModel_HandleMouse_WheelDebounceMsg_NoopWhenRenderNotPending(t *testing.
 }
 
 func TestModel_HandleMouse_WheelBurst_OppositeDirectionProcessesImmediately(t *testing.T) {
-	// the core fix for issue #179: a wheel-up event arriving during a wheel-down
-	// burst must NOT wait for buffered events' renders to complete. each wheel
-	// event shifts YOffset synchronously and defers cursor pin + renderDiff to
-	// a single debounce tick; only the first wheel of a burst schedules a tea
-	// Tick (subsequent wheels just bump gen) so per-event message count is
-	// O(1) regardless of burst length.
 	lines := make([]diff.DiffLine, 200)
 	for i := range lines {
 		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
@@ -1426,50 +1445,64 @@ func TestModel_HandleMouse_WheelBurst_OppositeDirectionProcessesImmediately(t *t
 	m.file.lines = lines
 	m.layout.viewport.SetContent(m.renderDiff())
 
-	// rapid wheel-down burst — first event schedules a tick, subsequent events
-	// just bump gen (no new tick) so the debounce-message count stays bounded.
 	model := m
 	for i := 1; i <= 5; i++ {
 		result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 		model = result.(Model)
-		assert.Equal(t, i, model.wheel.gen, "wheel gen must bump on each YOffset-shifting event")
-		assert.True(t, model.wheel.renderPending, "render must stay pending across the burst")
 		if i == 1 {
-			require.NotNil(t, cmd, "first wheel of a burst must schedule a debounce tick")
+			require.NotNil(t, cmd, "first wheel of a frame must schedule a tick")
 		} else {
-			assert.Nil(t, cmd, "wheel #%d must not schedule a new tick while one is already in flight", i)
+			assert.Nil(t, cmd)
 		}
 	}
-	require.Equal(t, 5*wheelStep, model.layout.viewport.YOffset, "five wheel-down events must scroll by 5*wheelStep")
-	assert.True(t, model.wheel.tickInFlight, "tickInFlight must stay true while the burst is alive")
+	require.Equal(t, 0, model.layout.viewport.YOffset)
+	require.Equal(t, 5*wheelStep, model.wheel.delta)
 
-	// wheel-up arrives mid-burst (gen=1 tick is still in flight). the up event
-	// shifts YOffset immediately and bumps gen to 6 — no new tick scheduled
-	// because tickInFlight is still true. the in-flight gen=1 tick will fire
-	// stale and reschedule itself for gen 6.
 	result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
 	model = result.(Model)
-	assert.Nil(t, cmd, "wheel-up mid-burst must not schedule a new tick — the existing one will reschedule itself")
+	require.NotNil(t, cmd, "reversal flush must schedule the render debounce")
 	assert.Equal(t, 4*wheelStep, model.layout.viewport.YOffset, "wheel-up must shift YOffset by -wheelStep relative to last down")
-	assert.Equal(t, 6, model.wheel.gen, "wheel-up shifting YOffset must bump gen past the down events")
+	assert.Zero(t, model.wheel.delta)
+	assert.False(t, model.wheel.frameInFlight)
+}
 
-	// the original gen=1 tick fires stale; handleWheelDebounce reschedules for
-	// gen=6 (the current burst tip). pending state stays true.
-	result, cmd = model.Update(wheelDebounceMsg{gen: 1})
-	model = result.(Model)
-	require.NotNil(t, cmd, "stale tick must reschedule a fresh tick targeting the current gen")
-	assert.True(t, model.wheel.renderPending, "stale debounce must not clear renderPending")
-	rescheduled, ok := cmd().(wheelDebounceMsg)
-	require.True(t, ok)
-	assert.Equal(t, 6, rescheduled.gen, "rescheduled tick must target current gen")
+func TestModel_HandleMouse_WheelReversalCanNetToZero(t *testing.T) {
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
 
-	// rescheduled gen=6 tick fires — burst has settled. flushes pin + render
-	// and clears tickInFlight so the next burst's first wheel can schedule
-	// fresh.
-	result, _ = model.Update(wheelDebounceMsg{gen: 6})
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	result, cmd := model.Update(wheelMsg(tea.MouseButtonWheelUp, 60, 10, false))
 	model = result.(Model)
-	assert.False(t, model.wheel.renderPending, "matching debounce gen must flush the deferred render")
-	assert.False(t, model.wheel.tickInFlight, "tickInFlight must clear once the flush completes")
+
+	assert.Nil(t, cmd)
+	assert.Zero(t, model.layout.viewport.YOffset)
+	assert.Zero(t, model.wheel.delta)
+	assert.False(t, model.wheel.frameInFlight)
+}
+
+func TestModel_HandleMouse_ClickFlushesPendingWheelFrame(t *testing.T) {
+	lines := make([]diff.DiffLine, 60)
+	for i := range lines {
+		lines[i] = diff.DiffLine{NewNum: i + 1, Content: "line", ChangeType: diff.ChangeContext}
+	}
+	m := mouseTestModel(t, []string{"a.go"}, map[string][]diff.DiffLine{"a.go": lines})
+	m.file.lines = lines
+	m.layout.viewport.SetContent(m.renderDiff())
+
+	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+	model := result.(Model)
+	result, _ = model.Update(leftPressAt(60, 2))
+	model = result.(Model)
+
+	assert.Zero(t, model.wheel.delta)
+	assert.Equal(t, wheelStep, model.layout.viewport.YOffset)
+	assert.Equal(t, wheelStep, model.nav.diffCursor, "click row must use the flushed YOffset")
 }
 
 func TestModel_HandleKey_FlushesPendingWheelBeforeAction(t *testing.T) {
@@ -1490,8 +1523,8 @@ func TestModel_HandleKey_FlushesPendingWheelBeforeAction(t *testing.T) {
 	// stale at the pre-burst position (0), renderPending+tickInFlight true.
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	require.True(t, model.wheel.renderPending)
-	require.True(t, model.wheel.tickInFlight)
+	require.NotZero(t, model.wheel.delta)
+	require.True(t, model.wheel.frameInFlight)
 	require.Equal(t, 0, model.nav.diffCursor, "cursor pin is deferred — stays at pre-burst position")
 
 	// arbitrary keypress — even one with no resolved action — triggers the
@@ -1500,6 +1533,7 @@ func TestModel_HandleKey_FlushesPendingWheelBeforeAction(t *testing.T) {
 	result, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	model = result.(Model)
 
+	assert.Zero(t, model.wheel.delta)
 	assert.False(t, model.wheel.renderPending, "handleKey must flush pending wheel work before processing the key")
 	assert.False(t, model.wheel.tickInFlight, "handleKey flush must also clear tickInFlight")
 	assert.Equal(t, wheelStep, model.nav.diffCursor, "cursor must be pinned to viewport top by the pre-key flush")
@@ -1520,9 +1554,7 @@ func TestModel_HandleResize_FlushesPendingWheelBeforeSync(t *testing.T) {
 
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	require.True(t, model.wheel.renderPending)
-	wheeledOffset := model.layout.viewport.YOffset
-	require.Positive(t, wheeledOffset, "wheel must advance YOffset for the test to be meaningful")
+	require.NotZero(t, model.wheel.delta)
 
 	// a window resize at the same dimensions still routes through handleResize
 	// and exercises the flush path; the values match the testModel defaults so
@@ -1551,7 +1583,7 @@ func TestModel_HandleBlameLoaded_FlushesPendingWheelBeforeSync(t *testing.T) {
 
 	result, _ := m.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
 	model := result.(Model)
-	require.True(t, model.wheel.renderPending)
+	require.NotZero(t, model.wheel.delta)
 	require.Equal(t, 0, model.nav.diffCursor)
 
 	result, _ = model.Update(blameLoadedMsg{
@@ -1564,4 +1596,45 @@ func TestModel_HandleBlameLoaded_FlushesPendingWheelBeforeSync(t *testing.T) {
 	assert.False(t, model.wheel.renderPending, "handleBlameLoaded must flush pending wheel work before syncViewportToCursor")
 	assert.False(t, model.wheel.tickInFlight, "handleBlameLoaded flush must also clear tickInFlight")
 	assert.Equal(t, wheelStep, model.nav.diffCursor, "cursor must be pinned to viewport top by the pre-blame flush")
+}
+
+func BenchmarkModel_TrackpadWheelFrames(b *testing.B) {
+	lines := make([]diff.DiffLine, 10_000)
+	for i := range lines {
+		lines[i] = diff.DiffLine{
+			NewNum:     i + 1,
+			Content:    fmt.Sprintf("line %05d %s", i, strings.Repeat("wrapped trackpad benchmark content ", 5)),
+			ChangeType: diff.ChangeAdd,
+		}
+	}
+	base := testModel([]string{"large.go"}, map[string][]diff.DiffLine{"large.go": lines})
+	base.tree = testNewFileTree([]string{"large.go"})
+	base.layout.width = 120
+	base.layout.height = 40
+	base.layout.treeWidth = 36
+	base.layout.viewport = viewport.New(80, 30)
+	base.file.name = "large.go"
+	base.file.lines = lines
+	base.modes.wrap = true
+	for i := 1; i <= len(lines); i += 10 {
+		base.store.Add(annotation.Annotation{File: "large.go", Line: i, Type: "+", Comment: "benchmark annotation"})
+	}
+	base.layout.viewport.SetContent(base.renderDiff())
+
+	for _, packets := range []int{1, 4, 16} {
+		b.Run(fmt.Sprintf("packets_per_frame_%d", packets), func(b *testing.B) {
+			b.ReportAllocs()
+			model := base
+			for range b.N {
+				model.layout.viewport.SetYOffset(100)
+				for range packets {
+					result, _ := model.Update(wheelMsg(tea.MouseButtonWheelDown, 60, 10, false))
+					model = result.(Model)
+					_ = model.View()
+				}
+				model.flushWheelPending()
+				_ = model.View()
+			}
+		})
+	}
 }

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -12,7 +12,8 @@ import (
 	"github.com/umputun/revdiff/app/ui/style"
 )
 
-// View renders the full TUI.
+// View renders the full TUI, or reuses the last complete frame while later
+// wheel packets wait for their coalescing tick.
 func (m Model) View() string {
 	if m.wheel.snapshot != "" {
 		return m.wheel.snapshot

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -12,12 +12,8 @@ import (
 	"github.com/umputun/revdiff/app/ui/style"
 )
 
-// View renders the full TUI, or reuses the last complete frame while later
-// wheel packets wait for their coalescing tick.
+// View renders the full TUI.
 func (m Model) View() string {
-	if m.wheel.snapshot != "" {
-		return m.wheel.snapshot
-	}
 	if !m.ready {
 		return "loading..."
 	}
@@ -43,15 +39,10 @@ func (m Model) View() string {
 		diffPaneW = m.layout.width - m.layout.treeWidth - 4
 	}
 
-	// diff pane title
-	diffTitle := "no file selected"
-	if m.file.name != "" {
-		diffTitle = m.file.name
-		if m.file.oldName != "" && m.file.oldName != m.file.name {
-			diffTitle = m.file.oldName + " → " + m.file.name
-		}
+	diffHeader := m.wheel.chrome.diffHeader
+	if !m.wheel.chrome.active {
+		diffHeader = m.renderDiffHeader(diffPaneW)
 	}
-	diffHeader := m.resolver.Style(style.StyleKeyDirEntry).Render(m.truncateHeaderTitle(diffTitle, diffPaneW))
 	diffContent := lipgloss.JoinVertical(lipgloss.Left, diffHeader, m.layout.viewport.View())
 
 	var mainView string
@@ -67,13 +58,21 @@ func (m Model) View() string {
 
 	case m.file.singleFile && m.file.mdTOC != nil:
 		// single-file markdown with TOC: two-pane layout with TOC in left pane
-		tocContent := m.file.mdTOC.Render(sidepane.TOCRender{Width: m.layout.treeWidth, Height: ph, Focused: m.layout.focus == paneTree, Resolver: m.resolver})
-		mainView = m.renderTwoPaneLayout(tocContent, diffContent, m.file.mdTOC.ScrollState(), ph, diffPaneW)
+		if m.wheel.chrome.active {
+			mainView = m.renderTwoPaneLayout("", diffContent, sidepane.ScrollState{}, ph, diffPaneW)
+		} else {
+			tocContent := m.file.mdTOC.Render(sidepane.TOCRender{Width: m.layout.treeWidth, Height: ph, Focused: m.layout.focus == paneTree, Resolver: m.resolver})
+			mainView = m.renderTwoPaneLayout(tocContent, diffContent, m.file.mdTOC.ScrollState(), ph, diffPaneW)
+		}
 
 	default:
-		annotated := m.annotatedFiles()
-		treeContent := m.tree.Render(sidepane.FileTreeRender{Width: m.layout.treeWidth, Height: ph, Annotated: annotated, Resolver: m.resolver, Renderer: m.renderer})
-		mainView = m.renderTwoPaneLayout(treeContent, diffContent, m.tree.ScrollState(), ph, diffPaneW)
+		if m.wheel.chrome.active {
+			mainView = m.renderTwoPaneLayout("", diffContent, sidepane.ScrollState{}, ph, diffPaneW)
+		} else {
+			annotated := m.annotatedFiles()
+			treeContent := m.tree.Render(sidepane.FileTreeRender{Width: m.layout.treeWidth, Height: ph, Annotated: annotated, Resolver: m.resolver, Renderer: m.renderer})
+			mainView = m.renderTwoPaneLayout(treeContent, diffContent, m.tree.ScrollState(), ph, diffPaneW)
+		}
 	}
 
 	mainView = m.overlay.Compose(mainView, overlay.RenderCtx{Width: m.layout.width, Height: m.layout.height, Resolver: m.resolver})
@@ -82,8 +81,26 @@ func (m Model) View() string {
 		return mainView
 	}
 
-	status := m.resolver.Style(style.StyleKeyStatusBar).Width(m.layout.width).Render(m.statusBarText())
+	status := m.wheel.chrome.status
+	if !m.wheel.chrome.active {
+		status = m.renderStatusBar()
+	}
 	return lipgloss.JoinVertical(lipgloss.Left, mainView, status)
+}
+
+func (m Model) renderDiffHeader(diffPaneW int) string {
+	diffTitle := "no file selected"
+	if m.file.name != "" {
+		diffTitle = m.file.name
+		if m.file.oldName != "" && m.file.oldName != m.file.name {
+			diffTitle = m.file.oldName + " → " + m.file.name
+		}
+	}
+	return m.resolver.Style(style.StyleKeyDirEntry).Render(m.truncateHeaderTitle(diffTitle, diffPaneW))
+}
+
+func (m Model) renderStatusBar() string {
+	return m.resolver.Style(style.StyleKeyStatusBar).Width(m.layout.width).Render(m.statusBarText())
 }
 
 // renderTwoPaneLayout renders a two-pane layout with left (tree/TOC) and right (diff) content.
@@ -100,14 +117,17 @@ func (m Model) renderTwoPaneLayout(leftContent, diffContent string, leftScroll s
 		diffStyle = m.resolver.Style(style.StyleKeyDiffPaneActive)
 	}
 
-	leftContent = m.padContentBg(leftContent, m.layout.treeWidth, m.resolver.Color(style.ColorKeyTreePaneBg))
 	diffContent = m.padContentBg(diffContent, diffPaneW, m.resolver.Color(style.ColorKeyDiffPaneBg))
 
-	leftPane := treeStyle.
-		Width(m.layout.treeWidth).
-		Height(ph).
-		Render(leftContent)
-	leftPane = m.applyNavigationScrollbar(leftPane, leftScroll)
+	leftPane := m.wheel.chrome.leftPane
+	if !m.wheel.chrome.active {
+		leftContent = m.padContentBg(leftContent, m.layout.treeWidth, m.resolver.Color(style.ColorKeyTreePaneBg))
+		leftPane = treeStyle.
+			Width(m.layout.treeWidth).
+			Height(ph).
+			Render(leftContent)
+		leftPane = m.applyNavigationScrollbar(leftPane, leftScroll)
+	}
 
 	diffPane := diffStyle.
 		Width(diffPaneW).
@@ -116,6 +136,42 @@ func (m Model) renderTwoPaneLayout(leftContent, diffContent string, leftScroll s
 	diffPane = m.applyScrollbar(diffPane)
 
 	return lipgloss.JoinHorizontal(lipgloss.Top, leftPane, diffPane)
+}
+
+// prepareWheelChrome captures only elements that stay stable while wheel
+// cursor pinning is deferred. The diff viewport and scrollbar are never cached.
+func (m *Model) prepareWheelChrome() {
+	if m.wheel.chrome.active || !m.ready || !m.filesLoaded {
+		return
+	}
+	ph := m.paneHeight()
+	diffPaneW := m.layout.width - 2
+	if !m.treePaneHidden() {
+		diffPaneW = m.layout.width - m.layout.treeWidth - 4
+	}
+	m.wheel.chrome.diffHeader = m.renderDiffHeader(diffPaneW)
+	if !m.treePaneHidden() {
+		var content string
+		var scroll sidepane.ScrollState
+		if m.file.singleFile && m.file.mdTOC != nil {
+			content = m.file.mdTOC.Render(sidepane.TOCRender{Width: m.layout.treeWidth, Height: ph, Focused: m.layout.focus == paneTree, Resolver: m.resolver})
+			scroll = m.file.mdTOC.ScrollState()
+		} else {
+			content = m.tree.Render(sidepane.FileTreeRender{Width: m.layout.treeWidth, Height: ph, Annotated: m.annotatedFiles(), Resolver: m.resolver, Renderer: m.renderer})
+			scroll = m.tree.ScrollState()
+		}
+		styleForPane := m.resolver.Style(style.StyleKeyTreePane)
+		if m.layout.focus == paneTree {
+			styleForPane = m.resolver.Style(style.StyleKeyTreePaneActive)
+		}
+		content = m.padContentBg(content, m.layout.treeWidth, m.resolver.Color(style.ColorKeyTreePaneBg))
+		m.wheel.chrome.leftPane = styleForPane.Width(m.layout.treeWidth).Height(ph).Render(content)
+		m.wheel.chrome.leftPane = m.applyNavigationScrollbar(m.wheel.chrome.leftPane, scroll)
+	}
+	if !m.cfg.noStatusBar {
+		m.wheel.chrome.status = m.renderStatusBar()
+	}
+	m.wheel.chrome.active = true
 }
 
 // truncateHeaderTitle returns the diff pane header text shortened to fit
@@ -295,13 +351,9 @@ func (m Model) lineNumberSegment() string {
 		return ""
 	}
 	var maxOld, maxNew int
-	for _, l := range m.file.lines {
-		if l.OldNum > maxOld {
-			maxOld = l.OldNum
-		}
-		if l.NewNum > maxNew {
-			maxNew = l.NewNum
-		}
+	for _, line := range m.file.lines {
+		maxOld = max(maxOld, line.OldNum)
+		maxNew = max(maxNew, line.NewNum)
 	}
 	total := maxNew
 	if dl.ChangeType == diff.ChangeRemove {

--- a/app/ui/view.go
+++ b/app/ui/view.go
@@ -14,6 +14,9 @@ import (
 
 // View renders the full TUI.
 func (m Model) View() string {
+	if m.wheel.snapshot != "" {
+		return m.wheel.snapshot
+	}
 	if !m.ready {
 		return "loading..."
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,7 +114,7 @@ Central package. Single `Model` struct implements bubbletea's `Model` interface.
 | `themeselect.go` | Theme selector operations: open, preview, confirm, apply (via injected `ThemeCatalog`) |
 | `filepicker.go` | File picker open and selected-path jump integration; delegates visible-order/filter ownership to `FileTreeComponent` and loading to the guarded file loader |
 | `search.go` | Search input handling, match computation, navigation |
-| `mouse.go` | Mouse event routing: `handleMouse` dispatch, `hitTest` pane classification (`hitZone`), wheel/left-click helpers (`clickTree`, `clickDiff`), layout helpers (`statusBarHeight`, `diffTopRow`, `treeTopRow`). Diff-pane wheel events defer both the cursor pin and the `SetContent(renderDiff())` call via a single in-flight `tea.Tick(wheelRenderDelay)` debounce (issue #179) — `wheelState.tickInFlight` ensures one tick at a time across an entire burst (subsequent wheels just bump `gen`); stale ticks reschedule, matching ticks flush. `flushWheelPending()` is called from `handleWheelDebounce`, `handleKey`, `handleResize`, and `handleBlameLoaded` (any path that runs `syncViewportToCursor` or reads `m.nav.diffCursor` must flush first). Mouse tracking is enabled program-wide via `tea.WithMouseCellMotion()` in `app/main.go` unless `--no-mouse` / `REVDIFF_NO_MOUSE` is set |
+| `mouse.go` | Mouse event routing: `handleMouse` dispatch, `hitTest` pane classification (`hitZone`), wheel/left-click helpers (`clickTree`, `clickDiff`), layout helpers (`statusBarHeight`, `diffTopRow`, `treeTopRow`). The first diff-pane wheel packet applies immediately; later same-direction packets accumulate as a clamped target behind a 16 ms frame tick while `View()` reuses the last complete frame. Reversals flush immediately. Cursor pinning and `SetContent(renderDiff())` remain behind the issue #179 idle debounce, with `tickInFlight` limiting it to one live tick. Any path that depends on current viewport, cursor, or rendered diff calls `flushWheelPending()` first; accepted file loads discard unapplied frame input. Mouse tracking is enabled program-wide via `tea.WithMouseCellMotion()` in `app/main.go` unless `--no-mouse` / `REVDIFF_NO_MOUSE` is set |
 
 Each source file has a matching `_test.go`.
 
@@ -129,7 +129,7 @@ Each source file has a matching `_test.go`.
 | `navigationState` (`m.nav`) | cursor position | `diffCursor`, `pendingHunkJump` |
 | `searchState` (`m.search`) | search lifecycle | `active`, `term`, `matches`, `cursor`, `input`, `matchSet`, `history`, `historyIdx` |
 | `annotationState` (`m.annot`) | annotation input lifecycle and visual-row cache | `annotating`, `fileAnnotating`, `cursorOnAnnotation`, `input`, `rowCache` |
-| `wheelState` (`m.wheel`) | diff-pane wheel coalescing (issue #179) | `gen`, `renderPending`, `tickInFlight` |
+| `wheelState` (`m.wheel`) | immediate wheel response, frame coalescing, and deferred cursor/render work | `targetOffset`, `direction`, `frameGen`, `frameInFlight`, `snapshot`, `gen`, `renderPending`, `tickInFlight` |
 
 Methods remain on `Model` — the sub-structs group mutable state for clarity, not to create mini-models.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,7 +114,7 @@ Central package. Single `Model` struct implements bubbletea's `Model` interface.
 | `themeselect.go` | Theme selector operations: open, preview, confirm, apply (via injected `ThemeCatalog`) |
 | `filepicker.go` | File picker open and selected-path jump integration; delegates visible-order/filter ownership to `FileTreeComponent` and loading to the guarded file loader |
 | `search.go` | Search input handling, match computation, navigation |
-| `mouse.go` | Mouse event routing: `handleMouse` dispatch, `hitTest` pane classification (`hitZone`), wheel/left-click helpers (`clickTree`, `clickDiff`), layout helpers (`statusBarHeight`, `diffTopRow`, `treeTopRow`). The first diff-pane wheel packet applies immediately; later same-direction packets accumulate as a clamped target behind a 16 ms frame tick while `View()` reuses the last complete frame. Reversals flush immediately. Cursor pinning and `SetContent(renderDiff())` remain behind the issue #179 idle debounce, with `tickInFlight` limiting it to one live tick. Any path that depends on current viewport, cursor, or rendered diff calls `flushWheelPending()` first; accepted file loads discard unapplied frame input. Mouse tracking is enabled program-wide via `tea.WithMouseCellMotion()` in `app/main.go` unless `--no-mouse` / `REVDIFF_NO_MOUSE` is set |
+| `mouse.go` | Mouse event routing: `handleMouse` dispatch, `hitTest` pane classification (`hitZone`), wheel/left-click helpers (`clickTree`, `clickDiff`), layout helpers (`statusBarHeight`, `diffTopRow`, `treeTopRow`). Diff-pane wheel packets update `YOffset` immediately for continuous trackpad motion. Cursor pinning and `SetContent(renderDiff())` remain behind the issue #179 idle debounce, with `tickInFlight` limiting it to one live tick. Any path that depends on current viewport, cursor, or rendered diff calls `flushWheelPending()` first. Mouse tracking is enabled program-wide via `tea.WithMouseCellMotion()` in `app/main.go` unless `--no-mouse` / `REVDIFF_NO_MOUSE` is set |
 
 Each source file has a matching `_test.go`.
 
@@ -129,7 +129,7 @@ Each source file has a matching `_test.go`.
 | `navigationState` (`m.nav`) | cursor position | `diffCursor`, `pendingHunkJump` |
 | `searchState` (`m.search`) | search lifecycle | `active`, `term`, `matches`, `cursor`, `input`, `matchSet`, `history`, `historyIdx` |
 | `annotationState` (`m.annot`) | annotation input lifecycle and visual-row cache | `annotating`, `fileAnnotating`, `cursorOnAnnotation`, `input`, `rowCache` |
-| `wheelState` (`m.wheel`) | immediate wheel response, frame coalescing, and deferred cursor/render work | `targetOffset`, `direction`, `frameGen`, `frameInFlight`, `snapshot`, `gen`, `renderPending`, `tickInFlight` |
+| `wheelState` (`m.wheel`) | immediate wheel response, stable chrome cache, and deferred cursor/render work | `chrome`, `gen`, `renderPending`, `tickInFlight` |
 
 Methods remain on `Model` — the sub-structs group mutable state for clarity, not to create mini-models.
 


### PR DESCRIPTION
## What changed

Diff-pane wheel packets update `YOffset` immediately. The existing 30 ms cursor-pin and `renderDiff()` debounce from #179 remains unchanged.

While wheel cursor work is deferred, `View()` reuses only stable pane chrome: the diff header, rendered tree or TOC pane, and status bar. The viewport and scrollbar remain live in every model view.

The Bubble Tea renderer now runs at its supported 120 FPS ceiling. Bubble Tea replaces buffered views between renderer ticks, so terminal-visible frames remain bounded by renderer cadence even when the model handles every packet.

## Why

The earlier 16 ms frame snapshot reduced repeated layout work but withheld intermediate viewport states before they reached Bubble Tea. Caching only stable chrome removes that model-level quantization while preserving the allocation improvement.

PTY tracing then exposed a second boundary: Bubble Tea's default 60 FPS renderer replaces buffered views between ticks. At an 8 ms packet cadence, master and the live-viewport branch both coalesced most intermediate offsets before terminal output. Raising the renderer ceiling to 120 FPS exposes more offsets without changing wheel scaling or the cursor-render debounce. Bursts faster than the 8.33 ms renderer interval can still coalesce.

## Benchmark

The benchmark runs the same raw `Update → View` workload on upstream/master and this branch using a 10,000-line wrapped diff with 1,000 annotations. Values are medians of five Apple M4 / Go 1.26.5 runs.

| Packets | upstream/master | This branch | Allocations |
|---:|---:|---:|---:|
| 1 | 0.52 ms, 648 allocs | 0.52 ms, 648 allocs | parity |
| 4 | 2.07 ms, 2,578 allocs | 1.94 ms, 1,822 allocs | 29.3% fewer |
| 16 | 8.41 ms, 10,292 allocs | 7.57 ms, 6,510 allocs | 36.7% fewer |

This measures model work, not terminal-visible frame count.

Raw PTY replay used a 541-line Markdown fixture with a TOC and 20 SGR wheel packets. A flush is counted from `CSI H` in the PTY byte stream, before any terminal emulator or multiplexer repaint behavior.

| Packet cadence | Zone | 60 FPS | 120 FPS |
|---:|---|---:|---:|
| 8 ms | content | 5–7 flushes | 10–11 flushes |
| 8 ms | TOC | 9 flushes | 16 flushes |
| 16 ms | content | 13 flushes | 17 flushes |
| 30 ms | content | 17–19 flushes | 20 flushes |

Flush count is an observed renderer-output metric, not an exact count of distinct model states.

## Verification

- `MISE_GO_VERSION=1.26.5 MISE_BUN_VERSION=1.3.13 mise exec go@1.26.5 -- go test -race ./...`
- `MISE_GO_VERSION=1.26.5 mise exec golangci-lint@2.11.4 -- golangci-lint run`
- focused live-viewport and cache-equivalence regression tests
- raw PTY SGR replay at 8, 16, and 30 ms cadences over content and TOC zones
- `git diff --check`

There are no CLI, config, or public API changes.
