### PR TITLE
feat: edit the review description from the info popup

### DIFF
--- a/.claude-plugin/skills/revdiff/references/usage.md
+++ b/.claude-plugin/skills/revdiff/references/usage.md
@@ -85,6 +85,8 @@ revdiff HEAD~3 --description-file=/tmp/review-notes.md
 
 `--description` and `--description-file` are mutually exclusive. Both are optional — omit when there's no useful context to add.
 
+The reviewer can edit the description: pressing `e` while the info popup is open opens `$EDITOR` seeded with the description text, emitted as a `## (description) (file-level)` block (see Output Format). The edit replaces the prose shown in the popup, so the corrected assumption supersedes the original rather than sitting beside it. This is how a reviewer corrects a wrong assumption in the context you supplied.
+
 ## Two-File Diff
 
 Use `--compare-old=<path>` together with `--compare-new=<path>` to diff two arbitrary files on disk using `git diff --no-index`. No VCS repo needed — works anywhere `git` is installed.
@@ -182,6 +184,7 @@ Press `Space` to mark the focused file reviewed. Press `F` to toggle the sidebar
 | `F` | Toggle filter: all files / unreviewed only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle info popup — review scope (mode, VCS, ref, filters, file/status counts, aggregate `+/-` stats) plus the commit log for the current ref range when applicable |
+| `e` (in info popup) | Edit the `--description` in `$EDITOR`; replaces the displayed prose, emitted as `## (description) (file-level)` |
 | `R` | Reload diff from VCS (warns if annotations exist) |
 | `q` | Quit, output annotations to stdout |
 | `Q` | Discard all annotations and quit (confirms if annotations exist) |
@@ -303,6 +306,8 @@ don't remove this validation
 ```
 
 Each annotation block: `## filename:line[-end] (type)` where type is `(+)` added, `(-)` removed, or `(file-level)`. The `-end` suffix is included when the annotation covers a line range.
+
+A `## (description) (file-level)` block is not a file path: it is the reviewer's annotation on the `--description` you supplied, added with `e` in the info popup. Treat it as a correction to the intent/context of the change, not a comment about a file named `(description)`.
 
 When annotation text contains the keyword "hunk" (case-insensitive, whole word), the output header automatically expands to include the full hunk line range (e.g., `handler.go:43-67 (+)` instead of `handler.go:43 (+)`). This gives AI consumers the range context without any extra steps.
 

--- a/README.md
+++ b/README.md
@@ -661,7 +661,9 @@ See ticket SEC-441 for context."
 revdiff HEAD~3 --description-file=.review-description.md
 ```
 
-`--description` and `--description-file` are mutually exclusive. The description section is hidden when neither is set, so the flag is purely additive — existing invocations are unchanged.
+`--description` and `--description-file` are mutually exclusive. The description section is hidden when neither is set.
+
+Press `e` while the info popup is open to edit the description in your editor, seeded on first edit with the description text. Your edit replaces the prose in the popup under a `description (edited)` header, so a corrected assumption is never shown next to the wrong one it replaced. The edit is emitted in the structured output as `## (description) (file-level)`; emptying the editor clears it and restores the supplied text.
 
 ### Markdown TOC Navigation
 
@@ -790,6 +792,7 @@ Press `Space` to mark the focused file reviewed. Press `F` to toggle the sidebar
 | `F` | Toggle filter: all files / unreviewed only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle info popup — review scope (mode, VCS, ref, filters, file/status counts, aggregate `+/-` stats) plus the commit log for the current ref range when applicable |
+| `e` (in info popup) | Edit the `--description` in `$EDITOR`; replaces the displayed prose, emitted as `## (description) (file-level)` |
 | `R` | Reload diff from VCS (warns if annotations exist) |
 | `q` | Quit, output annotations to stdout |
 | `Q` | Discard all annotations and quit (confirms if annotations exist) |

--- a/app/annotation/store.go
+++ b/app/annotation/store.go
@@ -9,6 +9,12 @@ import (
 	"github.com/umputun/revdiff/app/fsutil"
 )
 
