### PR TITLE
docs(skills): drop redundant pre-flight tool checks

### DIFF
--- a/.claude-plugin/skills/revdiff/SKILL.md
+++ b/.claude-plugin/skills/revdiff/SKILL.md
@@ -74,16 +74,6 @@ cat /tmp/feature.patch | "$("${CLAUDE_SKILL_DIR}/scripts/resolve-launcher.sh" la
 
 ## Workflow
 
-### Step 0: Verify Installation
-
-```bash
-which revdiff
-```
-
-If not found, guide installation:
-- `brew install umputun/apps/revdiff`
-- Binary releases: https://github.com/umputun/revdiff/releases
-
 ### Step 1: Determine Review Mode
 
 **All-files mode**: If `$ARGUMENTS` matches "all files", "all-files", or "browse all files" (with optional "exclude <prefix>" parts), use **all-files mode**:

--- a/plugins/codex/skills/revdiff-plan/SKILL.md
+++ b/plugins/codex/skills/revdiff-plan/SKILL.md
@@ -49,23 +49,6 @@ Use `$SCRIPT_DIR` and `$LAUNCHER_DIR` in place of script paths throughout this s
 
 ## Workflow
 
-### Step 0: Verify Installation
-
-```bash
-which revdiff
-```
-
-If not found, guide installation:
-- `brew install umputun/apps/revdiff`
-- Binary releases: https://github.com/umputun/revdiff/releases
-
-Also verify jq is installed (required for rollout extraction):
-```bash
-which jq
-```
-
-If not found: `brew install jq`
-
 ### Step 1: Extract Last Assistant Message
 
 Run the extraction script with `--skip-current` to avoid picking up this session's own output:

--- a/plugins/codex/skills/revdiff/SKILL.md
+++ b/plugins/codex/skills/revdiff/SKILL.md
@@ -89,16 +89,6 @@ cat /tmp/feature.patch | $SCRIPT_DIR/launch-revdiff.sh --stdin
 
 ## Workflow
 
-### Step 0: Verify Installation
-
-```bash
-which revdiff
-```
-
-If not found, guide installation:
-- `brew install umputun/apps/revdiff`
-- Binary releases: https://github.com/umputun/revdiff/releases
-
 ### Step 1: Determine Review Mode
 
 **All-files mode**: If `$ARGUMENTS` matches "all files", "all-files", or "browse all files" (with optional "exclude <prefix>" parts), use **all-files mode**:


### PR DESCRIPTION
Split out of #263 so it can land independently of the tmux backend work.

Every skill started its workflow with a pre-flight probe:

```bash
which revdiff
```

and `revdiff-plan` added a second one for `jq`.

Both cost an agent turn on every single review, to confirm something that already reports its own absence:

- the launcher resolves the `revdiff` binary inline and fails with a clear error if it is missing;
- `extract-last-message.sh` already checks `jq` itself and prints `install: brew install jq (or see https://jqlang.github.io/jq/download/)`.

So the probes pay a recurring per-run cost to pre-empt a one-time error message that is at least as clear as the probe's own guidance. Letting the failing command say what is missing is cheaper and fires exactly when the tool is actually needed.

Removed from:

- `.claude-plugin/skills/revdiff/SKILL.md`
- `plugins/codex/skills/revdiff/SKILL.md`
- `plugins/codex/skills/revdiff-plan/SKILL.md` (both the `revdiff` and `jq` checks; the surrounding steps keep their numbering)

Docs only — pure deletion, no script or Go changes.
