### PR TITLE
fix(ui): paint annotation input with the annotation color

### DIFF
--- a/app/ui/annotate.go
+++ b/app/ui/annotate.go
@@ -54,8 +54,6 @@ func (m *Model) newAnnotationInput(placeholder string, prefixWidth int) (textinp
 
 	// set DiffBg on all textinput sub-styles so View() output inherits the pane background.
 	// wrapping View() externally doesn't work because lipgloss Render emits \033[0m resets.
-	// text uses Normal fg (context line color) so active input is readable on any theme
-	// and visually distinct from saved annotations (which use Annotation color + italic).
 	inputStyle := m.resolver.Style(style.StyleKeyAnnotInputText)
 	ti.PromptStyle = inputStyle
 	ti.TextStyle = inputStyle

--- a/app/ui/style/resolver.go
+++ b/app/ui/style/resolver.go
@@ -256,9 +256,12 @@ func buildStyles(c Colors) map[StyleKey]lipgloss.Style {
 		Background(lipgloss.Color(c.SearchBg))
 
 	// annotation input styles (D14 — all inline lipgloss construction from annotate.go)
+	// text uses Annotation fg: Normal makes this style byte-identical to contextStyle below,
+	// so typed text would render exactly like the diff lines around it. italic stays off, which
+	// is what still separates the live input from a saved annotation.
 	inputStyle := lipgloss.NewStyle()
-	if c.Normal != "" {
-		inputStyle = inputStyle.Foreground(lipgloss.Color(c.Normal))
+	if c.Annotation != "" {
+		inputStyle = inputStyle.Foreground(lipgloss.Color(c.Annotation))
 	}
 	if c.DiffBg != "" {
 		inputStyle = inputStyle.Background(lipgloss.Color(c.DiffBg))

--- a/app/ui/style/resolver_test.go
+++ b/app/ui/style/resolver_test.go
@@ -3,6 +3,7 @@ package style
 import (
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/umputun/revdiff/app/diff"
@@ -162,6 +163,47 @@ func TestResolver_Style(t *testing.T) {
 			_ = got.Render("test") // verify style is functional
 		})
 	}
+}
+
+func TestResolver_AnnotationInputStyles(t *testing.T) {
+	// pins issue #343: input text resolved to Normal, making it byte-identical to a context line
+	r := NewResolver(fullColorsForTesting)
+
+	tests := []struct {
+		name string
+		key  StyleKey
+		fg   string
+	}{
+		{"text uses annotation fg", StyleKeyAnnotInputText, fullColorsForTesting.Annotation},
+		{"cursor follows text", StyleKeyAnnotInputCursor, fullColorsForTesting.Annotation},
+		{"placeholder stays muted", StyleKeyAnnotInputPlaceholder, fullColorsForTesting.Muted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.Style(tt.key)
+			assert.Equal(t, lipgloss.Color(tt.fg), got.GetForeground())
+			assert.Equal(t, lipgloss.Color(fullColorsForTesting.DiffBg), got.GetBackground())
+		})
+	}
+
+	t.Run("text is not the context line color", func(t *testing.T) {
+		input := r.Style(StyleKeyAnnotInputText)
+		context := r.Style(StyleKeyLineContext)
+		assert.NotEqual(t, context.GetForeground(), input.GetForeground())
+	})
+
+	t.Run("text carries no italic", func(t *testing.T) {
+		assert.False(t, r.Style(StyleKeyAnnotInputText).GetItalic(),
+			"italic is what distinguishes a saved annotation from the live input")
+	})
+
+	t.Run("no background without diff bg", func(t *testing.T) {
+		sparse := NewResolver(sparseColorsForTesting)
+		got := sparse.Style(StyleKeyAnnotInputText)
+		assert.Equal(t, lipgloss.Color(sparseColorsForTesting.Annotation), got.GetForeground())
+		assert.Empty(t, got.GetBackground())
+	})
 }
 
 func TestResolver_Style_coversAllKeys(t *testing.T) {


### PR DESCRIPTION
annotation input text now uses the annotation colour instead of blending into context lines.

`StyleKeyAnnotInputText` and `contextStyle` both resolved to `color-normal` on `color-diff-bg` for every valid theme. The two styles emitted the same ANSI bytes for the same text.

`StyleKeyAnnotInputText` now uses `color-annotation`, already documented as "annotation text and markers". The cursor aliases that style. The placeholder remains muted, and saved annotations remain distinct because only `AnnotationInline` adds italic.

**trade-off**

this lowers text/background contrast in two bundled themes: catppuccin-latte from 7.06 to 2.31 and solarized-dark from 4.75 to 3.26. Saved annotations already use those ratios.

both palette colours remain canonical. Of Latte's 14 official accent colours, only Red (4.80) and Mauve (4.79) clear AA on `#eff1f5`, and both already serve other roles in this theme.

**tests**

added six resolver subtests covering text, cursor, placeholder, context-line separation, italic and the no-`DiffBg` path. Reverting the resolver line fails four of them.

tested with `make test` and `make lint`.

Fixes #343
