### PR TITLE
Name the iTerm2 overlay pane so the tab keeps its label

### DIFF
--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -540,9 +540,10 @@ on run argv
                                 set newSession to split horizontally with same profile command cmd
                             end if
                         end tell
-                        -- the tab label and window title come from the active
-                        -- session's name, and a split inherits the parent's
-                        -- name setting but not the variables it interpolates
+                        -- the tab label comes from its active session's name,
+                        -- and the split gets none of its own: it copies the
+                        -- parent's profile but not the session variables that
+                        -- profile's name may interpolate
                         set name of newSession to overlayTitle
                         return id of newSession
                     end if

--- a/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
+++ b/.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh
@@ -518,12 +518,13 @@ LAUNCHER
     ITERM_UUID="${ITERM_SESSION_ID##*:}"
 
     # find target session by UUID, auto-detect split direction, capture new session id
-    ITERM_NEW_SESSION=$(osascript - "$ITERM_UUID" "$LAUNCH_SCRIPT" "$CWD" "$SENTINEL" <<'APPLESCRIPT' 2>&1
+    ITERM_NEW_SESSION=$(osascript - "$ITERM_UUID" "$LAUNCH_SCRIPT" "$CWD" "$SENTINEL" "$OVERLAY_TITLE" <<'APPLESCRIPT' 2>&1
 on run argv
     set targetId to item 1 of argv
     set launchScript to item 2 of argv
     set cwd to item 3 of argv
     set sentinel to item 4 of argv
+    set overlayTitle to item 5 of argv
     set cmd to quoted form of launchScript & " " & quoted form of cwd & " " & quoted form of sentinel
     tell application id "com.googlecode.iterm2"
         repeat with w in windows
@@ -539,6 +540,10 @@ on run argv
                                 set newSession to split horizontally with same profile command cmd
                             end if
                         end tell
+                        -- the tab label and window title come from the active
+                        -- session's name, and a split inherits the parent's
+                        -- name setting but not the variables it interpolates
+                        set name of newSession to overlayTitle
                         return id of newSession
                     end if
                 end repeat

--- a/app/plugin_exit_code_test.go
+++ b/app/plugin_exit_code_test.go
@@ -177,6 +177,74 @@ func TestShellLaunchersPreserveAnnotationExitCode(t *testing.T) {
 	}
 }
 
+// every other backend labels its overlay through a flag the exit-code matrix
+// already runs (tmux -T, kitty --title); iTerm2 names the session it splits from
+// an AppleScript argv, which nothing else in the suite reads
+func TestIterm2OverlayNamesSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell launchers are not used on windows")
+	}
+
+	root := testRepoRoot(t)
+	planFile := filepath.Join(t.TempDir(), "plan.md")
+	writeTestFile(t, planFile, "# Plan\n")
+	diffTitle := "rd: " + filepath.Base(root) + " [HEAD~1]"
+
+	launchers := []struct {
+		name  string
+		path  string
+		args  []string
+		title string
+	}{
+		{
+			name:  "claude",
+			path:  ".claude-plugin/skills/revdiff/scripts/launch-revdiff.sh",
+			args:  []string{"HEAD~1"},
+			title: diffTitle,
+		},
+		{
+			name:  "codex",
+			path:  "plugins/codex/skills/revdiff/scripts/launch-revdiff.sh",
+			args:  []string{"HEAD~1"},
+			title: diffTitle,
+		},
+		{
+			name:  "plan review",
+			path:  "plugins/revdiff-planning/scripts/launch-plan-review.sh",
+			args:  []string{planFile},
+			title: "plan: plan.md",
+		},
+	}
+
+	output := "## file.go:1 (+)\ncomment\n"
+	backend := launcherBackend{name: "iterm2", command: "osascript", env: map[string]string{"ITERM_SESSION_ID": "w0t0p0:ABC"}}
+	for _, launcher := range launchers {
+		t.Run(launcher.name, func(t *testing.T) {
+			env := fakeLauncherEnv(t, launcherRun{backend: backend, code: exitCodeAnnotations, output: output})
+			argsFile := filepath.Join(env["TMPDIR"], "osascript-args")
+			env["FAKE_OSASCRIPT_ARGS_FILE"] = argsFile
+
+			res := runTestCmd(t, cmdReq{
+				dir:  root,
+				name: "bash",
+				args: append([]string{filepath.Join(root, launcher.path)}, launcher.args...),
+				env:  env,
+			})
+			assert.Equal(t, exitCodeAnnotations, res.code)
+			assert.Equal(t, output, res.stdout)
+
+			raw, err := os.ReadFile(argsFile) //nolint:gosec // path is a test-owned temp file
+			require.NoError(t, err)
+			calls := strings.Split(strings.TrimSpace(string(raw)), "\n")
+			require.NotEmpty(t, calls)
+			// the title is the last argv item so the stub's positional dispatch
+			// on the launch script keeps matching
+			assert.True(t, strings.HasSuffix(calls[0], " "+launcher.title),
+				"split osascript argv should end with the overlay title, got %q", calls[0])
+		})
+	}
+}
+
 func TestAgtermPaneOverlayOptIn(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell launchers are not used on windows")

--- a/app/testdata/plugin-exit-code/fake-overlay-backend.sh
+++ b/app/testdata/plugin-exit-code/fake-overlay-backend.sh
@@ -67,6 +67,9 @@ case "$cmd_name" in
         esac
         ;;
     osascript)
