### PR TITLE
feat: add opt-in pprof server

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -59,6 +59,7 @@ Then uncomment and edit the values you want to change.
 | `--dump-keys` | | Print effective keybindings to stdout and exit | |
 | `--config` | `REVDIFF_CONFIG` | Path to config file | `~/.config/revdiff/config` |
 | `--dump-config` | | Print default config to stdout and exit | |
+| `--pprof` | | Start a pprof http server for CPU/heap profiling at ADDR; bare `--pprof` binds `:6060`, use `--pprof=ADDR` for a custom address | |
 
 Config-backed options use long flag names without leading `--`; for annotation exit status use `exit-code-on-annotations = true`.
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Positional arguments support several forms:
 | `--dump-keys` | Print effective keybindings to stdout and exit | |
 | `--dump-config` | Print default config to stdout and exit | |
 | `-V`, `--version` | Show version info | |
+| `--pprof` | Start a pprof http server for CPU/heap profiling at ADDR; bare `--pprof` binds `:6060`, use `--pprof=ADDR` for a custom address | |
 
 ### Config File
 

--- a/app/config.go
+++ b/app/config.go
@@ -66,6 +66,7 @@ type options struct {
 	Config                string   `long:"config" env:"REVDIFF_CONFIG" no-ini:"true" description:"path to config file"`
 	DumpConfig            bool     `long:"dump-config" no-ini:"true" description:"print default config to stdout and exit"`
 	Version               bool     `short:"V" long:"version" no-ini:"true" description:"show version info"`
+	Pprof                 string   `long:"pprof" no-ini:"true" optional:"true" optional-value:":6060" description:"start a pprof http server for CPU/heap profiling at ADDR; bare --pprof binds :6060, use --pprof=ADDR for a custom address"`
 
 	Colors struct {
 		Accent       string `long:"color-accent"      ini-name:"color-accent"      env:"REVDIFF_COLOR_ACCENT"      default:"#D5895F" description:"active pane borders and directory names"`

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -872,6 +872,25 @@ func TestDefaultConfigPath(t *testing.T) {
 	assert.Contains(t, path, "config")
 }
 
+func TestParseArgs_PprofDefaultDisabled(t *testing.T) {
+	opts, err := parseArgs(noConfigArgs(t))
+	require.NoError(t, err)
+	assert.Empty(t, opts.Pprof)
+}
+
+func TestParseArgs_PprofBareUsesDefaultAddr(t *testing.T) {
+	opts, err := parseArgs(append(noConfigArgs(t), "--pprof", "HEAD~3"))
+	require.NoError(t, err)
+	assert.Equal(t, ":6060", opts.Pprof)
+	assert.Equal(t, "HEAD~3", opts.Refs.Base, "bare --pprof must not consume the next positional arg")
+}
+
+func TestParseArgs_PprofCustomAddr(t *testing.T) {
+	opts, err := parseArgs(append(noConfigArgs(t), "--pprof=:7070"))
+	require.NoError(t, err)
+	assert.Equal(t, ":7070", opts.Pprof)
+}
+
 func TestParseArgs_AllFilesFlag(t *testing.T) {
 	opts, err := parseArgs(append(noConfigArgs(t), "--all-files"))
 	require.NoError(t, err)

--- a/app/main.go
+++ b/app/main.go
@@ -95,6 +95,8 @@ func main() {
 }
 
 func run(opts options) (int, error) {
+	startPprof(opts.Pprof)
+
 	// force lipgloss to truecolor when colors are enabled. revdiff's raw-ANSI
 	// helpers (style.ansiColor) always emit truecolor, but lipgloss respects
 	// the termenv-detected profile, which can downgrade to ANSI256 / ANSI in

--- a/app/pprof.go
+++ b/app/pprof.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	_ "net/http/pprof" //nolint:gosec // intentional: --pprof opts in to this debug endpoint, and it stays off unless the flag is set
+	"time"
+)
+
+// startPprof launches a debug-only pprof http server in the background when
+// addr is non-empty. It never blocks or fails run() — a bind error (e.g. the
+// port is already taken) is logged and profiling is simply unavailable for
+// that session, which isn't worth aborting a review over.
+func startPprof(addr string) {
+	if addr == "" {
+		return
+	}
+	srv := &http.Server{Addr: addr, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("[WARN] pprof server on %s: %v", addr, err)
+		}
+	}()
+}

--- a/app/pprof_test.go
+++ b/app/pprof_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartPprof_EmptyAddrIsNoop(t *testing.T) {
+	t.Log("startPprof with an empty addr must not panic or bind a listener")
+	startPprof("")
+}
+
+func TestStartPprof_ServesDebugEndpoint(t *testing.T) {
+	// port 0 lets the OS pick a free port, but startPprof only accepts a fixed
+	// addr string, so bind to loopback on an OS-assigned port ourselves first
+	// to get a free one, then hand that exact addr to startPprof.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	startPprof(addr)
+
+	var status int
+	require.Eventually(t, func() bool {
+		resp, getErr := http.Get("http://" + addr + "/debug/pprof/")
+		if getErr != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		status = resp.StatusCode
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, http.StatusOK, status)
+}

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -58,6 +58,7 @@ Then uncomment and edit the values you want to change.
 | `--dump-keys` | | Print effective keybindings to stdout and exit | |
 | `--config` | `REVDIFF_CONFIG` | Path to config file | `~/.config/revdiff/config` |
 | `--dump-config` | | Print default config to stdout and exit | |
+| `--pprof` | | Start a pprof http server for CPU/heap profiling at ADDR; bare `--pprof` binds `:6060`, use `--pprof=ADDR` for a custom address | |
 
 Config-backed options use long flag names without leading `--`; for annotation exit status use `exit-code-on-annotations = true`.
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -441,6 +441,7 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>--config</code></td><td>Path to config file</td><td><code>~/.config/revdiff/config</code></td></tr>
                 <tr><td><code>--dump-config</code></td><td>Print default config and exit</td><td></td></tr>
                 <tr><td><code>-V, --version</code></td><td>Show version info</td><td></td></tr>
+                <tr><td><code>--pprof</code></td><td>Start a pprof http server for CPU/heap profiling; bare form binds <code>:6060</code>, use <code>--pprof=ADDR</code> for a custom address</td><td></td></tr>
             </tbody>
         </table>
 


### PR DESCRIPTION
## Summary

- add an opt-in `--pprof` debug server for CPU and heap profiling
- use `:6060` for bare `--pprof` and require `--pprof=ADDR` for custom addresses
- keep bind failures non-fatal and document the new flag

## Testing

- `go test ./... -count=1`
- `golangci-lint run`

Closes #296