### PR TITLE
fix(launcher): hand review to a live tmux session when called headless

### DIFF
--- a/.claude-plugin/skills/revdiff/SKILL.md
+++ b/.claude-plugin/skills/revdiff/SKILL.md
@@ -146,6 +146,8 @@ The resolver and launcher MUST run in the same bash invocation — the resolver 
 
 **Disconnect-resilient tmux window mode**: when running under tmux, prefix the launcher with `REVDIFF_TMUX_WINDOW=1` to open revdiff in a persistent, server-owned tmux window instead of a client-owned `display-popup`. The review then survives a dropped SSH or tmux client — reattach and it is still there. This is a launcher environment variable, not a revdiff flag.
 
+**Headless review handoff**: from a background session with no terminal of its own (no `$TMUX`), the launcher probes the default tmux server and, if a client is attached, opens the review as a server-owned window in that client's session instead of failing — no action needed. When the probe cannot pick the right session (multiple sessions, or none attached), prefix the launcher with `REVDIFF_TMUX_TARGET=<session>` to target one explicitly; it forces window mode and skips the probe. This is a launcher environment variable, not a revdiff flag.
+
 The script:
 - Detects available terminal (tmux → Zellij → herdr → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm)
 - Launches revdiff in an overlay

--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -75,6 +75,8 @@ When launched via the Claude Code plugin skill, revdiff opens in a terminal over
 
 Set `REVDIFF_TMUX_WINDOW=1` in the launcher's environment to open revdiff in a persistent, server-owned tmux window instead of a client-owned `display-popup`. A dropped SSH or tmux client tears down a popup and kills the review, but a server-owned window survives the disconnect — reattach and the live review is still there. This is a launcher environment variable, not a revdiff flag.
 
+When the launcher runs from a background session with no terminal of its own (no `$TMUX` in the environment), it probes the default tmux server and, if a client is attached, opens the review as a server-owned window in that client's session instead of failing. Set `REVDIFF_TMUX_TARGET=<session>` to send the review to a specific tmux session explicitly (this also forces window mode and skips the probe). Both are launcher environment variables, not revdiff flags.
+
 ## Themes
 
 Eight bundled themes: **basic**, **catppuccin-latte**, **catppuccin-mocha**, **dracula**, **gruvbox**, **nord**, **revdiff**, **solarized-dark**. Stored in `~/.config/revdiff/themes/`, auto-created on first run.

--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -328,3 +328,5 @@ Override the history directory with `--history-dir`, `REVDIFF_HISTORY_DIR` env v
 ## Disconnect-Resilient Window Mode (tmux)
 
 Set `REVDIFF_TMUX_WINDOW=1` in the launcher's environment to open revdiff in a persistent, server-owned tmux window instead of a client-owned `display-popup`. A dropped SSH or tmux client tears down a popup and kills the review, but a server-owned window survives the disconnect — reattach and the live review is still there. This is a launcher environment variable, not a revdiff flag.
+
+When the launcher runs from a background session with no terminal of its own (no `$TMUX` in the environment), it probes the default tmux server and, if a client is attached, opens the review as a server-owned window in that client's session instead of failing. Set `REVDIFF_TMUX_TARGET=<session>` to send the review to a specific tmux session explicitly (this also forces window mode and skips the probe). Both are launcher environment variables, not revdiff flags.

--- a/.claude-plugin/skills/revdiff/scripts/agentdeck-window.sh
+++ b/.claude-plugin/skills/revdiff/scripts/agentdeck-window.sh
@@ -18,23 +18,39 @@
 # never pops over whatever other session they are working in.
 #
 # Activation:
