### PR TITLE
Add --no-tree to start with the file tree pane hidden

### DIFF
--- a/.claude-plugin/skills/revdiff/references/config.md
+++ b/.claude-plugin/skills/revdiff/references/config.md
@@ -37,6 +37,7 @@ Then uncomment and edit the values you want to change.
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
 | `--no-confirm-reload` | `REVDIFF_NO_CONFIRM_RELOAD` | Skip confirmation when dropping annotations on reload with R | `false` |
 | `--no-mouse` | `REVDIFF_NO_MOUSE` | Disable mouse support (scroll wheel, click) | `false` |
+| `--no-tree` | `REVDIFF_NO_TREE` | Hide the file tree pane | `false` |
 | `--vim-motion` | `REVDIFF_VIM_MOTION` | Enable vim-style motion preset (counts, `gg`, `G`, `H`/`M`/`L`, `zz`/`zt`/`zb`, `ZZ`/`ZQ`) | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
 | `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/`; use `auto` to choose by terminal background | |

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Positional arguments support several forms:
 | `--no-confirm-discard` | Skip confirmation when discarding annotations with Q, env: `REVDIFF_NO_CONFIRM_DISCARD` | `false` |
 | `--no-confirm-reload` | Skip confirmation when dropping annotations on reload with R, env: `REVDIFF_NO_CONFIRM_RELOAD` | `false` |
 | `--no-mouse` | Disable mouse support (scroll wheel, click), env: `REVDIFF_NO_MOUSE` | `false` |
+| `--no-tree` | Hide the file tree pane, env: `REVDIFF_NO_TREE` | `false` |
 | `--vim-motion` | Enable vim-style motion preset (counts, `gg`, `G`, `H`/`M`/`L`, `zz`/`zt`/`zb`, `ZZ`/`ZQ`), env: `REVDIFF_VIM_MOTION` | `false` |
 | `--chroma-style` | Chroma color theme for syntax highlighting, env: `REVDIFF_CHROMA_STYLE` | `catppuccin-macchiato` |
 | `--theme` | Load color theme from `~/.config/revdiff/themes/`; use `auto` to choose by terminal background, env: `REVDIFF_THEME` | |

--- a/app/config.go
+++ b/app/config.go
@@ -26,6 +26,7 @@ type options struct {
 	NoConfirmDiscard      bool     `long:"no-confirm-discard" ini-name:"no-confirm-discard" env:"REVDIFF_NO_CONFIRM_DISCARD" description:"skip confirmation prompt when discarding annotations with Q"`
 	NoConfirmReload       bool     `long:"no-confirm-reload" ini-name:"no-confirm-reload" env:"REVDIFF_NO_CONFIRM_RELOAD" description:"skip confirmation prompt when dropping annotations on reload with R"`
 	NoMouse               bool     `long:"no-mouse" ini-name:"no-mouse" env:"REVDIFF_NO_MOUSE" description:"disable mouse support (scroll wheel, click)"`
+	NoTree                bool     `long:"no-tree" ini-name:"no-tree" env:"REVDIFF_NO_TREE" description:"hide the file tree pane"`
 	Wrap                  bool     `long:"wrap" ini-name:"wrap" env:"REVDIFF_WRAP" description:"enable line wrapping in diff view"`
 	WrapIndent            int      `long:"wrap-indent" ini-name:"wrap-indent" env:"REVDIFF_WRAP_INDENT" default:"0" description:"indent wrap continuation rows by N columns so they hang under the first row's content (helps when reviewing markdown lists where unindented continuation can be misread as a new bullet)"`
 	Collapsed             bool     `long:"collapsed" ini-name:"collapsed" env:"REVDIFF_COLLAPSED" description:"start in collapsed diff mode"`

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -30,6 +30,7 @@ func TestParseArgs_Defaults(t *testing.T) {
 	assert.False(t, opts.NoConfirmDiscard)
 	assert.False(t, opts.NoConfirmReload)
 	assert.False(t, opts.NoMouse)
+	assert.False(t, opts.NoTree)
 	assert.False(t, opts.Wrap)
 	assert.False(t, opts.Collapsed)
 	assert.False(t, opts.Compact)
@@ -120,6 +121,31 @@ func TestParseArgs_NoMouse(t *testing.T) {
 		opts, err := parseArgs([]string{"--config", cfgPath})
 		require.NoError(t, err)
 		assert.True(t, opts.NoMouse)
+	})
+}
+
+func TestParseArgs_NoTree(t *testing.T) {
+	t.Run("flag", func(t *testing.T) {
+		opts, err := parseArgs(append(noConfigArgs(t), "--no-tree"))
+		require.NoError(t, err)
+		assert.True(t, opts.NoTree)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("REVDIFF_NO_TREE", "true")
+		opts, err := parseArgs(noConfigArgs(t))
+		require.NoError(t, err)
+		assert.True(t, opts.NoTree)
+	})
+
+	t.Run("config file", func(t *testing.T) {
+		cfgDir := t.TempDir()
+		cfgPath := filepath.Join(cfgDir, "config")
+		err := os.WriteFile(cfgPath, []byte("[Application Options]\nno-tree = true\n"), 0o600)
+		require.NoError(t, err)
+		opts, err := parseArgs([]string{"--config", cfgPath})
+		require.NoError(t, err)
+		assert.True(t, opts.NoTree)
 	})
 }
 