+        if [ -n "${FAKE_OSASCRIPT_ARGS_FILE:-}" ]; then
+            printf '%s\n' "$*" >> "$FAKE_OSASCRIPT_ARGS_FILE"
+        fi
         if [ "$#" -ge 5 ] && [ -x "${3:-}" ]; then
             "$3" "$4" "$5"
             echo "session:1"

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -541,9 +541,10 @@ on run argv
                                 set newSession to split horizontally with same profile command cmd
                             end if
                         end tell
-                        -- the tab label and window title come from the active
-                        -- session's name, and a split inherits the parent's
-                        -- name setting but not the variables it interpolates
+                        -- the tab label comes from its active session's name,
+                        -- and the split gets none of its own: it copies the
+                        -- parent's profile but not the session variables that
+                        -- profile's name may interpolate
                         set name of newSession to overlayTitle
                         return id of newSession
                     end if

--- a/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
+++ b/plugins/codex/skills/revdiff/scripts/launch-revdiff.sh
@@ -519,12 +519,13 @@ LAUNCHER
     ITERM_UUID="${ITERM_SESSION_ID##*:}"
 
     # find target session by UUID, auto-detect split direction, capture new session id
-    ITERM_NEW_SESSION=$(osascript - "$ITERM_UUID" "$LAUNCH_SCRIPT" "$CWD" "$SENTINEL" <<'APPLESCRIPT' 2>&1
+    ITERM_NEW_SESSION=$(osascript - "$ITERM_UUID" "$LAUNCH_SCRIPT" "$CWD" "$SENTINEL" "$OVERLAY_TITLE" <<'APPLESCRIPT' 2>&1
 on run argv
     set targetId to item 1 of argv
     set launchScript to item 2 of argv
     set cwd to item 3 of argv
     set sentinel to item 4 of argv
+    set overlayTitle to item 5 of argv
     set cmd to quoted form of launchScript & " " & quoted form of cwd & " " & quoted form of sentinel
     tell application id "com.googlecode.iterm2"
         repeat with w in windows
@@ -540,6 +541,10 @@ on run argv
                                 set newSession to split horizontally with same profile command cmd
                             end if
                         end tell
+                        -- the tab label and window title come from the active
+                        -- session's name, and a split inherits the parent's
+                        -- name setting but not the variables it interpolates
+                        set name of newSession to overlayTitle
                         return id of newSession
                     end if
                 end repeat

--- a/plugins/revdiff-planning/scripts/launch-plan-review.sh
+++ b/plugins/revdiff-planning/scripts/launch-plan-review.sh
@@ -397,11 +397,12 @@ LAUNCHER
 
     ITERM_UUID="${ITERM_SESSION_ID##*:}"
 
-    ITERM_NEW_SESSION=$(osascript - "$ITERM_UUID" "$LAUNCH_SCRIPT" "$SENTINEL" <<'APPLESCRIPT' 2>&1
+    ITERM_NEW_SESSION=$(osascript - "$ITERM_UUID" "$LAUNCH_SCRIPT" "$SENTINEL" "$OVERLAY_TITLE" <<'APPLESCRIPT' 2>&1
 on run argv
     set targetId to item 1 of argv
     set launchScript to item 2 of argv
     set sentinel to item 3 of argv
+    set overlayTitle to item 4 of argv
     set cmd to quoted form of launchScript & " " & quoted form of sentinel
     tell application id "com.googlecode.iterm2"
         repeat with w in windows
@@ -417,6 +418,11 @@ on run argv
                                 set newSession to split horizontally with same profile command cmd
                             end if
                         end tell
+                        -- the tab label comes from its active session's name,
+                        -- and the split gets none of its own: it copies the
+                        -- parent's profile but not the session variables that
+                        -- profile's name may interpolate
+                        set name of newSession to overlayTitle
                         return id of newSession
                     end if
                 end repeat


### PR DESCRIPTION
## Context

The iTerm2 overlay opens as a split pane, and that pane is created with no name of its own. A tab's label comes from its *active* session, so once the overlay takes focus the tab falls back to the profile's title for the duration of the review and stops saying which session it belongs to. #307 carries the measurements.

tmux (`-T`), zellij (`--name`), herdr (`--label`), kitty (`--title`) and the emacs frame name already label their overlay from `OVERLAY_TITLE`. iTerm2 is not the only backend that doesn't — wezterm, cmux, ghostty and agterm don't either — it is the one whose pane visibly relabels the tab. This passes the same title into the iTerm2 branch and sets it on the session the split returns. Nothing has to undo it afterwards: the name belongs to the session, so it goes when the pane does.

Reach is narrow: on a stock profile the parent and the overlay render the same title and the tab doesn't change. This shows up for people who name their sessions.

## Review guide

- **The fix** — `set name of newSession to overlayTitle` after the split, with `$OVERLAY_TITLE` appended to the `osascript` argv, in `.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh`
- **The same edit in the codex copy**, which carries the `# source: … (keep in sync)` header
- **And in `plugins/revdiff-planning/scripts/launch-plan-review.sh`** — the planning hook splits the same way and computes its own `OVERLAY_TITLE` (`plan: <file>`), so plan reviews had the same unlabelled tab
- **Why the title is appended rather than inserted** — the `osascript` arm of `app/testdata/plugin-exit-code/fake-overlay-backend.sh` dispatches on argument count plus `-x "$3"`, so an earlier position would shift the launch script out from under the stub. Appending leaves the stub's dispatch intact.
- **The test** — `TestIterm2OverlayNamesSession` asserts the split `osascript` argv ends with the overlay title for all three launchers. The other backends pass `OVERLAY_TITLE` as a flag that `TestShellLaunchersPreserveAnnotationExitCode` already runs; iTerm2 hands it to AppleScript through argv, which nothing read, so a dropped argument was invisible. Capture is a new `FAKE_OSASCRIPT_ARGS_FILE` in the fake backend, mirroring `FAKE_AGTERM_ARGS_FILE`.

## Testing

Ran the launcher for real on iTerm2 3.6.11 / macOS 26.5.2, against a profile whose session name interpolates a session variable:

| | overlay pane name | tab label |
|:---|:---|:---|
| `master` | the profile's title, which renders empty here — the probe in #307 shows the pane carrying `<b>\(user.probe_var)</b>` with the variable missing. On a stock profile it is the default title text. | the same, once the overlay takes focus |
| this branch | `rd: revdiff [HEAD~1]` | `rd: revdiff [HEAD~1]` |

The tab label is what the fix restores. My OS window title emptied along with it, but @umputun's never moved, so that part follows from window title components rather than from the session name.

`go test ./...` passes and the CI shellcheck gate is clean on all three launchers.