-#   REVDIFF_TMUX_WINDOW=1   force window mode, focused + restore prior window on exit (any tmux)
-#   REVDIFF_TMUX_WINDOW=0   force the popup path (skip this backend)
-#   unset                   auto: background window mode only when agent-deck is detected
+#   REVDIFF_TMUX_WINDOW=1      force window mode, focused + restore prior window on exit (any tmux)
+#   REVDIFF_TMUX_WINDOW=0      force the popup path (skip this backend)
+#   REVDIFF_TMUX_TARGET=NAME   force window mode + focus at session NAME, addressing it with an
+#                              explicit `-t` so nothing depends on tmux's client-less "current
+#                              session" resolution. This is how a headless caller hands the review
+#                              to a live client's session; also usable from inside tmux to target
+#                              another session.
+#   unset                      auto: background window mode only when agent-deck is detected
 #
-# Reuses from the caller (launch-revdiff.sh): TMPBASE, CWD, DIR_NAME, TITLE_REF and the helpers
-# sq() / write_rc_cmd() / read_rc() / print_output_and_exit(). The caller guarantees $TMUX is
-# set and tmux is on PATH before sourcing this. This file is SOURCED, so it must not install an
-# EXIT trap (that would clobber the caller's cleanup trap); it cleans up explicitly instead and
-# either returns (window mode off → caller falls through to the popup) or exits the process.
+# Reuses from the caller (launch-revdiff.sh): TMPBASE, CWD, DIR_NAME, TITLE_REF, an optional
+# _rd_target, and the helpers sq() / write_rc_cmd() / read_rc() / print_output_and_exit(). The caller
+# guarantees tmux is on PATH and that bare `tmux` reaches the intended server (via $TMUX when inside
+# tmux, or the default socket when a headless caller probed it). This file is SOURCED, so it must not
+# install an EXIT trap (that would clobber the caller's cleanup trap); it cleans up explicitly instead
+# and either returns (window mode off → caller falls through to the popup) or exits the process.
 
-# _rd_focus marks the first-class interactive opt-in: set only when the user explicitly forces
-# window mode with REVDIFF_TMUX_WINDOW=1. Capture it BEFORE the auto-detection below folds user-opt
-# and agent-deck detection into the same _rd_winmode=1 — the focus + restore behavior is opt-in only.
+# explicit target session for the review window (and its prior-window restore). Comes from
+# REVDIFF_TMUX_TARGET or from an _rd_target the caller already resolved (headless server probe).
+# A non-empty target implies window mode + focus: the caller has decided which session hosts the
+# review, so nothing falls back to tmux's client-less "current session" resolution.
+_rd_target="${REVDIFF_TMUX_TARGET:-${_rd_target:-}}"
+
+# _rd_focus marks the first-class interactive opt-in: set when the user forces window mode with
+# REVDIFF_TMUX_WINDOW=1 or when an explicit target session is given. Capture it BEFORE the
+# auto-detection below folds user-opt and agent-deck detection into the same _rd_winmode=1 — the
+# focus + restore behavior is opt-in only (agent-deck auto-detection stays background).
 _rd_focus=0
 [ "${REVDIFF_TMUX_WINDOW:-}" = 1 ] && _rd_focus=1
+[ -n "$_rd_target" ] && _rd_focus=1
 
+# an explicit target forces window mode; otherwise honor REVDIFF_TMUX_WINDOW, else auto-detect.
 _rd_winmode="${REVDIFF_TMUX_WINDOW:-}"
+[ -n "$_rd_target" ] && _rd_winmode=1
 if [ -z "$_rd_winmode" ]; then
     # agent-deck markers: its env var (also mirrored into the tmux session env), with the
     # agentdeck_* session-name prefix as a fallback signal.
@@ -65,7 +81,11 @@ rm -f "$_rd_sentinel"
 # first-class interactive mode: remember the active window so it can be restored after the review.
 _rd_prevwin=""
 if [ "$_rd_focus" = 1 ]; then
-    _rd_prevwin=$(tmux display-message -p '#{window_id}' 2>/dev/null || true)
+    if [ -n "$_rd_target" ]; then
+        _rd_prevwin=$(tmux display-message -t "$_rd_target" -p '#{window_id}' 2>/dev/null || true)
+    else
+        _rd_prevwin=$(tmux display-message -p '#{window_id}' 2>/dev/null || true)
+    fi
 fi
 
 # Open the review in a background window (-d: don't steal the active window; -c: start dir).