--- a/app/main.go
+++ b/app/main.go
@@ -211,6 +211,7 @@ func run(opts options) (int, error) {
 		NoStatusBar:          opts.NoStatusBar,
 		NoConfirmDiscard:     opts.NoConfirmDiscard,
 		NoConfirmReload:      opts.NoConfirmReload,
+		NoTree:               opts.NoTree,
 		Wrap:                 opts.Wrap,
 		WrapIndent:           opts.WrapIndent,
 		Collapsed:            opts.Collapsed,

--- a/app/ui/model.go
+++ b/app/ui/model.go
@@ -738,6 +738,7 @@ type ModelConfig struct {
 	NoColors         bool     // disable all colors including syntax highlighting
 	MouseTracking    bool     // enable mouse tracking for clicks and wheel events
 	NoStatusBar      bool     // hide the status bar
+	NoTree           bool     // hide the file tree pane
 	NoConfirmDiscard bool     // skip confirmation prompt when discarding annotations
 	NoConfirmReload  bool     // skip confirmation prompt when dropping annotations on reload
 	Wrap             bool     // enable line wrapping
@@ -864,6 +865,14 @@ func NewModel(cfg ModelConfig) (Model, error) {
 	cls := resolveCommitLogSource(cfg.CommitLog, cfg.Renderer)
 	reviewCfg := cloneReviewInfoConfig(cfg.ReviewInfo)
 
+	// starting with the tree hidden has to move focus to the diff, the same way
+	// toggleTreePane does when it hides the pane. Leaving focus on the tree would
+	// point the cursor keys at a pane that is not on screen.
+	startFocus := paneTree
+	if cfg.NoTree {
+		startFocus = paneDiff
+	}
+
 	return Model{
 		resolver:      cfg.StyleResolver,
 		renderer:      cfg.StyleRenderer,
@@ -900,7 +909,8 @@ func NewModel(cfg ModelConfig) (Model, error) {
 			outputPath:         cfg.OutputPath,
 		},
 		layout: layoutState{
-			focus: paneTree,
+			focus:      startFocus,
+			treeHidden: cfg.NoTree,
 		},
 		modes: modeState{
 			wrap:           cfg.Wrap,

--- a/app/ui/model_test.go
+++ b/app/ui/model_test.go
@@ -1737,3 +1737,42 @@ func TestModel_AnnotatingNoOpMessageDoesNotRerenderDiff(t *testing.T) {
 	assert.NotContains(t, m.layout.viewport.View(), "sentinel-after-render",
 		"blink left the input value untouched, so the diff must not be re-rendered")
 }
+
+func TestNewModel_NoTree(t *testing.T) {
+	renderer := &mocks.RendererMock{
+		ChangedFilesFunc: func(string, bool) ([]diff.FileEntry, error) { return nil, nil },
+		FileDiffFunc:     func(diff.FileDiffRequest) ([]diff.DiffLine, error) { return nil, nil },
+	}
+	newModel := func(noTree bool) Model {
+		return testNewModel(t, renderer, annotation.NewStore(), noopHighlighter(),
+			ModelConfig{NoTree: noTree, TreeWidthRatio: 3})
+	}
+
+	t.Run("default keeps the tree visible and focused", func(t *testing.T) {
+		m := newModel(false)
+		assert.False(t, m.layout.treeHidden)
+		assert.Equal(t, paneTree, m.layout.focus)
+	})
+
+	t.Run("hidden tree moves focus to the diff", func(t *testing.T) {
+		m := newModel(true)
+		assert.True(t, m.layout.treeHidden)
+		assert.Equal(t, paneDiff, m.layout.focus, "focus must not sit on a pane that is not rendered")
+	})
+
+	t.Run("diff pane spans the full width after resize", func(t *testing.T) {
+		result, _ := newModel(true).Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+		m := result.(Model)
+		assert.Zero(t, m.layout.treeWidth)
+		assert.Equal(t, 118, m.layout.viewport.Width, "only the diff pane's own borders are subtracted")
+	})
+
+	t.Run("toggle restores the tree", func(t *testing.T) {
+		result, _ := newModel(true).Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+		m := result.(Model)
+		m.toggleTreePane()
+		assert.False(t, m.layout.treeHidden)
+		assert.Positive(t, m.layout.treeWidth, "the tree must get its width back")
+		assert.Less(t, m.layout.viewport.Width, 118, "the diff pane must give width back to the tree")
+	})
+}

--- a/plugins/codex/skills/revdiff/references/config.md
+++ b/plugins/codex/skills/revdiff/references/config.md
@@ -36,6 +36,7 @@ Then uncomment and edit the values you want to change.
 | `--exit-code-on-annotations` | `REVDIFF_EXIT_CODE_ON_ANNOTATIONS` | Exit 10 when annotations are produced | `false` |
 | `--no-confirm-discard` | `REVDIFF_NO_CONFIRM_DISCARD` | Skip confirmation when discarding annotations with Q | `false` |
 | `--no-mouse` | `REVDIFF_NO_MOUSE` | Disable mouse support (scroll wheel, click) | `false` |
+| `--no-tree` | `REVDIFF_NO_TREE` | Hide the file tree pane | `false` |
 | `--vim-motion` | `REVDIFF_VIM_MOTION` | Enable vim-style motion preset (counts, `gg`, `G`, `H`/`M`/`L`, `zz`/`zt`/`zb`, `ZZ`/`ZQ`) | `false` |
 | `--chroma-style` | `REVDIFF_CHROMA_STYLE` | Chroma color theme for syntax highlighting | `catppuccin-macchiato` |
 | `--theme` | `REVDIFF_THEME` | Load color theme from `~/.config/revdiff/themes/`; use `auto` to choose by terminal background | |

--- a/plugins/pi/skills/revdiff/SKILL.md
+++ b/plugins/pi/skills/revdiff/SKILL.md
@@ -34,6 +34,7 @@ Tool examples:
 - `args: "--untracked"`: review untracked files with working-tree changes
 - `args: "--only README.md"`: review one standalone file
 - `args: "--all-files --exclude vendor"`: review all tracked files except vendor
+- `args: "--no-tree"`: review with the file tree pane hidden
 - `args: "--description='why this refactor matters' main"`: include review context in the info popup
 - `args: "--description-file=/tmp/revdiff-desc.md main"`: include longer markdown review context
 - `args: "--annotations=/tmp/revdiff-review.md main"`: preload in-session review notes
@@ -75,6 +76,7 @@ When annotations arrive from `/revdiff` or `revdiff_review`:
 /revdiff --all-files --include src
 /revdiff --all-files --exclude vendor
 /revdiff --only README.md
+/revdiff --no-tree
 /revdiff HEAD~3 --description="why this refactor matters"
 /revdiff HEAD~3 --description-file=/tmp/revdiff-desc.md
 /revdiff main --annotations=/tmp/revdiff-review.md

--- a/site/docs.html
+++ b/site/docs.html
@@ -412,6 +412,7 @@ revdiff --dump-config > ~/.config/revdiff/config</code></div>
                 <tr><td><code>--no-confirm-discard</code></td><td>Skip discard confirmation</td><td><code>false</code></td></tr>
                 <tr><td><code>--no-confirm-reload</code></td><td>Skip reload confirmation</td><td><code>false</code></td></tr>
                 <tr><td><code>--no-mouse</code></td><td>Disable mouse support (scroll wheel, click)</td><td><code>false</code></td></tr>
+                <tr><td><code>--no-tree</code></td><td>Hide the file tree pane</td><td><code>false</code></td></tr>
                 <tr><td><code>--vim-motion</code></td><td>Enable vim-style motion preset (counts, <code>gg</code>, <code>G</code>, <code>H</code>/<code>M</code>/<code>L</code>, <code>zz</code>/<code>zt</code>/<code>zb</code>, <code>ZZ</code>/<code>ZQ</code>)</td><td><code>false</code></td></tr>
                 <tr><td><code>--chroma-style</code></td><td>Syntax highlighting theme</td><td><code>catppuccin-macchiato</code></td></tr>
                 <tr><td><code>--theme</code></td><td>Load color theme from <code>~/.config/revdiff/themes/</code>; use <code>auto</code> to choose by terminal background</td><td></td></tr>


### PR DESCRIPTION
the file tree pane could only be toggled at runtime with `t`, so there was no way to open revdiff with it already hidden. From discussion #305.

**What changed**

`--no-tree` on the `options` struct, following the `--no-mouse` shape, so `no-tree` in the config file and `REVDIFF_NO_TREE` come with it. `main.go` passes it into `ModelConfig.NoTree` and `NewModel` sets `layout.treeHidden` from it.

The layout math is untouched: `handleResize` and the file-load switch already branch on `treeHidden`, so the flag reuses those paths rather than adding a second way to compute pane widths. `t` still toggles the pane back on, and a single markdown file's TOC follows the same flag, matching what `t` does today.

The one piece that is not just wiring is initial focus. Starting with the tree hidden moves focus to the diff pane, the same thing `toggleTreePane` does when it hides the pane; without it the cursor keys would drive a pane that is not on screen.

**Tests**

Flag, env var and config-file parsing, plus four model cases: default, hidden, full-width geometry after a resize, and the toggle round-trip.

Related to #305