+// DescriptionFile is the synthetic store key for a note on the review
+// description (the --description prose shown in the info popup). It is never a
+// real path, so it carries no diff to resolve against: consumers that match
+// store keys to files in the diff have to admit it explicitly.
+const DescriptionFile = "(description)"
+
 // Annotation represents a user comment on a specific diff line.
 type Annotation struct {
 	File    string // file path relative to repo root

--- a/app/annotations_load.go
+++ b/app/annotations_load.go
@@ -120,6 +120,14 @@ func (p *preloader) load(records []annotation.Annotation) error {
 		// usage on commit Author/Subject/Body.
 		a.Comment = diff.SanitizeCommitText(a.Comment)
 
+		// (description) is not a path, so the checks below find no diff for it
+		// and would drop it as an orphan, losing the description note whenever
+		// an -o snapshot is reloaded with --annotations.
+		if a.File == annotation.DescriptionFile {
+			p.store.Add(a)
+			continue
+		}
+
 		status, ok := known[a.File]
 		if !ok {
 			p.warnf("warning: --annotations: file %q not in diff, dropping annotation\n", a.File)

--- a/app/annotations_load_test.go
+++ b/app/annotations_load_test.go
@@ -375,6 +375,31 @@ func TestValidateStdinFlags_RejectsAnnotations(t *testing.T) {
 	assert.Contains(t, err.Error(), "--annotations")
 }
 
+func TestPreloadAnnotations_KeepsDescriptionNote(t *testing.T) {
+	body := "## " + annotation.DescriptionFile + " (file-level)\nthe endpoint is not idempotent\n\n" +
+		"## a.go:5 (+)\nline-add note\n"
+	path := writeTempAnnotations(t, body)
+
+	store := annotation.NewStore()
+	r := &mocks.RendererMock{
+		ChangedFilesFunc: func(string, bool) ([]diff.FileEntry, error) {
+			return []diff.FileEntry{{Path: "a.go", Status: diff.FileModified}}, nil
+		},
+		FileDiffFunc: func(req diff.FileDiffRequest) ([]diff.DiffLine, error) {
+			assert.Equal(t, "a.go", req.Path, "the synthetic description key must not reach FileDiff")
+			return []diff.DiffLine{{OldNum: 0, NewNum: 5, Content: "added", ChangeType: diff.ChangeAdd}}, nil
+		},
+	}
+	warn := &bytes.Buffer{}
+	require.NoError(t, preloadAnnotations(path, store, r, "", false, nil, nil, "", warn))
+
+	assert.Equal(t, 2, store.Count())
+	got := store.Get(annotation.DescriptionFile)
+	require.Len(t, got, 1)
+	assert.Equal(t, "the endpoint is not idempotent", got[0].Comment)
+	assert.Empty(t, warn.String(), "the description note is not an orphan")
+}
+
 func TestPreloadAnnotations_EmptyFile(t *testing.T) {
 	path := writeTempAnnotations(t, "")
 	store := annotation.NewStore()

--- a/app/ui/description_annotation_test.go
+++ b/app/ui/description_annotation_test.go
@@ -1,0 +1,153 @@
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/umputun/revdiff/app/annotation"
+	"github.com/umputun/revdiff/app/keymap"
+	"github.com/umputun/revdiff/app/ui/mocks"
+	"github.com/umputun/revdiff/app/ui/overlay"
+)
+
+// descriptionAnnotationModel builds a model whose info popup carries a description,
+// with the given editor wired in. Used to exercise the issue #281 flow.
+func descriptionAnnotationModel(t *testing.T, editor ExternalEditor, note string) Model {
+	t.Helper()
+	store := annotation.NewStore()
+	if note != "" {
+		store.Add(annotation.Annotation{File: annotation.DescriptionFile, Line: 0, Type: "", Comment: note})
+	}
+	m := testNewModel(t, &mocks.RendererMock{}, store, noopHighlighter(), ModelConfig{
+		ReviewInfo: &ReviewInfoConfig{Description: "agent prose"},
+	})
+	m.editor = editor
+	return m
+}
+
+func TestDescriptionAnnotation_BuildInfoSpecCarriesSanitizedAnnotation(t *testing.T) {
+	m := descriptionAnnotationModel(t, mockEditor("", nil), "wrong \x1b[31massumption")
+	spec := m.buildInfoSpec()
+	assert.Equal(t, "wrong assumption", spec.DescriptionAnnotation, "note must be sanitized before display")
+}
+
+func TestOpenDescriptionEditor_SeedsFromExistingAnnotation(t *testing.T) {
+	fake := mockEditor("", nil)
+	m := descriptionAnnotationModel(t, fake, "prior note")
+	cmd := m.openDescriptionEditor()
+	require.NotNil(t, cmd)
+	require.Len(t, fake.CommandCalls(), 1)
+	assert.Equal(t, "prior note", fake.CommandCalls()[0].Content, "editor must be seeded with the existing note")
+}
+
+func TestOpenDescriptionEditor_SeedsFromDescriptionOnFirstEdit(t *testing.T) {
+	fake := mockEditor("", nil)
+	m := descriptionAnnotationModel(t, fake, "") // no existing note
+	cmd := m.openDescriptionEditor()
+	require.NotNil(t, cmd)
+	require.Len(t, fake.CommandCalls(), 1)
+	assert.Equal(t, "agent prose", fake.CommandCalls()[0].Content,
+		"first edit must seed from the description prose, not a blank file")
+}
+
+func TestOpenDescriptionEditor_CommandErrorProducesFinishedMsg(t *testing.T) {
+	cmdErr := errors.New("temp file unavailable")
+	m := descriptionAnnotationModel(t, mockEditor("", cmdErr), "seed note")
+	cmd := m.openDescriptionEditor()
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(descriptionEditorFinishedMsg)
+	require.True(t, ok, "expected descriptionEditorFinishedMsg, got %T", cmd())
+	assert.Equal(t, cmdErr, msg.err)
+	assert.Equal(t, "seed note", msg.seed)
+}
+
+func TestHandleDescriptionEditorFinished_StoresAnnotationAndReopensPopup(t *testing.T) {
+	m := descriptionAnnotationModel(t, mockEditor("", nil), "")
+	result, _ := m.Update(descriptionEditorFinishedMsg{content: "correcting the intent"})
+	model := result.(Model)
+
+	got := model.store.Get(annotation.DescriptionFile)
+	require.Len(t, got, 1)
+	assert.Equal(t, 0, got[0].Line, "annotation is stored file-level")
+	assert.Equal(t, "correcting the intent", got[0].Comment)
+	assert.Equal(t, overlay.KindInfo, model.overlay.Kind(), "info popup reopens so the note shows inline")
+}
+
+func TestHandleDescriptionEditorFinished_EmptyContentClearsAnnotation(t *testing.T) {
+	m := descriptionAnnotationModel(t, mockEditor("", nil), "existing note")
+	result, _ := m.Update(descriptionEditorFinishedMsg{content: ""})
+	model := result.(Model)
+	assert.Empty(t, model.store.Get(annotation.DescriptionFile), "emptying the editor deletes the note")
+}
+
+func TestHandleDescriptionEditorFinished_ErrorWithUnchangedSeedKeepsAnnotation(t *testing.T) {
+	m := descriptionAnnotationModel(t, mockEditor("", nil), "keep me")
+	result, _ := m.Update(descriptionEditorFinishedMsg{
+		content: "keep me",
+		seed:    "keep me",
+		err:     errors.New("tty release failed"),
+	})
+	model := result.(Model)
+	got := model.store.Get(annotation.DescriptionFile)
+	require.Len(t, got, 1, "unchanged read-back on error is treated as no edit — note preserved")
+	assert.Equal(t, "keep me", got[0].Comment)
+}
+
+func TestHandleDescriptionEditorFinished_RestoreMouseEmitsEnable(t *testing.T) {
+	m := descriptionAnnotationModel(t, mockEditor("", nil), "")
+	_, cmd := m.Update(descriptionEditorFinishedMsg{content: "note", restoreMouse: true})
+	require.NotNil(t, cmd)
+	assert.IsType(t, tea.EnableMouseCellMotion(), cmd())
+}
+
+func TestDescriptionAnnotation_OutputEmitsFileLevelBlock(t *testing.T) {
+	store := annotation.NewStore()
+	store.Add(annotation.Annotation{File: annotation.DescriptionFile, Line: 0, Type: "", Comment: "intent note"})
+	out := store.FormatOutput()
+	assert.Contains(t, out, "## (description) (file-level)\nintent note")
+}
+
+// the --annotations half of the round-trip, where the synthetic key has no diff
+// to resolve against, is covered by TestPreloadAnnotations_KeepsDescriptionNote.
+func TestDescriptionAnnotation_RoundTripsThroughParse(t *testing.T) {
+	store := annotation.NewStore()
+	store.Add(annotation.Annotation{File: annotation.DescriptionFile, Line: 0, Type: "", Comment: "intent note"})
+	out := store.FormatOutput()
+
+	reloaded := annotation.NewStore()
+	require.NoError(t, reloaded.Load(strings.NewReader(out)))
+	got := reloaded.Get(annotation.DescriptionFile)
+	require.Len(t, got, 1, "the synthetic (description) key must survive the format/parse pair")
+	assert.Equal(t, "intent note", got[0].Comment)
+}
+
+// the hint names a rebindable action, so it has to follow the keymap rather
+// than a literal key.
+func TestDescriptionAnnotation_HintFollowsTheKeymap(t *testing.T) {
+	m := descriptionAnnotationModel(t, mockEditor("", nil), "")
+	assert.Equal(t, "press e to annotate the description", m.buildInfoSpec().DescriptionHint, "default binding is advertised")
+
+	m.keymap.Unbind("e")
+	m.keymap.Bind("ctrl+x", keymap.ActionOpenFileInEditor)
+	assert.Equal(t, "press Ctrl+X to annotate the description", m.buildInfoSpec().DescriptionHint, "a rebound action is advertised under its new key")
+
+	m.keymap.Unbind("ctrl+x")
+	assert.Empty(t, m.buildInfoSpec().DescriptionHint, "an unbound action advertises no key")
+}
+
+func TestInfoOverlay_PressingAnnotateKeyLaunchesEditor(t *testing.T) {
+	fake := mockEditor("", nil)
+	m := descriptionAnnotationModel(t, fake, "")
+	m.overlay.OpenInfo(m.buildInfoSpec())
+	require.True(t, m.overlay.Active())
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	model := result.(Model)
+	assert.False(t, model.overlay.Active(), "info popup closes before the editor takes the terminal")
+	require.NotNil(t, cmd, "the annotate key must launch the description editor")
+}

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -980,6 +980,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleSourceEditorFinished(msg)
 	case postFlushFinishedMsg:
 		return m.handlePostFlushFinished(msg)
+	case descriptionEditorFinishedMsg:
+		return m.handleDescriptionEditorFinished(msg)
 	case wheelDebounceMsg:
 		return m.handleWheelDebounce(msg)
 	}
@@ -1263,6 +1265,12 @@ func (m Model) handleModalKey(msg tea.KeyMsg) (bool, tea.Model, tea.Cmd) {
 	// overlay popup dispatch (help, annotation list, theme selector)
 	if m.overlay.Active() {
 		action := m.keymap.Resolve(msg.String())
+		// e annotates the description from the info popup. Gated in the Model,
+		// not the overlay, so the overlay package stays free of the store.
+		if m.overlay.Kind() == overlay.KindInfo && action == keymap.ActionOpenFileInEditor && m.review.descriptionHighlighted != "" {
+			m.overlay.Close()
+			return true, m, m.openDescriptionEditor()
+		}
 		out := m.overlay.HandleKey(msg, action)
 		switch out.Kind {
 		case overlay.OutcomeAnnotationChosen:

--- a/app/ui/overlay/info.go
+++ b/app/ui/overlay/info.go
@@ -123,6 +123,7 @@ func (c *infoOverlay) buildContent(innerWidth int, resolver Resolver) []string {
 		out = append(out, section...)
 	}
 	appendSection(c.buildDescriptionSection(innerWidth, resolver))
+	appendSection(c.buildDescriptionHintSection(innerWidth, resolver))
 	appendSection(c.buildDetailRows(innerWidth, resolver))
 	appendSection(c.buildCommitsSection(innerWidth, resolver))
 	if len(out) == 0 {
@@ -135,18 +136,25 @@ func (c *infoOverlay) buildContent(innerWidth int, resolver Resolver) []string {
 	return out
 }
 
-// buildDescriptionSection renders the optional agent-supplied prose. Empty
-// description returns nil so the section is skipped entirely. The text is
-// wrapped to inner width; newlines in the source are honored as paragraph
-// breaks. Caller is responsible for sanitizing the input before it reaches
-// the spec — this code does not strip control bytes because chroma-style
-// ANSI is preserved verbatim for highlighted output.
+// buildDescriptionSection renders the review context: the reviewer's edit when
+// one exists, otherwise the agent-supplied prose. The edit supersedes the
+// original rather than sitting beside it, so a corrected assumption is never
+// displayed next to the wrong one it replaced. Empty description returns nil so
+// the section is skipped entirely. The text is wrapped to inner width;
+// newlines in the source are honored as paragraph breaks. Caller is
+// responsible for sanitizing the input before it reaches the spec — this code
+// does not strip control bytes because chroma-style ANSI is preserved verbatim
+// for highlighted output.
 func (c *infoOverlay) buildDescriptionSection(innerWidth int, resolver Resolver) []string {
 	if strings.TrimSpace(c.spec.Description) == "" {
 		return nil
 	}
-	out := []string{c.sectionHeader("description", innerWidth, resolver)}
-	for _, raw := range c.splitLines(c.spec.Description) {
+	header, body := "description", c.spec.Description
+	if strings.TrimSpace(c.spec.DescriptionAnnotation) != "" {
+		header, body = "description (edited)", c.spec.DescriptionAnnotation
+	}
+	out := []string{c.sectionHeader(header, innerWidth, resolver)}
+	for _, raw := range c.splitLines(body) {
 		if raw == "" {
 			out = append(out, c.padLine("", innerWidth))
 			continue
@@ -156,6 +164,21 @@ func (c *infoOverlay) buildDescriptionSection(innerWidth int, resolver Resolver)
 		}
 	}
 	return out
+}
+
+// buildDescriptionHintSection advertises the annotate key, and only while the
+// description is still the supplied one: once edited, buildDescriptionSection's
+// "(edited)" header carries that state and a prompt to annotate would read as
+// though nothing had been recorded. Returns nil without a description, so it
+// never appears where the annotate key does nothing.
+func (c *infoOverlay) buildDescriptionHintSection(innerWidth int, _ Resolver) []string {
+	if strings.TrimSpace(c.spec.Description) == "" {
+		return nil
+	}
+	if strings.TrimSpace(c.spec.DescriptionAnnotation) != "" || c.spec.DescriptionHint == "" {
+		return nil
+	}
+	return c.centeredMessage(c.spec.DescriptionHint, innerWidth, true)
 }
 
 // buildDetailRows renders the trimmed session/detail block. Most session

--- a/app/ui/overlay/info_test.go
+++ b/app/ui/overlay/info_test.go
@@ -696,3 +696,59 @@ func TestShortHash(t *testing.T) {
 		})
 	}
 }
+
+func TestInfoOverlay_RenderDescriptionAnnotation(t *testing.T) {
+	t.Run("the edit replaces the prose rather than joining it", func(t *testing.T) {
+		mgr := NewManager()
+		mgr.OpenInfo(InfoSpec{
+			Description:           "the endpoint is idempotent",
+			DescriptionAnnotation: "the endpoint is NOT idempotent",
+			DescriptionHint:       "press e to annotate the description",
+		})
+		out := mgr.info.render(infoRenderCtx(), mgr)
+		assert.Contains(t, out, "description (edited)", "header marks the prose as superseded")
+		assert.Contains(t, out, "the endpoint is NOT idempotent")
+		assert.NotContains(t, out, "the endpoint is idempotent\x1b", "superseded prose must not render alongside the edit")
+		assert.NotContains(t, out, "your annotation", "there is no second section to contradict the first")
+		assert.NotContains(t, out, "to annotate the description", "hint retires once an edit exists")
+	})
+
+	t.Run("unedited description keeps its plain header", func(t *testing.T) {
+		mgr := NewManager()
+		mgr.OpenInfo(InfoSpec{Description: "agent prose", DescriptionHint: "press e to annotate the description"})
+		out := mgr.info.render(infoRenderCtx(), mgr)
+		assert.Contains(t, out, "agent prose")
+		assert.NotContains(t, out, "(edited)", "nothing is marked edited until it is")
+	})
+
+	t.Run("hint renders when a description exists but no annotation", func(t *testing.T) {
+		mgr := NewManager()
+		mgr.OpenInfo(InfoSpec{Description: "agent prose", DescriptionHint: "press e to annotate the description"})
+		out := mgr.info.render(infoRenderCtx(), mgr)
+		assert.Contains(t, out, "press e to annotate the description")
+	})
+
+	t.Run("hint names the bound key", func(t *testing.T) {
+		mgr := NewManager()
+		mgr.OpenInfo(InfoSpec{Description: "agent prose", DescriptionHint: "press Ctrl+X to annotate the description"})
+		out := mgr.info.render(infoRenderCtx(), mgr)
+		assert.Contains(t, out, "press Ctrl+X to annotate the description")
+		assert.NotContains(t, out, "press e to annotate")
+	})
+
+	t.Run("no hint when the action is unbound", func(t *testing.T) {
+		mgr := NewManager()
+		mgr.OpenInfo(InfoSpec{Description: "agent prose"})
+		out := mgr.info.render(infoRenderCtx(), mgr)
+		assert.Contains(t, out, "agent prose")
+		assert.NotContains(t, out, "to annotate the description", "an unbound action advertises no key")
+	})
+
+	t.Run("no annotation affordance without a description", func(t *testing.T) {
+		mgr := NewManager()
+		mgr.OpenInfo(InfoSpec{DescriptionAnnotation: "orphan note", CommitsApplicable: false})
+		out := mgr.info.render(infoRenderCtx(), mgr)
+		assert.NotContains(t, out, "orphan note", "an edit with no description to supersede renders nothing")
+		assert.NotContains(t, out, "description", "section is gated on a present description")
+	})
+}

--- a/app/ui/overlay/overlay.go
+++ b/app/ui/overlay/overlay.go
@@ -159,14 +159,16 @@ type InfoSpec struct {
 	// surface aggregate stats (files, +/-, status, vcs) without spending
 	// body rows on them. Empty leaves the bottom border bare. Both
 	// header and footer gracefully no-op when too wide for the popup.
-	FooterText        string
-	Description       string
-	Rows              []InfoRow
-	Commits           []diff.CommitInfo
-	CommitsApplicable bool
-	CommitsLoaded     bool
-	Truncated         bool
-	CommitsErr        error
+	FooterText            string
+	Description           string
+	DescriptionAnnotation string // reviewer's annotation on the description prose; empty when none
+	DescriptionHint       string // prompt rendered in place of an absent annotation; empty renders no hint
+	Rows                  []InfoRow
+	Commits               []diff.CommitInfo
+	CommitsApplicable     bool
+	CommitsLoaded         bool
+	Truncated             bool
+	CommitsErr            error
 }
 
 // InfoRow is a label/value line rendered in the session section of the info

--- a/app/ui/reviewinfo.go
+++ b/app/ui/reviewinfo.go
@@ -2,13 +2,16 @@ package ui
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/umputun/revdiff/app/annotation"
 	"github.com/umputun/revdiff/app/diff"
+	"github.com/umputun/revdiff/app/keymap"
 	"github.com/umputun/revdiff/app/review"
 	"github.com/umputun/revdiff/app/ui/overlay"
 )
@@ -142,16 +145,105 @@ func (m *Model) refreshInfoOverlay() {
 // render a "loading commits…" line inside the section.
 func (m Model) buildInfoSpec() overlay.InfoSpec {
 	return overlay.InfoSpec{
-		HeaderText:        m.reviewHeaderText(),
-		FooterText:        m.reviewFooterText(),
-		Description:       m.review.descriptionHighlighted,
-		Rows:              m.reviewRows(),
-		Commits:           m.commits.list,
-		CommitsApplicable: m.commits.applicable && m.commits.source != nil,
-		CommitsLoaded:     m.commits.loaded,
-		Truncated:         m.commits.truncated,
-		CommitsErr:        m.commits.err,
+		HeaderText:            m.reviewHeaderText(),
+		FooterText:            m.reviewFooterText(),
+		Description:           m.review.descriptionHighlighted,
+		DescriptionAnnotation: m.descriptionAnnotation(),
+		DescriptionHint:       m.descriptionHint(),
+		Rows:                  m.reviewRows(),
+		Commits:               m.commits.list,
+		CommitsApplicable:     m.commits.applicable && m.commits.source != nil,
+		CommitsLoaded:         m.commits.loaded,
+		Truncated:             m.commits.truncated,
+		CommitsErr:            m.commits.err,
 	}
+}
+
+// descriptionHint composes the popup's annotate prompt. Chords are excluded
+// because chord dispatch bypasses the info popup's gate in handleModalKey.
+func (m Model) descriptionHint() string {
+	var single []string
+	for _, k := range m.keymap.KeysFor(keymap.ActionOpenFileInEditor) {
+		if strings.Index(k, ">") <= 0 {
+			single = append(single, m.displayKeyName(k))
+		}
+	}
+	if len(single) == 0 {
+		return ""
+	}
+	return "press " + strings.Join(single, " / ") + " to annotate the description"
+}
+
+// descriptionAnnotationRaw returns the reviewer's file-level annotation on the description,
+// or "" when none exists.
+func (m Model) descriptionAnnotationRaw() string {
+	for _, a := range m.store.Get(annotation.DescriptionFile) {
+		if a.Line == 0 {
+			return a.Comment
+		}
+	}
+	return ""
+}
+
+// descriptionAnnotation returns the note sanitized for display, routed through the
+// same strip path as any other untrusted stored comment.
+func (m Model) descriptionAnnotation() string {
+	return diff.SanitizeCommitText(m.descriptionAnnotationRaw())
+}
+
+// descriptionEditorFinishedMsg carries the external-editor result. seed lets the
+// handler tell a launch-time failure (read-back equals seed) from a post-save
+// soft failure, mirroring editorFinishedMsg.
+type descriptionEditorFinishedMsg struct {
+	content      string
+	seed         string
+	err          error
+	restoreMouse bool
+}
+
+// openDescriptionEditor opens $EDITOR seeded with the existing annotation, or the
+// description prose itself on first edit so the reviewer starts from the
+// supplied context rather than a blank file. The caller closes the info popup
+// before launch; the handler reopens it on return.
+func (m Model) openDescriptionEditor() tea.Cmd {
+	seed := m.descriptionAnnotationRaw()
+	if seed == "" {
+		seed = descriptionFromConfig(m.review.cfg)
+	}
+	cmd, complete, err := m.editor.Command(seed)
+	if err != nil {
+		return func() tea.Msg { return descriptionEditorFinishedMsg{err: err, seed: seed} }
+	}
+	return tea.ExecProcess(cmd, func(runErr error) tea.Msg {
+		text, finalErr := complete(runErr)
+		return descriptionEditorFinishedMsg{content: text, seed: seed, err: finalErr, restoreMouse: m.cfg.mouseTracking}
+	})
+}
+
+// handleDescriptionEditorFinished stores (empty clears) the annotation and reopens the
+// info popup. Error handling mirrors handleEditorFinished: an unchanged
+// read-back on error is treated as no edit.
+func (m Model) handleDescriptionEditorFinished(msg descriptionEditorFinishedMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	if msg.restoreMouse {
+		cmd = tea.EnableMouseCellMotion
+	}
+	if msg.err != nil {
+		log.Printf("[WARN] description editor session error: %v", msg.err)
+		if msg.content == "" || msg.content == msg.seed {
+			m.overlay.OpenInfo(m.buildInfoSpec())
+			return m, cmd
+		}
+	}
+	// saving an empty buffer is how the reviewer retracts a note; without the
+	// delete there would be no way to remove one. Absent key is a no-op.
+	if msg.content == "" {
+		m.store.Delete(annotation.DescriptionFile, 0, "")
+	} else {
+		m.store.Add(annotation.Annotation{File: annotation.DescriptionFile, Line: 0, Type: "", Comment: msg.content})
+	}
+	m.overlay.OpenInfo(m.buildInfoSpec())
+	return m, cmd
 }
 
 // precomputeDescriptionHighlight runs the description prose through the

--- a/plugins/codex/skills/revdiff/references/usage.md
+++ b/plugins/codex/skills/revdiff/references/usage.md
@@ -85,6 +85,8 @@ revdiff HEAD~3 --description-file=/tmp/review-notes.md
 
 `--description` and `--description-file` are mutually exclusive. Both are optional — omit when there's no useful context to add.
 
+The reviewer can edit the description: pressing `e` while the info popup is open opens `$EDITOR` seeded with the description text, emitted as a `## (description) (file-level)` block (see Output Format). The edit replaces the prose shown in the popup, so the corrected assumption supersedes the original rather than sitting beside it. This is how a reviewer corrects a wrong assumption in the context you supplied.
+
 ## Two-File Diff
 
 Use `--compare-old=<path>` together with `--compare-new=<path>` to diff two arbitrary files on disk using `git diff --no-index`. No VCS repo needed — works anywhere `git` is installed.
@@ -176,6 +178,7 @@ Press `Space` to mark the focused file reviewed. Press `F` to toggle the sidebar
 | `F` | Toggle filter: all files / unreviewed only |
 | `?` | Toggle help overlay showing all keybindings |
 | `i` | Toggle info popup — review scope (mode, VCS, ref, filters, file/status counts, aggregate `+/-` stats) plus the commit log for the current ref range when applicable |
+| `e` (in info popup) | Edit the `--description` in `$EDITOR`; replaces the displayed prose, emitted as `## (description) (file-level)` |
 | `R` | Reload diff from VCS (warns if annotations exist) |
 | `q` | Quit, output annotations to stdout |
 | `Q` | Discard all annotations and quit (confirms if annotations exist) |
@@ -297,6 +300,8 @@ don't remove this validation
 ```
 
 Each annotation block: `## filename:line[-end] (type)` where type is `(+)` added, `(-)` removed, or `(file-level)`. The `-end` suffix is included when the annotation covers a line range.
+
+A `## (description) (file-level)` block is not a file path: it is the reviewer's annotation on the `--description` you supplied, added with `e` in the info popup. Treat it as a correction to the intent/context of the change, not a comment about a file named `(description)`.
 
 When annotation text contains the keyword "hunk" (case-insensitive, whole word), the output header automatically expands to include the full hunk line range (e.g., `handler.go:43-67 (+)` instead of `handler.go:43 (+)`). This gives AI consumers the range context without any extra steps.
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -286,7 +286,8 @@ See ticket SEC-441 for context."
 
 # longer descriptions: keep the markdown in a file
 revdiff HEAD~3 --description-file=.review-description.md</code></div>
-        <p><code>--description</code> and <code>--description-file</code> are mutually exclusive. The description section is hidden when neither is set, so the flag is purely additive.</p>
+        <p><code>--description</code> and <code>--description-file</code> are mutually exclusive. The description section is hidden when neither is set.</p>
+        <p>Press <code>e</code> while the info popup is open to edit the description in your editor, seeded on first edit with the description text. Your edit replaces the prose in the popup under a <code>description (edited)</code> header, so a corrected assumption is never shown next to the wrong one it replaced. The edit is emitted in the structured output as <code>## (description) (file-level)</code>; emptying the editor clears it and restores the supplied text.</p>
 
         <h2 id="markdown-toc">Markdown TOC navigation</h2>
         <p>When reviewing a single markdown file in context-only mode, a table-of-contents pane appears on the left listing all markdown headers. This works for <code>--only</code> files and for <code>--stdin</code> when <code>--stdin-name</code> ends with <code>.md</code> or <code>.markdown</code>. Use <code>Tab</code> to switch focus, <code>j</code>/<code>k</code> to navigate, <code>Enter</code> to jump. The TOC highlights the current section as you scroll. Headers inside fenced code blocks are excluded.</p>
@@ -584,6 +585,7 @@ printf '\033]52;c;%s\007' "$data" > /dev/tty</code></div>
                 <tr><td><code>f</code></td><td>Filter: all files / annotated only</td></tr>
                 <tr><td><code>?</code></td><td>Help overlay</td></tr>
                 <tr><td><code>i</code></td><td>Info popup &mdash; review scope (mode, VCS, ref, filters, file/status counts, aggregate <code>+/-</code> stats) plus the commit log for the current ref range when applicable</td></tr>
+                <tr><td><code>e</code> (in info popup)</td><td>Annotate the <code>--description</code> in <code>$EDITOR</code>; emitted as <code>## (description) (file-level)</code></td></tr>
                 <tr><td><code>R</code></td><td>Reload diff from VCS (warns if annotations exist)</td></tr>
                 <tr><td><code>q</code></td><td>Quit, output annotations</td></tr>
                 <tr><td><code>Q</code></td><td>Discard annotations and quit</td></tr>


### PR DESCRIPTION
## Context

Along with a diff, prose context can be provided via `--description`
(this can be a prior commit message, an agent's intention, etc)

This context can currently be viewed via an info popup (`i`)

This PR enables editing this context.  Correcting _intent_ is a high-leverage edit: a wrong
premise keeps generating the same class of mistake, so one fix to the premise can often
flow to multiple change sites, avoid repetitive corrections, or even reduce session turn count

## Demo

A `/ship-it` run opens an **already-committed** change for review, passing the
commit message as the review context

The reviewer annotates **no code at all**. They open the context (`i`), press
`e`, and correct the one assumption. On exit the correction comes back as a
`## (description)` block, and the skill acts on it: two code defects that both
followed from the premise (no idempotency key on a replayed charge; a
`time.Sleep` backoff that ignores context cancellation), plus the commit message
that asserted it. A second pass returns no annotations, and that clean signal is
what releases the change

![One context correction driving two code fixes and a commit-message rewrite](https://github.com/chris-peterson/revdiff/releases/download/pr-4-assets/ship-it-loop.gif)

Note the popup mid-clip: the correction renders under a `description (edited)`
header while `commits (1)` still shows the original, uncorrected commit beneath
it

> The assistant turns in the clip are scripted. The two revdiff passes, the git
> state, the file edits, and the `--amend` are real; the narration around them
> is staged

## Review guide

- [exported const](https://github.com/chris-peterson/revdiff/pull/4/changes#diff-87297acfa6e391df0db42099534ce377685a2b0860e8bffa3b5ebcbf2cead7df-R16)
- [`annotations_load.go` R126](https://github.com/chris-peterson/revdiff/pull/4/changes#diff-f4a0635bfe3d23a72ad96a3bd6788c4e26a02a2c519b74c8bc1c9a8bb4c0a321-R126)
  — the `--annotations` preloader resolves every record against the diff and
  drops what it can't find. Without this exemption an `-o` snapshot silently
  loses its description edit on reload, which is exactly the leak you predicted
  on the issue
- [`info.go` R152-154](https://github.com/chris-peterson/revdiff/pull/4/changes#diff-837eb274bbff89054162a594e10dc5892ddfd806b06ad84ca16daaa6d1770a9b-R152)
  — the edit **replaces** the supplied prose under a `description (edited)`
  header instead of rendering as a second section, so a corrected assumption is
  never displayed next to the wrong one it supersedes

The rest, in descending order:

- [`reviewinfo.go` R208](https://github.com/chris-peterson/revdiff/pull/4/changes#diff-421ec9fee1006bc6094853874515487c3cc88aafcdf2773285d54b864c9769be-R208)
  and [R226](https://github.com/chris-peterson/revdiff/pull/4/changes#diff-421ec9fee1006bc6094853874515487c3cc88aafcdf2773285d54b864c9769be-R226)
  — open `$EDITOR` seeded from the existing edit, else the description prose;
  store or (on an empty buffer) delete on return. Error handling mirrors
  `handleEditorFinished`: an unchanged read-back on error counts as no edit.
- [`model.go` R1258](https://github.com/chris-peterson/revdiff/pull/4/changes#diff-f35be84b66d47d2dc83baabcf787c38dc460cc4a3e712310d57af4d761b09e07-R1258)
  — the key is gated in the Model, not the overlay, so `app/ui/overlay` stays
  free of the annotation store
- [`reviewinfo.go` R164](https://github.com/chris-peterson/revdiff/pull/4/changes#diff-421ec9fee1006bc6094853874515487c3cc88aafcdf2773285d54b864c9769be-R164)
  — the popup hint is composed from the keymap rather than naming a literal
  `e`, since `open_file_in_editor` is rebindable. Chords are excluded because
  chord dispatch goes through `dispatchAction` and never reaches the popup's
  gate in `handleModalKey`, so a chord-only binding genuinely cannot annotate
  the description
- docs across `README.md`, `site/docs.html`, and both plugin `usage.md` refs,
  including a note telling agents that `## (description)` is not a file path

## Approach & trade-offs

**Reusing `open_file_in_editor` rather than adding an action.** It already means
"edit this in `$EDITOR`" and it's unbound while the info popup is open, so the
binding is free and no new keymap surface appears. Cost: a user who rebinds it
moves this too, which is why the hint follows the keymap

**Seeding the first edit with the description text** rather than a blank buffer.
It makes the edit a revision of the context, which is what the replace-on-display
behavior above then reflects. Every other annotation starts blank, so this is the
one place the feature departs from the existing pattern