@@ -73,8 +93,12 @@ fi
 # invocation (every backend runs the command through sh, and REVDIFF_CMD is built sh-compatible).
 # If tmux can't create the window, fail loudly instead of busy-waiting on a sentinel that will
 # never appear.
-if ! _rd_winid=$(tmux new-window -d -P -F '#{window_id}' -c "$CWD" -n "$_rd_winname" \
-        -- sh -c "$(write_rc_cmd "$_rd_sentinel")"); then
+# build the invocation; an explicit target lands the window in the chosen session. The arg array is
+# always non-empty, so "${_rd_neww[@]}" is safe to expand under set -u (bash 3.2 compatible).
+_rd_neww=(new-window -d -P -F '#{window_id}')
+[ -n "$_rd_target" ] && _rd_neww+=(-t "$_rd_target")
+_rd_neww+=(-c "$CWD" -n "$_rd_winname" -- sh -c "$(write_rc_cmd "$_rd_sentinel")")
+if ! _rd_winid=$(tmux "${_rd_neww[@]}"); then
     rm -f "$_rd_sentinel" "$_rd_sentinel".tmp
     echo "revdiff: failed to open tmux review window" >&2
     exit 1
@@ -90,7 +114,9 @@ fi
 # wait on the window still existing rather than a timer: a real review may take a long time, but
 # if the window disappears without a sentinel (killed / tmux died) we stop instead of hanging.
 while [ ! -f "$_rd_sentinel" ]; do
-    tmux list-windows -F '#{window_id}' 2>/dev/null | grep -qxF "$_rd_winid" || break
+    # -a lists windows across every session so the watch finds the review window whichever session
+    # hosts it (window ids are server-global), including an explicit -t target session.
+    tmux list-windows -a -F '#{window_id}' 2>/dev/null | grep -qxF "$_rd_winid" || break
     sleep 0.3
 done
 

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -167,6 +167,38 @@ if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     print_output_and_exit "$rc"
 fi
 
