### PR TITLE
test(highlight): keep the long-string fixture below the lexer timeout

### DIFF
--- a/app/highlight/highlight_test.go
+++ b/app/highlight/highlight_test.go
@@ -209,7 +209,8 @@ func TestSetStyle_unknownStyle(t *testing.T) {
 }
 
 func TestHighlighter_LongQuotedStringUsesStringColor(t *testing.T) {
-	// pins the regexp2 v2.7.1 regression that repainted a 40k-character Go quoted string as an error
+	// pins the regexp2 v2.7.1 regression that repainted a long Go quoted string as an error
+	// 20k stays above the old backtracking cap and below Chroma's fixed 250ms rule timeout
 	h := New("monokai", true)
 
 	render := func(n int) string {
@@ -224,7 +225,7 @@ func TestHighlighter_LongQuotedStringUsesStringColor(t *testing.T) {
 		return fmt.Sprintf("\033[38;2;%d;%d;%dm", c.Red(), c.Green(), c.Blue())
 	}
 
-	long := render(40000)
+	long := render(20000)
 	assert.Contains(t, long, fg(chroma.LiteralString), "long literal must keep the string color")
 	assert.NotContains(t, long, fg(chroma.Error), "long literal must not be painted as an error token")
 }


### PR DESCRIPTION
`TestHighlighter_LongQuotedStringUsesStringColor` is flaky on CI. It failed on one run of #338 and passed on a second run of the same commit.

cause: chroma sets a fixed 250ms `MatchTimeout` on every lexer rule, which `app/highlight/highlight.go` already documents as a ceiling the backtracking cap cannot lift. The test matched a 40,000-character string against it, so it was really asserting that the machine finishes that match inside 250ms. Measured here: 7.4ms plain but 147.6ms under `-race`, which is how CI runs it. That is 1.7x headroom on hardware faster than a GitHub runner. When it goes over, the string rule loses and the body is repainted by whichever rule matches next, which is the wrong colour in the failure log.

fix: 20,000 characters instead of 40,000. Sweeping sizes with the cap reverted to the pre-fix 100,000 shows 15,000 still passing and 17,000 already failing, which matches the slot arithmetic in that same comment, so 20,000 is comfortably above the old cap and still fails without the fix. It costs about 78ms under `-race`, roughly 3x headroom instead of 1.7x.

the input is smaller, the test is not weaker: reverting the cap to 100,000 in a scratch tree makes the 20,000 case fail by receiving `chroma.Error`, so it pins the same regression it always did. The comment now records both facts, the regression it catches and why the number cannot be raised back.