+# headless / background caller: no $TMUX in the environment but a reachable tmux server with an
+# attached client. A background agent session (no controlling terminal) cannot render a TUI itself,
+# so hand the review to the user's live terminal: run revdiff in a server-owned tmux *window*
+# (survives a client disconnect, unlike a display-popup) addressed with an explicit -t at the
+# attached client's session. Probes the DEFAULT tmux server via bare `tmux`; REVDIFF_TMUX_TARGET=<session>
+# forces this path at an explicit session and skips the probe. Falls through untouched when there is
+# no tmux, no server, or no attached client — the later backends and the final error still apply.
+if [ -z "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+    _rd_target="${REVDIFF_TMUX_TARGET:-}"
+    if [ -z "$_rd_target" ] && tmux ls >/dev/null 2>&1; then
+        # pick the session of the most-recently-active attached client, so the review lands where
+        # the user is actually looking rather than tmux's ambiguous client-less "current session".
+        _rd_target=$(tmux list-clients -F '#{client_activity} #{client_session}' 2>/dev/null \
+            | sort -rn | head -1 | cut -d' ' -f2- || true)
+    fi
+    if [ -n "$_rd_target" ]; then
+        # shellcheck disable=SC2034  # consumed by the sourced agentdeck-window.sh below
+        REVDIFF_TMUX_WINDOW=1
+        _RD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+        # shellcheck source=/dev/null  # sibling backend resolved at runtime; not followed at lint time
+        # shellcheck disable=SC1091
+        if [ -f "$_RD_SCRIPT_DIR/agentdeck-window.sh" ]; then
+            . "$_RD_SCRIPT_DIR/agentdeck-window.sh"
+        fi
+        # agentdeck-window.sh exits the process on success (window opened, review ran). Reaching here
+        # means the window could not be opened — surface a targeted error instead of falling through
+        # to the generic "no overlay terminal available" message, which would misdescribe the failure.
+        echo "error: tmux session '$_rd_target' reachable but revdiff review window could not be opened" >&2
+        exit 1
+    fi
+fi
+
 # zellij: floating pane with sentinel file for blocking
 if [ -n "${ZELLIJ:-}" ] && command -v zellij >/dev/null 2>&1; then
     SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Priority: agterm → tmux → Zellij → herdr → kitty → wezterm/Kaku → cm
 
 > **Disconnect-resilient tmux window mode:** set `REVDIFF_TMUX_WINDOW=1` in the launcher's environment to open revdiff in a persistent, server-owned tmux window instead of a client-owned `display-popup`. A dropped SSH or tmux client tears down a popup and kills the review, but a server-owned window survives the disconnect — reattach and the live review is still there. This is a launcher environment variable, not a revdiff flag.
 
+> **Headless review handoff:** when the launcher runs from a background session with no terminal of its own (no `$TMUX` in the environment), it probes the default tmux server and, if a client is attached, opens the review as a server-owned window in that client's session instead of failing. Set `REVDIFF_TMUX_TARGET=<session>` to send the review to a specific tmux session explicitly (this also forces window mode and skips the probe). Both are launcher environment variables, not revdiff flags.
+
 **Install:**
 
 ```bash

--- a/plugins/codex/skills/revdiff/SKILL.md
+++ b/plugins/codex/skills/revdiff/SKILL.md
@@ -158,6 +158,8 @@ $SCRIPT_DIR/launch-revdiff.sh [base] [against] [--staged] [--untracked] [--only=
 
 **Disconnect-resilient tmux window mode**: when running under tmux, prefix the launcher with `REVDIFF_TMUX_WINDOW=1` to open revdiff in a persistent, server-owned tmux window instead of a client-owned `display-popup`. The review then survives a dropped SSH or tmux client — reattach and it is still there. This is a launcher environment variable, not a revdiff flag.
 
+**Headless review handoff**: from a background session with no terminal of its own (no `$TMUX`), the launcher probes the default tmux server and, if a client is attached, opens the review as a server-owned window in that client's session instead of failing — no action needed. When the probe cannot pick the right session (multiple sessions, or none attached), prefix the launcher with `REVDIFF_TMUX_TARGET=<session>` to target one explicitly; it forces window mode and skips the probe. This is a launcher environment variable, not a revdiff flag.
+
 The script:
 - Detects available terminal (agterm → tmux → Zellij → herdr → kitty → wezterm/Kaku → cmux → ghostty → iTerm2 → Emacs vterm)
 - Launches revdiff in an overlay

--- a/plugins/codex/skills/revdiff/scripts/agentdeck-window.sh
+++ b/plugins/codex/skills/revdiff/scripts/agentdeck-window.sh
@@ -18,23 +18,39 @@
 # never pops over whatever other session they are working in.
 #
 # Activation:
-#   REVDIFF_TMUX_WINDOW=1   force window mode, focused + restore prior window on exit (any tmux)
-#   REVDIFF_TMUX_WINDOW=0   force the popup path (skip this backend)
-#   unset                   auto: background window mode only when agent-deck is detected
+#   REVDIFF_TMUX_WINDOW=1      force window mode, focused + restore prior window on exit (any tmux)
+#   REVDIFF_TMUX_WINDOW=0      force the popup path (skip this backend)
+#   REVDIFF_TMUX_TARGET=NAME   force window mode + focus at session NAME, addressing it with an
+#                              explicit `-t` so nothing depends on tmux's client-less "current
+#                              session" resolution. This is how a headless caller hands the review
+#                              to a live client's session; also usable from inside tmux to target
+#                              another session.
+#   unset                      auto: background window mode only when agent-deck is detected
 #
-# Reuses from the caller (launch-revdiff.sh): TMPBASE, CWD, DIR_NAME, TITLE_REF and the helpers
-# sq() / write_rc_cmd() / read_rc() / print_output_and_exit(). The caller guarantees $TMUX is
-# set and tmux is on PATH before sourcing this. This file is SOURCED, so it must not install an
-# EXIT trap (that would clobber the caller's cleanup trap); it cleans up explicitly instead and
-# either returns (window mode off → caller falls through to the popup) or exits the process.
+# Reuses from the caller (launch-revdiff.sh): TMPBASE, CWD, DIR_NAME, TITLE_REF, an optional
+# _rd_target, and the helpers sq() / write_rc_cmd() / read_rc() / print_output_and_exit(). The caller
+# guarantees tmux is on PATH and that bare `tmux` reaches the intended server (via $TMUX when inside
+# tmux, or the default socket when a headless caller probed it). This file is SOURCED, so it must not
+# install an EXIT trap (that would clobber the caller's cleanup trap); it cleans up explicitly instead
+# and either returns (window mode off → caller falls through to the popup) or exits the process.
 
-# _rd_focus marks the first-class interactive opt-in: set only when the user explicitly forces
-# window mode with REVDIFF_TMUX_WINDOW=1. Capture it BEFORE the auto-detection below folds user-opt
-# and agent-deck detection into the same _rd_winmode=1 — the focus + restore behavior is opt-in only.
+# explicit target session for the review window (and its prior-window restore). Comes from
+# REVDIFF_TMUX_TARGET or from an _rd_target the caller already resolved (headless server probe).
+# A non-empty target implies window mode + focus: the caller has decided which session hosts the
+# review, so nothing falls back to tmux's client-less "current session" resolution.
+_rd_target="${REVDIFF_TMUX_TARGET:-${_rd_target:-}}"
+
+# _rd_focus marks the first-class interactive opt-in: set when the user forces window mode with
+# REVDIFF_TMUX_WINDOW=1 or when an explicit target session is given. Capture it BEFORE the
+# auto-detection below folds user-opt and agent-deck detection into the same _rd_winmode=1 — the
+# focus + restore behavior is opt-in only (agent-deck auto-detection stays background).
 _rd_focus=0
 [ "${REVDIFF_TMUX_WINDOW:-}" = 1 ] && _rd_focus=1
+[ -n "$_rd_target" ] && _rd_focus=1
 
+# an explicit target forces window mode; otherwise honor REVDIFF_TMUX_WINDOW, else auto-detect.
 _rd_winmode="${REVDIFF_TMUX_WINDOW:-}"
+[ -n "$_rd_target" ] && _rd_winmode=1
 if [ -z "$_rd_winmode" ]; then
     # agent-deck markers: its env var (also mirrored into the tmux session env), with the
     # agentdeck_* session-name prefix as a fallback signal.
@@ -65,7 +81,11 @@ rm -f "$_rd_sentinel"
 # first-class interactive mode: remember the active window so it can be restored after the review.
 _rd_prevwin=""
 if [ "$_rd_focus" = 1 ]; then
-    _rd_prevwin=$(tmux display-message -p '#{window_id}' 2>/dev/null || true)
+    if [ -n "$_rd_target" ]; then
+        _rd_prevwin=$(tmux display-message -t "$_rd_target" -p '#{window_id}' 2>/dev/null || true)
+    else
+        _rd_prevwin=$(tmux display-message -p '#{window_id}' 2>/dev/null || true)
+    fi
 fi
 
 # Open the review in a background window (-d: don't steal the active window; -c: start dir).
@@ -73,8 +93,12 @@ fi
 # invocation (every backend runs the command through sh, and REVDIFF_CMD is built sh-compatible).
 # If tmux can't create the window, fail loudly instead of busy-waiting on a sentinel that will
 # never appear.
-if ! _rd_winid=$(tmux new-window -d -P -F '#{window_id}' -c "$CWD" -n "$_rd_winname" \
-        -- sh -c "$(write_rc_cmd "$_rd_sentinel")"); then
+# build the invocation; an explicit target lands the window in the chosen session. The arg array is
+# always non-empty, so "${_rd_neww[@]}" is safe to expand under set -u (bash 3.2 compatible).
+_rd_neww=(new-window -d -P -F '#{window_id}')
+[ -n "$_rd_target" ] && _rd_neww+=(-t "$_rd_target")
+_rd_neww+=(-c "$CWD" -n "$_rd_winname" -- sh -c "$(write_rc_cmd "$_rd_sentinel")")
+if ! _rd_winid=$(tmux "${_rd_neww[@]}"); then
     rm -f "$_rd_sentinel" "$_rd_sentinel".tmp
     echo "revdiff: failed to open tmux review window" >&2
     exit 1
@@ -90,7 +114,9 @@ fi
 # wait on the window still existing rather than a timer: a real review may take a long time, but
 # if the window disappears without a sentinel (killed / tmux died) we stop instead of hanging.
 while [ ! -f "$_rd_sentinel" ]; do
-    tmux list-windows -F '#{window_id}' 2>/dev/null | grep -qxF "$_rd_winid" || break
+    # -a lists windows across every session so the watch finds the review window whichever session
+    # hosts it (window ids are server-global), including an explicit -t target session.
+    tmux list-windows -a -F '#{window_id}' 2>/dev/null | grep -qxF "$_rd_winid" || break
     sleep 0.3
 done
 

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -168,6 +168,38 @@ if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     print_output_and_exit "$rc"
 fi
 
+# headless / background caller: no $TMUX in the environment but a reachable tmux server with an
+# attached client. A background agent session (no controlling terminal) cannot render a TUI itself,
+# so hand the review to the user's live terminal: run revdiff in a server-owned tmux *window*
+# (survives a client disconnect, unlike a display-popup) addressed with an explicit -t at the
+# attached client's session. Probes the DEFAULT tmux server via bare `tmux`; REVDIFF_TMUX_TARGET=<session>
+# forces this path at an explicit session and skips the probe. Falls through untouched when there is
+# no tmux, no server, or no attached client — the later backends and the final error still apply.
+if [ -z "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+    _rd_target="${REVDIFF_TMUX_TARGET:-}"
+    if [ -z "$_rd_target" ] && tmux ls >/dev/null 2>&1; then
+        # pick the session of the most-recently-active attached client, so the review lands where
+        # the user is actually looking rather than tmux's ambiguous client-less "current session".
+        _rd_target=$(tmux list-clients -F '#{client_activity} #{client_session}' 2>/dev/null \
+            | sort -rn | head -1 | cut -d' ' -f2- || true)
+    fi
+    if [ -n "$_rd_target" ]; then
+        # shellcheck disable=SC2034  # consumed by the sourced agentdeck-window.sh below
+        REVDIFF_TMUX_WINDOW=1
+        _RD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+        # shellcheck source=/dev/null  # sibling backend resolved at runtime; not followed at lint time
+        # shellcheck disable=SC1091
+        if [ -f "$_RD_SCRIPT_DIR/agentdeck-window.sh" ]; then
+            . "$_RD_SCRIPT_DIR/agentdeck-window.sh"
+        fi
+        # agentdeck-window.sh exits the process on success (window opened, review ran). Reaching here
+        # means the window could not be opened — surface a targeted error instead of falling through
+        # to the generic "no overlay terminal available" message, which would misdescribe the failure.
+        echo "error: tmux session '$_rd_target' reachable but revdiff review window could not be opened" >&2
+        exit 1
+    fi
+fi
+
 # zellij: floating pane with sentinel file for blocking
 if [ -n "${ZELLIJ:-}" ] && command -v zellij >/dev/null 2>&1; then
     SENTINEL=$(mktemp "$TMPBASE/revdiff-done-XXXXXX")

--- a/site/docs.html
+++ b/site/docs.html
@@ -706,6 +706,7 @@ map alt+t&gt;n theme_select</code></div>
         <div class="code-block"><code>{ "permissions": { "excludedCommands": ["*/launch-revdiff.sh*"] } }</code></div>
         <p>Terminals that use CLI tools instead of AppleScript (agterm, tmux, Zellij, herdr, kitty, wezterm, Kaku, cmux) are not affected.</p>
         <p><strong>Disconnect-resilient tmux window mode:</strong> set <code>REVDIFF_TMUX_WINDOW=1</code> in the launcher's environment to open revdiff in a persistent, server-owned tmux window instead of a client-owned <code>display-popup</code>. A dropped SSH or tmux client tears down a popup and kills the review, but a server-owned window survives the disconnect &mdash; reattach and the live review is still there. This is a launcher environment variable, not a revdiff flag.</p>
+        <p><strong>Headless review handoff:</strong> when the launcher runs from a background session with no terminal of its own (no <code>$TMUX</code> in the environment), it probes the default tmux server and, if a client is attached, opens the review as a server-owned window in that client's session instead of failing. Set <code>REVDIFF_TMUX_TARGET=&lt;session&gt;</code> to send the review to a specific tmux session explicitly (this also forces window mode and skips the probe). Both are launcher environment variables, not revdiff flags.</p>
 
         <h2 id="plugin-usage">Plugin usage</h2>
         <h3>Slash commands</h3>


### PR DESCRIPTION
> **Draft — still in local testing.** The logic is covered by an isolated automated test suite (details below), but I have not yet run it through a real headless agent handoff on my own machine. I will take it out of draft once that manual QA passes. Review welcome in the meantime.

## Problem

A background or headless agent session (no controlling terminal, and none of the client environment variables like `$TMUX`, `$ZELLIJ`, `$KITTY_LISTEN_ON`) cannot launch a revdiff review. Every overlay backend in `launch-revdiff.sh` gates on a client-inherited environment variable, so a session with no terminal ancestry always falls through to:

```
error: no overlay terminal available (requires agterm, tmux, zellij, ...)
```

This happens even when a tmux server is running on the default socket with an attached, focused client that could have hosted the review. Background/headless agent sessions are exactly the case where the agent cannot render a TUI itself and most needs to hand the review to the user's live terminal.

**Repro:** from any shell with `$TMUX` unset but a running, attached tmux server, run the launcher with a valid ref. Before this change: exit 1, "no overlay terminal available".

## Fix

When `$TMUX` is unset but `tmux` is on `PATH`, the launcher now probes the default server. If a client is attached, it opens the review in a **server-owned tmux window** (which survives a client disconnect, unlike a `display-popup`) addressed with an explicit `-t` at the most-recently-active attached client's session — so nothing depends on tmux's ambiguous client-less "current session" resolution.

- `REVDIFF_TMUX_TARGET=<session>` forces this path at an explicit session and skips the probe. It also works from inside tmux to target another session.
- The path falls through untouched when there is no tmux, no server, or no attached client — the later backends and the original final error still apply.
- The window backend (`agentdeck-window.sh`) now threads the explicit target through the prior-window capture, `new-window`, the watch loop (`list-windows -a`), and the prior-window restore. With no target it is byte-for-byte the previous behavior (agent-deck auto-detection and a bare `REVDIFF_TMUX_WINDOW=1` are unchanged).

Both are launcher environment variables, not revdiff flags.

## Scope

- `launch-revdiff.sh` + `agentdeck-window.sh` (Claude plugin), with the Codex plugin copies kept in sync.
- Docs: `README.md`, `site/docs.html`, `SKILL.md` (both plugins), and the `config.md` / `usage.md` references document the fallback and the new `REVDIFF_TMUX_TARGET` variable.

## Testing

- `shellcheck -x` clean on all four scripts; parses under bash 3.2 (macOS system bash) and bash 5.
- An isolated automated suite (a `tmux -L rdqa` sandbox server, a stub `revdiff` that reports which session hosted its window, run 3×) covers: no server → falls through; server but no attached client → falls through; attached client → auto-probe lands the review in that session; `REVDIFF_TMUX_TARGET` overrides the probe; the window closes on exit; and focus/restore returns the prior active window. 7/7 green, stable across runs.

Still to do before undrafting: a real headless-agent → live-terminal handoff on my machine.
